### PR TITLE
feat: add multi-agent AI review pipeline with HITL checkpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "scrape": "tsx scripts/run-scheduled-scrapers.ts"
+    "scrape": "tsx scripts/run-scheduled-scrapers.ts",
+    "pipeline": "tsx scripts/run-daily-pipeline.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",

--- a/scripts/run-daily-pipeline.ts
+++ b/scripts/run-daily-pipeline.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env tsx
+/**
+ * Daily AI Review Pipeline Runner
+ *
+ * Runs the full research and verification pipeline daily.
+ * After research and verification, findings are stored for human review.
+ * The admin must approve findings via the dashboard before implementation.
+ *
+ * Usage:
+ *   tsx scripts/run-daily-pipeline.ts
+ *
+ * Cron example (run daily at 6 AM AEST):
+ *   0 6 * * * cd /path/to/Policai && tsx scripts/run-daily-pipeline.ts >> logs/pipeline.log 2>&1
+ */
+
+const PIPELINE_API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3002';
+
+async function runDailyPipeline() {
+  console.log('='.repeat(60));
+  console.log('Daily AI Review Pipeline');
+  console.log(`Started at: ${new Date().toISOString()}`);
+  console.log('='.repeat(60));
+
+  // Check if API key is configured
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error('ERROR: ANTHROPIC_API_KEY environment variable is not set');
+    process.exit(1);
+  }
+
+  try {
+    // Check if there's already a pipeline run waiting for review
+    console.log('\nChecking for pending pipeline reviews...');
+    const statusResponse = await fetch(`${PIPELINE_API_URL}/api/admin/pipeline?action=latest`);
+    const statusData = await statusResponse.json();
+
+    if (statusData.success && statusData.data?.run?.stage === 'hitl_review') {
+      console.log('A pipeline run is already awaiting human review.');
+      console.log(`Run ID: ${statusData.data.run.id}`);
+      console.log(`Findings: ${statusData.data.run.findingsCount}`);
+      console.log(`Verified: ${statusData.data.run.verifiedCount}`);
+      console.log('\nPlease review and approve/reject via the admin dashboard before running a new pipeline.');
+      process.exit(0);
+    }
+
+    // Start a new pipeline run
+    console.log('\nStarting pipeline run...');
+    console.log('Stage 1: Research Agent scanning sources...');
+    console.log('Stage 2: Verifier Agent cross-referencing findings...');
+    console.log('(This may take several minutes)\n');
+
+    const response = await fetch(`${PIPELINE_API_URL}/api/admin/pipeline`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'start' }),
+    });
+
+    if (!response.ok) {
+      const error = await response.json();
+      throw new Error(error.error || `HTTP ${response.status}`);
+    }
+
+    const result = await response.json();
+
+    if (!result.success) {
+      throw new Error(result.error || 'Pipeline failed');
+    }
+
+    const run = result.data;
+    console.log('Pipeline run completed successfully.');
+    console.log(`Run ID: ${run.id}`);
+    console.log(`Stage: ${run.stage}`);
+    console.log(`Sources scanned: ${run.sourcesScanned?.length || 0}`);
+    console.log(`Findings discovered: ${run.findingsCount}`);
+    console.log(`Findings verified: ${run.verifiedCount}`);
+    console.log(`Findings rejected: ${run.rejectedCount}`);
+
+    if (run.stage === 'hitl_review') {
+      console.log('\nPipeline paused for human review.');
+      console.log('Please visit the admin dashboard to approve or reject findings.');
+    } else if (run.stage === 'complete' && run.findingsCount === 0) {
+      console.log('\nNo new findings discovered. The policy database is up to date.');
+    }
+
+  } catch (error) {
+    console.error('Pipeline error:', error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+
+  console.log('\n' + '='.repeat(60));
+  console.log(`Completed at: ${new Date().toISOString()}`);
+  console.log('='.repeat(60));
+}
+
+runDailyPipeline().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/src/app/api/admin/pipeline/route.ts
+++ b/src/app/api/admin/pipeline/route.ts
@@ -1,0 +1,210 @@
+import { NextResponse } from 'next/server';
+import { verifyAuth, unauthorizedResponse } from '@/lib/auth';
+import {
+  getPipelineRuns,
+  getLatestPipelineRun,
+  getFindings,
+  getVerifications,
+} from '@/lib/agents/pipeline-storage';
+import {
+  startPipelineRun,
+  approvePipelineRun,
+  rejectPipelineRun,
+} from '@/lib/agents/pipeline';
+import fs from 'fs/promises';
+import path from 'path';
+
+const POLICIES_FILE = path.join(process.cwd(), 'public', 'data', 'sample-policies.json');
+
+async function getExistingPolicyTitles(): Promise<string[]> {
+  try {
+    const data = await fs.readFile(POLICIES_FILE, 'utf-8');
+    const policies = JSON.parse(data);
+    return policies.map((p: { title: string }) => p.title);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * GET /api/admin/pipeline
+ * Retrieve pipeline runs, findings, and verification results
+ *
+ * Query params:
+ * - action: 'runs' | 'latest' | 'findings' | 'verifications'
+ * - runId: pipeline run ID (for findings/verifications)
+ */
+export async function GET(request: Request) {
+  const user = await verifyAuth(request);
+  if (!user) {
+    return unauthorizedResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+  const action = searchParams.get('action') || 'latest';
+  const runId = searchParams.get('runId');
+
+  try {
+    switch (action) {
+      case 'runs': {
+        const runs = await getPipelineRuns();
+        return NextResponse.json({
+          success: true,
+          data: runs.sort((a, b) =>
+            new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+          ),
+        });
+      }
+
+      case 'latest': {
+        const latest = await getLatestPipelineRun();
+        if (!latest) {
+          return NextResponse.json({
+            success: true,
+            data: null,
+            message: 'No pipeline runs found',
+          });
+        }
+
+        const findings = await getFindings(latest.id);
+        const verifications = await getVerifications(latest.id);
+
+        return NextResponse.json({
+          success: true,
+          data: {
+            run: latest,
+            findings,
+            verifications,
+          },
+        });
+      }
+
+      case 'findings': {
+        const findings = await getFindings(runId || undefined);
+        return NextResponse.json({ success: true, data: findings });
+      }
+
+      case 'verifications': {
+        const verifications = await getVerifications(runId || undefined);
+        return NextResponse.json({ success: true, data: verifications });
+      }
+
+      default:
+        return NextResponse.json(
+          { success: false, error: 'Invalid action' },
+          { status: 400 }
+        );
+    }
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to fetch pipeline data',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/admin/pipeline
+ * Trigger pipeline actions
+ *
+ * Body:
+ * - action: 'start' | 'approve' | 'reject'
+ * - runId: pipeline run ID (for approve/reject)
+ * - notes: optional notes
+ * - approvedFindingIds: optional array of finding IDs to approve (for selective approval)
+ */
+export async function POST(request: Request) {
+  const user = await verifyAuth(request);
+  if (!user) {
+    return unauthorizedResponse();
+  }
+
+  try {
+    const body = await request.json();
+    const { action, runId, notes, approvedFindingIds } = body;
+
+    if (!process.env.ANTHROPIC_API_KEY) {
+      return NextResponse.json(
+        { success: false, error: 'ANTHROPIC_API_KEY not configured' },
+        { status: 500 }
+      );
+    }
+
+    switch (action) {
+      case 'start': {
+        const existingTitles = await getExistingPolicyTitles();
+        const run = await startPipelineRun(existingTitles);
+
+        return NextResponse.json({
+          success: true,
+          data: run,
+          message: run.stage === 'hitl_review'
+            ? `Pipeline paused for review. ${run.findingsCount} findings discovered, ${run.verifiedCount} verified.`
+            : run.stage === 'complete'
+            ? 'Pipeline complete. No new findings discovered.'
+            : `Pipeline at stage: ${run.stage}`,
+        });
+      }
+
+      case 'approve': {
+        if (!runId) {
+          return NextResponse.json(
+            { success: false, error: 'runId is required' },
+            { status: 400 }
+          );
+        }
+
+        const approvedRun = await approvePipelineRun(
+          runId,
+          user.email || 'admin',
+          notes,
+          approvedFindingIds
+        );
+
+        return NextResponse.json({
+          success: true,
+          data: approvedRun,
+          message: `Pipeline approved and implemented. ${approvedRun.implementedCount} policies created/updated.`,
+        });
+      }
+
+      case 'reject': {
+        if (!runId) {
+          return NextResponse.json(
+            { success: false, error: 'runId is required' },
+            { status: 400 }
+          );
+        }
+
+        const rejectedRun = await rejectPipelineRun(
+          runId,
+          user.email || 'admin',
+          notes
+        );
+
+        return NextResponse.json({
+          success: true,
+          data: rejectedRun,
+          message: 'Pipeline run rejected. No changes were made.',
+        });
+      }
+
+      default:
+        return NextResponse.json(
+          { success: false, error: 'Invalid action. Use: start, approve, reject' },
+          { status: 400 }
+        );
+    }
+  } catch (error) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Pipeline operation failed',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/agents/implementation-agent.ts
+++ b/src/lib/agents/implementation-agent.ts
@@ -1,0 +1,259 @@
+import Anthropic from '@anthropic-ai/sdk';
+import fs from 'fs/promises';
+import path from 'path';
+import type { ResearchFinding, VerificationResult, Policy } from '@/types';
+import { updateFindingStatus } from './pipeline-storage';
+
+const anthropic = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY || '',
+});
+
+const MODEL = 'claude-sonnet-4-20250514';
+
+const POLICIES_FILE = path.join(process.cwd(), 'public', 'data', 'sample-policies.json');
+
+async function loadPolicies(): Promise<Policy[]> {
+  try {
+    const data = await fs.readFile(POLICIES_FILE, 'utf-8');
+    return JSON.parse(data);
+  } catch {
+    return [];
+  }
+}
+
+async function savePolicies(policies: Policy[]) {
+  await fs.writeFile(POLICIES_FILE, JSON.stringify(policies, null, 2), 'utf-8');
+}
+
+/**
+ * Generate a proper policy entry from a verified finding using Claude
+ */
+async function generatePolicyEntry(
+  finding: ResearchFinding,
+  verification: VerificationResult
+): Promise<Omit<Policy, 'id' | 'createdAt' | 'updatedAt'>> {
+  const message = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: 1024,
+    messages: [
+      {
+        role: 'user',
+        content: `You are an implementation agent for an Australian AI Policy Tracker. Generate a complete, accurate policy database entry from this verified research finding.
+
+FINDING:
+Title: ${finding.title}
+Summary: ${finding.summary}
+Source URL: ${finding.sourceUrl}
+Type: ${finding.suggestedType}
+Jurisdiction: ${finding.suggestedJurisdiction}
+Tags: ${finding.tags.join(', ')}
+Agencies: ${finding.agencies.join(', ')}
+Key Dates: ${finding.keyDates.join(', ')}
+
+VERIFICATION NOTES:
+Outcome: ${verification.outcome}
+Confidence: ${verification.confidenceScore}
+Notes: ${verification.verificationNotes}
+${verification.suggestedCorrections.length > 0 ? `Corrections: ${verification.suggestedCorrections.join('; ')}` : ''}
+
+SOURCE CONTENT:
+${finding.sourceContent.slice(0, 3000)}
+
+Generate a policy entry. Apply any suggested corrections from verification. Be factual and accurate.
+
+Respond in JSON format:
+{
+  "title": "official policy title",
+  "description": "2-3 sentence accurate description",
+  "jurisdiction": "federal|nsw|vic|qld|wa|sa|tas|act|nt",
+  "type": "legislation|regulation|guideline|framework|standard",
+  "status": "proposed|active|amended|repealed",
+  "effectiveDate": "YYYY-MM-DD or empty string",
+  "agencies": ["agencies involved"],
+  "sourceUrl": "source URL",
+  "content": "detailed content/notes about the policy",
+  "aiSummary": "AI-generated summary with key points",
+  "tags": ["relevant tags"]
+}`,
+      },
+    ],
+  });
+
+  const text = message.content[0].type === 'text' ? message.content[0].text : '';
+
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      return JSON.parse(jsonMatch[0]);
+    }
+  } catch {
+    console.error('[Implementation Agent] Failed to parse policy entry response');
+  }
+
+  // Fallback: build from finding data directly
+  return {
+    title: finding.title,
+    description: finding.summary,
+    jurisdiction: (finding.suggestedJurisdiction as Policy['jurisdiction']) || 'federal',
+    type: (finding.suggestedType as Policy['type']) || 'guideline',
+    status: 'active',
+    effectiveDate: finding.keyDates[0] || '',
+    agencies: finding.agencies,
+    sourceUrl: finding.sourceUrl,
+    content: finding.sourceContent.slice(0, 5000),
+    aiSummary: finding.summary,
+    tags: finding.tags,
+  };
+}
+
+/**
+ * Generate a slug-based ID from a title
+ */
+function generatePolicyId(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60);
+}
+
+export interface ImplementationResult {
+  findingId: string;
+  action: 'created' | 'updated' | 'skipped';
+  policyId: string;
+  error?: string;
+}
+
+export interface ImplementationAgentResult {
+  results: ImplementationResult[];
+  createdCount: number;
+  updatedCount: number;
+  skippedCount: number;
+  errors: string[];
+}
+
+/**
+ * Run the Implementation Agent - applies verified findings to the policy database
+ */
+export async function runImplementationAgent(
+  findings: ResearchFinding[],
+  verifications: VerificationResult[]
+): Promise<ImplementationAgentResult> {
+  const results: ImplementationResult[] = [];
+  const errors: string[] = [];
+  let createdCount = 0;
+  let updatedCount = 0;
+  let skippedCount = 0;
+
+  const policies = await loadPolicies();
+  const verificationMap = new Map(verifications.map(v => [v.findingId, v]));
+
+  // Only implement verified findings
+  const verifiedFindings = findings.filter(f => f.status === 'verified');
+
+  for (const finding of verifiedFindings) {
+    try {
+      const verification = verificationMap.get(finding.id);
+      if (!verification || verification.confidenceScore < 0.6) {
+        results.push({
+          findingId: finding.id,
+          action: 'skipped',
+          policyId: '',
+          error: 'Insufficient verification confidence',
+        });
+        skippedCount++;
+        continue;
+      }
+
+      console.log(`[Implementation Agent] Processing: ${finding.title}`);
+
+      // Check if this is an update to an existing policy
+      const existingPolicy = policies.find(p =>
+        p.title.toLowerCase() === finding.title.toLowerCase() ||
+        p.sourceUrl === finding.sourceUrl
+      );
+
+      if (existingPolicy && !finding.isNewPolicy) {
+        // Update existing policy
+        const policyData = await generatePolicyEntry(finding, verification);
+        const idx = policies.findIndex(p => p.id === existingPolicy.id);
+
+        policies[idx] = {
+          ...existingPolicy,
+          description: policyData.description,
+          aiSummary: policyData.aiSummary,
+          tags: [...new Set([...existingPolicy.tags, ...policyData.tags])],
+          agencies: [...new Set([...existingPolicy.agencies, ...policyData.agencies])],
+          updatedAt: new Date().toISOString(),
+        };
+
+        await updateFindingStatus(finding.id, 'implemented');
+        results.push({
+          findingId: finding.id,
+          action: 'updated',
+          policyId: existingPolicy.id,
+        });
+        updatedCount++;
+      } else {
+        // Create new policy
+        const policyData = await generatePolicyEntry(finding, verification);
+        const policyId = generatePolicyId(policyData.title);
+
+        // Check for duplicate IDs
+        if (policies.find(p => p.id === policyId)) {
+          results.push({
+            findingId: finding.id,
+            action: 'skipped',
+            policyId,
+            error: 'Policy with this ID already exists',
+          });
+          skippedCount++;
+          continue;
+        }
+
+        const newPolicy: Policy = {
+          ...policyData,
+          id: policyId,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        };
+
+        policies.push(newPolicy);
+        await updateFindingStatus(finding.id, 'implemented');
+        results.push({
+          findingId: finding.id,
+          action: 'created',
+          policyId,
+        });
+        createdCount++;
+      }
+
+      // Rate limit: 1s between AI calls
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    } catch (err) {
+      const errMsg = `Failed to implement "${finding.title}": ${err instanceof Error ? err.message : 'Unknown error'}`;
+      console.error(`[Implementation Agent] ${errMsg}`);
+      errors.push(errMsg);
+      results.push({
+        findingId: finding.id,
+        action: 'skipped',
+        policyId: '',
+        error: errMsg,
+      });
+      skippedCount++;
+    }
+  }
+
+  // Save updated policies
+  await savePolicies(policies);
+
+  console.log(`[Implementation Agent] Complete. Created: ${createdCount}, Updated: ${updatedCount}, Skipped: ${skippedCount}`);
+
+  return {
+    results,
+    createdCount,
+    updatedCount,
+    skippedCount,
+    errors,
+  };
+}

--- a/src/lib/agents/pipeline-storage.ts
+++ b/src/lib/agents/pipeline-storage.ts
@@ -1,0 +1,118 @@
+import fs from 'fs/promises';
+import path from 'path';
+import type {
+  PipelineRun,
+  ResearchFinding,
+  VerificationResult,
+} from '@/types';
+
+const PIPELINE_DIR = path.join(process.cwd(), 'data', 'pipeline');
+const RUNS_FILE = path.join(PIPELINE_DIR, 'pipeline-runs.json');
+const FINDINGS_FILE = path.join(PIPELINE_DIR, 'research-findings.json');
+const VERIFICATIONS_FILE = path.join(PIPELINE_DIR, 'verification-results.json');
+
+async function ensureDir() {
+  await fs.mkdir(PIPELINE_DIR, { recursive: true });
+}
+
+async function readJson<T>(filePath: string, fallback: T): Promise<T> {
+  try {
+    const data = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(data);
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeJson(filePath: string, data: unknown) {
+  await ensureDir();
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+// Pipeline Runs
+
+export async function getPipelineRuns(): Promise<PipelineRun[]> {
+  return readJson<PipelineRun[]>(RUNS_FILE, []);
+}
+
+export async function getPipelineRun(id: string): Promise<PipelineRun | null> {
+  const runs = await getPipelineRuns();
+  return runs.find(r => r.id === id) ?? null;
+}
+
+export async function getLatestPipelineRun(): Promise<PipelineRun | null> {
+  const runs = await getPipelineRuns();
+  if (runs.length === 0) return null;
+  return runs.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())[0];
+}
+
+export async function savePipelineRun(run: PipelineRun) {
+  const runs = await getPipelineRuns();
+  const idx = runs.findIndex(r => r.id === run.id);
+  if (idx >= 0) {
+    runs[idx] = run;
+  } else {
+    runs.push(run);
+  }
+  await writeJson(RUNS_FILE, runs);
+}
+
+// Research Findings
+
+export async function getFindings(pipelineRunId?: string): Promise<ResearchFinding[]> {
+  const findings = await readJson<ResearchFinding[]>(FINDINGS_FILE, []);
+  if (pipelineRunId) {
+    return findings.filter(f => f.pipelineRunId === pipelineRunId);
+  }
+  return findings;
+}
+
+export async function getFinding(id: string): Promise<ResearchFinding | null> {
+  const findings = await readJson<ResearchFinding[]>(FINDINGS_FILE, []);
+  return findings.find(f => f.id === id) ?? null;
+}
+
+export async function saveFindings(newFindings: ResearchFinding[]) {
+  const existing = await readJson<ResearchFinding[]>(FINDINGS_FILE, []);
+  for (const finding of newFindings) {
+    const idx = existing.findIndex(f => f.id === finding.id);
+    if (idx >= 0) {
+      existing[idx] = finding;
+    } else {
+      existing.push(finding);
+    }
+  }
+  await writeJson(FINDINGS_FILE, existing);
+}
+
+export async function updateFindingStatus(id: string, status: ResearchFinding['status']) {
+  const findings = await readJson<ResearchFinding[]>(FINDINGS_FILE, []);
+  const idx = findings.findIndex(f => f.id === id);
+  if (idx >= 0) {
+    findings[idx].status = status;
+    await writeJson(FINDINGS_FILE, findings);
+  }
+}
+
+// Verification Results
+
+export async function getVerifications(pipelineRunId?: string): Promise<VerificationResult[]> {
+  const results = await readJson<VerificationResult[]>(VERIFICATIONS_FILE, []);
+  if (pipelineRunId) {
+    return results.filter(v => v.pipelineRunId === pipelineRunId);
+  }
+  return results;
+}
+
+export async function saveVerifications(newResults: VerificationResult[]) {
+  const existing = await readJson<VerificationResult[]>(VERIFICATIONS_FILE, []);
+  for (const result of newResults) {
+    const idx = existing.findIndex(v => v.id === result.id);
+    if (idx >= 0) {
+      existing[idx] = result;
+    } else {
+      existing.push(result);
+    }
+  }
+  await writeJson(VERIFICATIONS_FILE, existing);
+}

--- a/src/lib/agents/pipeline.ts
+++ b/src/lib/agents/pipeline.ts
@@ -1,0 +1,186 @@
+import type { PipelineRun, PipelineStage } from '@/types';
+import {
+  savePipelineRun,
+  getPipelineRun,
+  getFindings,
+  getVerifications,
+} from './pipeline-storage';
+import { runResearchAgent } from './research-agent';
+import { runVerifierAgent } from './verifier-agent';
+import { runImplementationAgent } from './implementation-agent';
+
+/**
+ * Generate a unique pipeline run ID
+ */
+function generateRunId(): string {
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `run-${date}-${rand}`;
+}
+
+/**
+ * Start a new pipeline run - executes the Research Agent and Verifier Agent,
+ * then pauses for HITL review before implementation.
+ *
+ * Pipeline stages:
+ * 1. research        -> Research Agent scans sources
+ * 2. research_complete -> Findings stored
+ * 3. verification    -> Verifier Agent checks findings
+ * 4. verification_complete -> HITL checkpoint #1 (post-verification)
+ * 5. hitl_review     -> Waiting for human approval
+ * 6. implementation  -> Implementation Agent applies changes
+ * 7. complete        -> Done
+ */
+export async function startPipelineRun(
+  existingPolicyTitles: string[]
+): Promise<PipelineRun> {
+  const runId = generateRunId();
+  const run: PipelineRun = {
+    id: runId,
+    startedAt: new Date().toISOString(),
+    stage: 'research',
+    sourcesScanned: [],
+    findingsCount: 0,
+    verifiedCount: 0,
+    implementedCount: 0,
+    rejectedCount: 0,
+    hitlRequired: true,
+  };
+
+  await savePipelineRun(run);
+  console.log(`[Pipeline] Started run: ${runId}`);
+
+  try {
+    // Stage 1: Research
+    await updateStage(run, 'research');
+    const researchResult = await runResearchAgent(runId, existingPolicyTitles);
+
+    run.sourcesScanned = researchResult.sourcesScanned;
+    run.findingsCount = researchResult.findings.length;
+    await updateStage(run, 'research_complete');
+
+    if (researchResult.findings.length === 0) {
+      console.log('[Pipeline] No findings discovered. Completing.');
+      run.completedAt = new Date().toISOString();
+      await updateStage(run, 'complete');
+      return run;
+    }
+
+    // Stage 2: Verification
+    await updateStage(run, 'verification');
+    const verifierResult = await runVerifierAgent(researchResult.findings);
+
+    run.verifiedCount = verifierResult.confirmedCount;
+    run.rejectedCount = verifierResult.rejectedCount;
+    await updateStage(run, 'verification_complete');
+
+    // Stage 3: HITL checkpoint - pause for human review
+    // The pipeline stops here. An admin must call approvePipelineRun() to continue.
+    await updateStage(run, 'hitl_review');
+
+    console.log(`[Pipeline] Run ${runId} paused at HITL review.`);
+    console.log(`  Findings: ${run.findingsCount}, Verified: ${run.verifiedCount}, Rejected: ${run.rejectedCount}`);
+
+    return run;
+  } catch (err) {
+    run.error = err instanceof Error ? err.message : 'Unknown pipeline error';
+    run.stage = 'failed';
+    await savePipelineRun(run);
+    console.error(`[Pipeline] Run ${runId} failed:`, run.error);
+    return run;
+  }
+}
+
+/**
+ * Approve a pipeline run at the HITL checkpoint and proceed to implementation.
+ * This is called after a human reviews the verified findings.
+ */
+export async function approvePipelineRun(
+  runId: string,
+  approvedBy: string,
+  notes?: string,
+  approvedFindingIds?: string[]
+): Promise<PipelineRun> {
+  const run = await getPipelineRun(runId);
+  if (!run) {
+    throw new Error(`Pipeline run ${runId} not found`);
+  }
+
+  if (run.stage !== 'hitl_review') {
+    throw new Error(`Pipeline run ${runId} is not at HITL review stage (current: ${run.stage})`);
+  }
+
+  run.hitlApprovedAt = new Date().toISOString();
+  run.hitlApprovedBy = approvedBy;
+  run.hitlNotes = notes;
+
+  try {
+    // Stage 4: Implementation
+    await updateStage(run, 'implementation');
+
+    let findings = await getFindings(runId);
+    const verifications = await getVerifications(runId);
+
+    // If specific findings were approved, only implement those
+    if (approvedFindingIds && approvedFindingIds.length > 0) {
+      findings = findings.filter(f =>
+        approvedFindingIds.includes(f.id) && f.status === 'verified'
+      );
+    } else {
+      // Default: implement all verified findings
+      findings = findings.filter(f => f.status === 'verified');
+    }
+
+    const implResult = await runImplementationAgent(findings, verifications);
+
+    run.implementedCount = implResult.createdCount + implResult.updatedCount;
+
+    // Stage 5: Complete
+    run.completedAt = new Date().toISOString();
+    await updateStage(run, 'complete');
+
+    console.log(`[Pipeline] Run ${runId} completed. Implemented: ${run.implementedCount}`);
+
+    return run;
+  } catch (err) {
+    run.error = err instanceof Error ? err.message : 'Implementation error';
+    run.stage = 'failed';
+    await savePipelineRun(run);
+    throw err;
+  }
+}
+
+/**
+ * Reject a pipeline run at the HITL checkpoint (discard all findings)
+ */
+export async function rejectPipelineRun(
+  runId: string,
+  rejectedBy: string,
+  notes?: string
+): Promise<PipelineRun> {
+  const run = await getPipelineRun(runId);
+  if (!run) {
+    throw new Error(`Pipeline run ${runId} not found`);
+  }
+
+  if (run.stage !== 'hitl_review') {
+    throw new Error(`Pipeline run ${runId} is not at HITL review stage (current: ${run.stage})`);
+  }
+
+  run.hitlApprovedBy = rejectedBy;
+  run.hitlNotes = notes || 'Rejected by admin';
+  run.completedAt = new Date().toISOString();
+  run.stage = 'complete';
+  run.implementedCount = 0;
+
+  await savePipelineRun(run);
+  console.log(`[Pipeline] Run ${runId} rejected by ${rejectedBy}.`);
+
+  return run;
+}
+
+async function updateStage(run: PipelineRun, stage: PipelineStage) {
+  run.stage = stage;
+  await savePipelineRun(run);
+  console.log(`[Pipeline] ${run.id} -> ${stage}`);
+}

--- a/src/lib/agents/research-agent.ts
+++ b/src/lib/agents/research-agent.ts
@@ -1,0 +1,334 @@
+import Anthropic from '@anthropic-ai/sdk';
+import * as cheerio from 'cheerio';
+import type { ResearchFinding } from '@/types';
+import { saveFindings } from './pipeline-storage';
+
+const anthropic = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY || '',
+});
+
+const MODEL = 'claude-sonnet-4-20250514';
+
+// Australian government AI policy sources
+const RESEARCH_SOURCES = [
+  {
+    id: 'dta',
+    name: 'DTA AI Policy',
+    url: 'https://www.dta.gov.au/our-projects/artificial-intelligence',
+  },
+  {
+    id: 'diser',
+    name: 'DISER AI Strategy',
+    url: 'https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence',
+  },
+  {
+    id: 'csiro',
+    name: 'CSIRO Data61',
+    url: 'https://www.csiro.au/en/research/technology-space/ai',
+  },
+  {
+    id: 'ahrc',
+    name: 'AHRC AI Ethics',
+    url: 'https://humanrights.gov.au/our-work/technology-and-human-rights',
+  },
+  {
+    id: 'oaic',
+    name: 'OAIC AI Guidance',
+    url: 'https://www.oaic.gov.au/privacy/guidance-and-advice/artificial-intelligence-and-privacy',
+  },
+  {
+    id: 'nsw',
+    name: 'NSW Digital AI',
+    url: 'https://www.digital.nsw.gov.au/policy/artificial-intelligence',
+  },
+  {
+    id: 'vic',
+    name: 'Victorian AI Strategy',
+    url: 'https://www.vic.gov.au/artificial-intelligence-strategy',
+  },
+  {
+    id: 'accc',
+    name: 'ACCC Digital Platforms',
+    url: 'https://www.accc.gov.au/focus-areas/digital-platforms-and-services',
+  },
+];
+
+interface ScrapedPage {
+  url: string;
+  title: string;
+  content: string;
+  sourceId: string;
+}
+
+/**
+ * Scrape links from a source page
+ */
+async function scrapeSourceLinks(sourceUrl: string): Promise<{ url: string; title: string }[]> {
+  try {
+    const response = await fetch(sourceUrl, {
+      headers: { 'User-Agent': 'Policai/1.0 (Australian AI Policy Tracker)' },
+    });
+
+    if (!response.ok) return [];
+
+    const html = await response.text();
+    const $ = cheerio.load(html);
+    const links: { url: string; title: string }[] = [];
+
+    $('a').each((_, el) => {
+      const href = $(el).attr('href');
+      const text = $(el).text().trim();
+      if (!href || !text) return;
+
+      let absoluteUrl = href;
+      if (href.startsWith('/')) {
+        const base = new URL(sourceUrl);
+        absoluteUrl = `${base.origin}${href}`;
+      } else if (!href.startsWith('http')) {
+        return;
+      }
+
+      const keywords = ['policy', 'framework', 'guidance', 'standard', 'regulation', 'strategy', 'ai', 'artificial-intelligence', 'digital'];
+      const combined = (href + ' ' + text).toLowerCase();
+      if (keywords.some(kw => combined.includes(kw))) {
+        links.push({ url: absoluteUrl, title: text });
+      }
+    });
+
+    return links.slice(0, 15);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fetch and clean page content
+ */
+async function fetchPageContent(url: string): Promise<string> {
+  const response = await fetch(url, {
+    headers: { 'User-Agent': 'Policai/1.0 (Australian AI Policy Tracker)' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const html = await response.text();
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Use Claude to analyze a page for AI policy research findings
+ */
+async function analyzeForFindings(
+  page: ScrapedPage,
+  existingPolicyTitles: string[]
+): Promise<Omit<ResearchFinding, 'id' | 'pipelineRunId' | 'status'>[]> {
+  const message = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: 2048,
+    messages: [
+      {
+        role: 'user',
+        content: `You are a research agent for an Australian AI Policy Tracker. Analyse this web page content and extract any AI policy findings.
+
+Source: ${page.url}
+Page Title: ${page.title}
+
+Content:
+${page.content.slice(0, 6000)}
+
+Existing policies already tracked:
+${existingPolicyTitles.slice(0, 20).map(t => `- ${t}`).join('\n')}
+
+For each distinct AI policy finding on this page, extract the details. A finding could be:
+- A new policy, framework, guideline, or regulation
+- An update or amendment to an existing tracked policy
+- A significant government announcement about AI governance
+
+Respond in JSON format:
+{
+  "findings": [
+    {
+      "title": "name of the policy/finding",
+      "summary": "2-3 sentence summary of what this finding is about",
+      "relevanceScore": 0.0-1.0,
+      "suggestedType": "legislation|regulation|guideline|framework|standard|null",
+      "suggestedJurisdiction": "federal|nsw|vic|qld|wa|sa|tas|act|nt|null",
+      "tags": ["relevant tags"],
+      "agencies": ["government agencies mentioned"],
+      "keyDates": ["important dates YYYY-MM-DD"],
+      "relatedTopics": ["related topics"],
+      "isNewPolicy": true/false,
+      "existingPolicyTitle": "title of existing policy if this is an update, or null",
+      "changeDescription": "what changed if this is an update to existing policy, or null"
+    }
+  ]
+}
+
+If the page has no relevant AI policy content, return: {"findings": []}`,
+      },
+    ],
+  });
+
+  const text = message.content[0].type === 'text' ? message.content[0].text : '';
+
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      return (parsed.findings || []).map((f: Record<string, unknown>) => ({
+        title: f.title as string,
+        summary: f.summary as string,
+        sourceUrl: page.url,
+        sourceContent: page.content.slice(0, 2000),
+        discoveredAt: new Date().toISOString(),
+        relevanceScore: f.relevanceScore as number,
+        suggestedType: f.suggestedType as string | null,
+        suggestedJurisdiction: f.suggestedJurisdiction as string | null,
+        tags: (f.tags as string[]) || [],
+        agencies: (f.agencies as string[]) || [],
+        keyDates: (f.keyDates as string[]) || [],
+        relatedTopics: (f.relatedTopics as string[]) || [],
+        isNewPolicy: f.isNewPolicy as boolean,
+        existingPolicyId: undefined,
+        changeDescription: f.changeDescription as string | undefined,
+      }));
+    }
+  } catch {
+    console.error('Failed to parse research findings from Claude response');
+  }
+
+  return [];
+}
+
+export interface ResearchAgentResult {
+  findings: ResearchFinding[];
+  sourcesScanned: string[];
+  errors: string[];
+}
+
+/**
+ * Run the Research Agent - scans all sources for new AI policy information
+ */
+export async function runResearchAgent(
+  pipelineRunId: string,
+  existingPolicyTitles: string[]
+): Promise<ResearchAgentResult> {
+  const allFindings: ResearchFinding[] = [];
+  const sourcesScanned: string[] = [];
+  const errors: string[] = [];
+  let findingCounter = 0;
+
+  for (const source of RESEARCH_SOURCES) {
+    try {
+      console.log(`[Research Agent] Scanning: ${source.name} (${source.url})`);
+      sourcesScanned.push(source.id);
+
+      // Get links from source page
+      const links = await scrapeSourceLinks(source.url);
+      console.log(`[Research Agent] Found ${links.length} links from ${source.name}`);
+
+      // Also analyze the source page itself
+      const pages: ScrapedPage[] = [];
+
+      try {
+        const sourceContent = await fetchPageContent(source.url);
+        pages.push({
+          url: source.url,
+          title: source.name,
+          content: sourceContent,
+          sourceId: source.id,
+        });
+      } catch (err) {
+        console.error(`[Research Agent] Failed to fetch source page: ${source.url}`, err);
+      }
+
+      // Fetch content from linked pages (limit to 5 per source)
+      for (const link of links.slice(0, 5)) {
+        try {
+          const content = await fetchPageContent(link.url);
+          pages.push({
+            url: link.url,
+            title: link.title,
+            content,
+            sourceId: source.id,
+          });
+
+          // Rate limit: 2s between fetches
+          await new Promise(resolve => setTimeout(resolve, 2000));
+        } catch (err) {
+          console.error(`[Research Agent] Failed to fetch: ${link.url}`, err);
+        }
+      }
+
+      // Analyze each page for findings
+      for (const page of pages) {
+        try {
+          const pageFindings = await analyzeForFindings(page, existingPolicyTitles);
+
+          for (const finding of pageFindings) {
+            if (finding.relevanceScore >= 0.5) {
+              findingCounter++;
+              allFindings.push({
+                ...finding,
+                id: `finding-${pipelineRunId}-${findingCounter}`,
+                pipelineRunId,
+                status: 'discovered',
+              } as ResearchFinding);
+            }
+          }
+
+          // Rate limit: 1s between AI calls
+          await new Promise(resolve => setTimeout(resolve, 1000));
+        } catch (err) {
+          console.error(`[Research Agent] Analysis failed for: ${page.url}`, err);
+        }
+      }
+
+      // Rate limit: 3s between sources
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    } catch (err) {
+      const errMsg = `Failed to scan ${source.name}: ${err instanceof Error ? err.message : 'Unknown error'}`;
+      console.error(`[Research Agent] ${errMsg}`);
+      errors.push(errMsg);
+    }
+  }
+
+  // Deduplicate findings by title similarity
+  const uniqueFindings = deduplicateFindings(allFindings);
+
+  // Save findings to storage
+  await saveFindings(uniqueFindings);
+
+  console.log(`[Research Agent] Complete. Found ${uniqueFindings.length} unique findings from ${sourcesScanned.length} sources.`);
+
+  return {
+    findings: uniqueFindings,
+    sourcesScanned,
+    errors,
+  };
+}
+
+/**
+ * Remove duplicate findings based on title similarity
+ */
+function deduplicateFindings(findings: ResearchFinding[]): ResearchFinding[] {
+  const seen = new Map<string, ResearchFinding>();
+
+  for (const finding of findings) {
+    const normalizedTitle = finding.title.toLowerCase().replace(/[^a-z0-9]/g, '');
+    const existing = seen.get(normalizedTitle);
+
+    if (!existing || finding.relevanceScore > existing.relevanceScore) {
+      seen.set(normalizedTitle, finding);
+    }
+  }
+
+  return Array.from(seen.values());
+}

--- a/src/lib/agents/verifier-agent.ts
+++ b/src/lib/agents/verifier-agent.ts
@@ -1,0 +1,168 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { ResearchFinding, VerificationResult } from '@/types';
+import { saveVerifications, updateFindingStatus } from './pipeline-storage';
+
+const anthropic = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY || '',
+});
+
+const MODEL = 'claude-sonnet-4-20250514';
+
+/**
+ * Verify a single research finding by cross-referencing its content and claims
+ */
+async function verifyFinding(
+  finding: ResearchFinding,
+  allFindings: ResearchFinding[]
+): Promise<VerificationResult> {
+  // Find corroborating findings from other sources
+  const corroborating = allFindings.filter(
+    f => f.id !== finding.id &&
+    (f.title.toLowerCase().includes(finding.title.toLowerCase().split(' ').slice(0, 3).join(' ')) ||
+     finding.tags.some(tag => f.tags.includes(tag)))
+  );
+
+  const message = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: 1024,
+    messages: [
+      {
+        role: 'user',
+        content: `You are a verification agent for an Australian AI Policy Tracker. Your job is to verify the accuracy and reliability of research findings about Australian AI policy.
+
+FINDING TO VERIFY:
+Title: ${finding.title}
+Summary: ${finding.summary}
+Source URL: ${finding.sourceUrl}
+Relevance Score: ${finding.relevanceScore}
+Suggested Type: ${finding.suggestedType}
+Suggested Jurisdiction: ${finding.suggestedJurisdiction}
+Tags: ${finding.tags.join(', ')}
+Agencies: ${finding.agencies.join(', ')}
+Key Dates: ${finding.keyDates.join(', ')}
+Is New Policy: ${finding.isNewPolicy}
+${finding.changeDescription ? `Change Description: ${finding.changeDescription}` : ''}
+
+SOURCE CONTENT EXCERPT:
+${finding.sourceContent.slice(0, 3000)}
+
+${corroborating.length > 0 ? `
+CORROBORATING FINDINGS FROM OTHER SOURCES:
+${corroborating.map(c => `- "${c.title}" from ${c.sourceUrl} (score: ${c.relevanceScore})`).join('\n')}
+` : 'No corroborating findings from other sources.'}
+
+Please verify this finding. Check for:
+1. Does the source content actually support the claimed finding?
+2. Are the extracted metadata (type, jurisdiction, agencies) accurate?
+3. Are there any factual issues or inconsistencies?
+4. Is this a legitimate Australian government AI policy source?
+5. If corroborating sources exist, do they agree?
+
+Respond in JSON format:
+{
+  "outcome": "confirmed|partially_confirmed|unverifiable|contradicted",
+  "confidenceScore": 0.0-1.0,
+  "verificationNotes": "explanation of verification outcome",
+  "factualIssues": ["any factual problems found"],
+  "suggestedCorrections": ["corrections if any"],
+  "sourcesCrossReferenced": ["list of source URLs checked"]
+}`,
+      },
+    ],
+  });
+
+  const text = message.content[0].type === 'text' ? message.content[0].text : '';
+
+  let parsed = {
+    outcome: 'unverifiable' as VerificationResult['outcome'],
+    confidenceScore: 0,
+    verificationNotes: 'Failed to verify',
+    factualIssues: [] as string[],
+    suggestedCorrections: [] as string[],
+    sourcesCrossReferenced: [finding.sourceUrl],
+  };
+
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      parsed = JSON.parse(jsonMatch[0]);
+    }
+  } catch {
+    console.error('[Verifier Agent] Failed to parse verification response');
+  }
+
+  return {
+    id: `verification-${finding.id}`,
+    findingId: finding.id,
+    pipelineRunId: finding.pipelineRunId,
+    verifiedAt: new Date().toISOString(),
+    outcome: parsed.outcome,
+    confidenceScore: parsed.confidenceScore,
+    sourcesCrossReferenced: parsed.sourcesCrossReferenced || [finding.sourceUrl],
+    verificationNotes: parsed.verificationNotes,
+    factualIssues: parsed.factualIssues || [],
+    suggestedCorrections: parsed.suggestedCorrections || [],
+  };
+}
+
+export interface VerifierAgentResult {
+  verifications: VerificationResult[];
+  confirmedCount: number;
+  rejectedCount: number;
+  errors: string[];
+}
+
+/**
+ * Run the Verifier Agent - verifies all research findings from a pipeline run
+ */
+export async function runVerifierAgent(
+  findings: ResearchFinding[]
+): Promise<VerifierAgentResult> {
+  const verifications: VerificationResult[] = [];
+  const errors: string[] = [];
+  let confirmedCount = 0;
+  let rejectedCount = 0;
+
+  for (const finding of findings) {
+    try {
+      console.log(`[Verifier Agent] Verifying: ${finding.title}`);
+
+      const result = await verifyFinding(finding, findings);
+      verifications.push(result);
+
+      // Update finding status based on verification
+      if (result.outcome === 'confirmed' || result.outcome === 'partially_confirmed') {
+        if (result.confidenceScore >= 0.6) {
+          await updateFindingStatus(finding.id, 'verified');
+          confirmedCount++;
+        } else {
+          await updateFindingStatus(finding.id, 'rejected');
+          rejectedCount++;
+        }
+      } else if (result.outcome === 'contradicted') {
+        await updateFindingStatus(finding.id, 'rejected');
+        rejectedCount++;
+      }
+      // 'unverifiable' stays as 'discovered' for HITL review
+
+      // Rate limit: 1s between verifications
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    } catch (err) {
+      const errMsg = `Failed to verify "${finding.title}": ${err instanceof Error ? err.message : 'Unknown error'}`;
+      console.error(`[Verifier Agent] ${errMsg}`);
+      errors.push(errMsg);
+    }
+  }
+
+  // Save all verification results
+  await saveVerifications(verifications);
+
+  console.log(`[Verifier Agent] Complete. Confirmed: ${confirmedCount}, Rejected: ${rejectedCount}`);
+
+  return {
+    verifications,
+    confirmedCount,
+    rejectedCount,
+    errors,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -161,3 +161,96 @@ export const POLICY_STATUS_NAMES: Record<PolicyStatus, string> = {
   amended: 'Amended',
   repealed: 'Repealed',
 };
+
+// AI Review Pipeline Types
+
+export type PipelineStage =
+  | 'research'
+  | 'research_complete'
+  | 'verification'
+  | 'verification_complete'
+  | 'hitl_review'
+  | 'implementation'
+  | 'complete'
+  | 'failed';
+
+export type FindingStatus =
+  | 'discovered'
+  | 'verified'
+  | 'rejected'
+  | 'implemented';
+
+export type VerificationOutcome =
+  | 'confirmed'
+  | 'partially_confirmed'
+  | 'unverifiable'
+  | 'contradicted';
+
+export interface ResearchFinding {
+  id: string;
+  pipelineRunId: string;
+  title: string;
+  summary: string;
+  sourceUrl: string;
+  sourceContent: string;
+  discoveredAt: string;
+  status: FindingStatus;
+  relevanceScore: number;
+  suggestedType: PolicyType | null;
+  suggestedJurisdiction: Jurisdiction | null;
+  tags: string[];
+  agencies: string[];
+  keyDates: string[];
+  relatedTopics: string[];
+  isNewPolicy: boolean;
+  existingPolicyId?: string;
+  changeDescription?: string;
+}
+
+export interface VerificationResult {
+  id: string;
+  findingId: string;
+  pipelineRunId: string;
+  verifiedAt: string;
+  outcome: VerificationOutcome;
+  confidenceScore: number;
+  sourcesCrossReferenced: string[];
+  verificationNotes: string;
+  factualIssues: string[];
+  suggestedCorrections: string[];
+}
+
+export interface PipelineRun {
+  id: string;
+  startedAt: string;
+  completedAt?: string;
+  stage: PipelineStage;
+  sourcesScanned: string[];
+  findingsCount: number;
+  verifiedCount: number;
+  implementedCount: number;
+  rejectedCount: number;
+  hitlRequired: boolean;
+  hitlApprovedAt?: string;
+  hitlApprovedBy?: string;
+  hitlNotes?: string;
+  error?: string;
+}
+
+export const PIPELINE_STAGE_NAMES: Record<PipelineStage, string> = {
+  research: 'Researching',
+  research_complete: 'Research Complete',
+  verification: 'Verifying',
+  verification_complete: 'Verification Complete',
+  hitl_review: 'Awaiting Review',
+  implementation: 'Implementing',
+  complete: 'Complete',
+  failed: 'Failed',
+};
+
+export const VERIFICATION_OUTCOME_NAMES: Record<VerificationOutcome, string> = {
+  confirmed: 'Confirmed',
+  partially_confirmed: 'Partially Confirmed',
+  unverifiable: 'Unverifiable',
+  contradicted: 'Contradicted',
+};


### PR DESCRIPTION
Implements a 3-stage automated pipeline for daily AI policy review:

1. Research Agent - scans 8 Australian government sources, discovers
   new/updated AI policies, stores findings with timestamps
2. Verifier Agent - cross-references findings, validates accuracy,
   scores confidence, flags factual issues
3. Implementation Agent - generates policy entries from verified
   findings and applies them to the database

The pipeline pauses at a human-in-the-loop checkpoint after
verification, requiring admin approval before any changes are
implemented. Admins can selectively approve individual findings
or reject the entire run.

New files:
- src/lib/agents/ - Research, Verifier, Implementation agents
  plus pipeline orchestrator and storage module
- src/app/api/admin/pipeline/route.ts - Pipeline API endpoints
- scripts/run-daily-pipeline.ts - Daily cron runner (npm run pipeline)

Modified:
- Admin dashboard: new "AI Pipeline" tab with stage visualization,
  HITL review interface, and run history
- types/index.ts: Pipeline, Finding, Verification types

https://claude.ai/code/session_01Gs8AF6jCGisaL27ihF3Asd