### PR TITLE
fix: improve mobile responsiveness across admin and public pages

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1107,7 +1107,7 @@ export default function AdminPage() {
                     onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                   />
                 </div>
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="grid gap-2">
                     <Label>Jurisdiction *</Label>
                     <Select
@@ -1145,7 +1145,7 @@ export default function AdminPage() {
                     </Select>
                   </div>
                 </div>
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div className="grid gap-2">
                     <Label>Status *</Label>
                     <Select
@@ -1224,35 +1224,37 @@ export default function AdminPage() {
       </div>
 
       <Tabs value={selectedTab} onValueChange={setSelectedTab}>
-        <TabsList className="mb-8">
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="review">
-            Content Review
-            {pendingContent.length > 0 && (
-              <Badge variant="secondary" className="ml-2">
-                {pendingContent.length}
-              </Badge>
-            )}
-          </TabsTrigger>
-          <TabsTrigger value="pipeline">
-            AI Pipeline
-            {pipelineRun?.stage === 'hitl_review' && (
-              <Badge variant="default" className="ml-2 bg-orange-500">
-                Review
-              </Badge>
-            )}
-          </TabsTrigger>
-          <TabsTrigger value="sources">Data Sources</TabsTrigger>
-          <TabsTrigger value="trash">
-            Trash
-            {trashedPolicies.length > 0 && (
-              <Badge variant="destructive" className="ml-2">
-                {trashedPolicies.length}
-              </Badge>
-            )}
-          </TabsTrigger>
-          <TabsTrigger value="settings">Settings</TabsTrigger>
-        </TabsList>
+        <div className="overflow-x-auto -mx-4 px-4 mb-8">
+          <TabsList className="w-max">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="review">
+              Content Review
+              {pendingContent.length > 0 && (
+                <Badge variant="secondary" className="ml-2">
+                  {pendingContent.length}
+                </Badge>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="pipeline">
+              AI Pipeline
+              {pipelineRun?.stage === 'hitl_review' && (
+                <Badge variant="default" className="ml-2 bg-orange-500">
+                  Review
+                </Badge>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="sources">Data Sources</TabsTrigger>
+            <TabsTrigger value="trash">
+              Trash
+              {trashedPolicies.length > 0 && (
+                <Badge variant="destructive" className="ml-2">
+                  {trashedPolicies.length}
+                </Badge>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="settings">Settings</TabsTrigger>
+          </TabsList>
+        </div>
 
         {/* Overview Tab */}
         <TabsContent value="overview" className="space-y-6">
@@ -1358,18 +1360,18 @@ export default function AdminPage() {
                   {recentPolicies.map((policy) => (
                     <div
                       key={policy.id}
-                      className="flex items-center justify-between border-b pb-4 last:border-0 last:pb-0 group"
+                      className="flex flex-col sm:flex-row sm:items-center justify-between border-b pb-4 last:border-0 last:pb-0 group gap-2"
                     >
-                      <div className="flex items-center gap-3 flex-1">
-                        <FileText className="h-4 w-4 text-muted-foreground" />
-                        <div className="flex-1">
-                          <p className="font-medium text-sm">{policy.title}</p>
+                      <div className="flex items-center gap-3 flex-1 min-w-0">
+                        <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium text-sm truncate">{policy.title}</p>
                           <p className="text-xs text-muted-foreground">
                             Updated {new Date(policy.updatedAt).toLocaleDateString('en-AU')}
                           </p>
                         </div>
                       </div>
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 ml-7 sm:ml-0">
                         <Badge variant="outline">
                           {JURISDICTION_NAMES[policy.jurisdiction as keyof typeof JURISDICTION_NAMES]}
                         </Badge>
@@ -1439,11 +1441,11 @@ export default function AdminPage() {
 
               {/* Batch Actions */}
               {selectedItems.size > 0 && (
-                <div className="mt-4 flex items-center gap-3 p-3 bg-primary/10 rounded-lg">
+                <div className="mt-4 flex flex-wrap items-center gap-3 p-3 bg-primary/10 rounded-lg">
                   <span className="text-sm font-medium">
                     {selectedItems.size} selected
                   </span>
-                  <div className="flex gap-2 ml-auto">
+                  <div className="flex flex-wrap gap-2 ml-auto">
                     <Button
                       size="sm"
                       className="bg-green-600 hover:bg-green-700"
@@ -1473,7 +1475,7 @@ export default function AdminPage() {
               )}
             </CardHeader>
             <CardContent>
-              <ScrollArea className="h-[500px]">
+              <ScrollArea className="h-[350px] sm:h-[500px]">
                 {filteredContent.length > 0 && (
                   <div className="mb-4 flex items-center gap-2 px-1">
                     <input
@@ -1497,12 +1499,12 @@ export default function AdminPage() {
                             className="mt-1 h-4 w-4 rounded border-gray-300"
                           />
                           <div className="flex-1">
-                            <div className="flex items-start justify-between">
-                              <div className="flex-1">
+                            <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-2">
+                              <div className="flex-1 min-w-0">
                                 <h3 className="font-semibold">{item.title}</h3>
                                 <a
                                   href={item.source}
-                                  className="text-sm text-primary hover:underline"
+                                  className="text-sm text-primary hover:underline block truncate"
                                   target="_blank"
                                   rel="noopener noreferrer"
                                 >
@@ -1514,6 +1516,7 @@ export default function AdminPage() {
                               </div>
                               <Badge
                                 variant={item.aiAnalysis.isRelevant ? 'default' : 'secondary'}
+                                className="shrink-0 self-start"
                               >
                                 {Math.round(item.aiAnalysis.relevanceScore * 100)}% relevant
                               </Badge>
@@ -1619,7 +1622,7 @@ export default function AdminPage() {
         {/* AI Pipeline Tab */}
         <TabsContent value="pipeline" className="space-y-6">
           {/* Pipeline Controls */}
-          <div className="flex justify-between items-center">
+          <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4">
             <div>
               <h2 className="text-xl font-semibold flex items-center gap-2">
                 <Zap className="h-5 w-5" />
@@ -1662,7 +1665,7 @@ export default function AdminPage() {
               </CardDescription>
             </CardHeader>
             <CardContent>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 overflow-x-auto pb-2">
                 {(['research', 'verification', 'hitl_review', 'implementation', 'complete'] as PipelineStage[]).map((stage, idx) => {
                   const isActive = pipelineRun?.stage === stage;
                   const isPast = pipelineRun && getStageOrder(pipelineRun.stage) > getStageOrder(stage);
@@ -1688,7 +1691,7 @@ export default function AdminPage() {
               </div>
 
               {pipelineRun && (
-                <div className="mt-4 grid grid-cols-4 gap-4 text-center">
+                <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
                   <div>
                     <div className="text-2xl font-bold">{pipelineRun.findingsCount}</div>
                     <p className="text-xs text-muted-foreground">Findings</p>
@@ -1734,7 +1737,7 @@ export default function AdminPage() {
                   <ShieldCheck className="h-4 w-4 text-green-500" />
                   Verified Findings ({pipelineFindings.filter(f => f.status === 'verified').length})
                 </h3>
-                <ScrollArea className="h-[400px]">
+                <ScrollArea className="h-[300px] sm:h-[400px]">
                   <div className="space-y-3">
                     {pipelineFindings
                       .filter(f => f.status === 'verified')
@@ -1750,13 +1753,13 @@ export default function AdminPage() {
                                   onChange={() => toggleFindingSelection(finding.id)}
                                   className="mt-1 h-4 w-4 rounded"
                                 />
-                                <div className="flex-1">
-                                  <div className="flex items-start justify-between">
-                                    <div className="flex-1">
+                                <div className="flex-1 min-w-0">
+                                  <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-2">
+                                    <div className="flex-1 min-w-0">
                                       <h4 className="font-semibold text-sm">{finding.title}</h4>
                                       <p className="text-xs text-muted-foreground mt-1">{finding.summary}</p>
                                     </div>
-                                    <div className="flex gap-1 ml-2">
+                                    <div className="flex gap-1 shrink-0">
                                       <Badge variant="outline" className="text-xs">
                                         {Math.round(finding.relevanceScore * 100)}%
                                       </Badge>
@@ -1801,7 +1804,7 @@ export default function AdminPage() {
                                       )}
                                     </div>
                                   )}
-                                  <div className="mt-2 text-xs text-muted-foreground">
+                                  <div className="mt-2 text-xs text-muted-foreground break-all sm:break-normal">
                                     Source: <a href={finding.sourceUrl} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">{finding.sourceUrl}</a>
                                     {' '}&middot; Discovered: {new Date(finding.discoveredAt).toLocaleString('en-AU')}
                                   </div>
@@ -1897,23 +1900,23 @@ export default function AdminPage() {
               {pipelineRuns.length > 0 ? (
                 <div className="space-y-3">
                   {pipelineRuns.slice(0, 10).map(run => (
-                    <div key={run.id} className="flex items-center justify-between border-b pb-3 last:border-0 last:pb-0">
-                      <div className="flex items-center gap-3">
-                        <div className={`h-2 w-2 rounded-full ${
+                    <div key={run.id} className="flex flex-col sm:flex-row sm:items-center justify-between border-b pb-3 last:border-0 last:pb-0 gap-2">
+                      <div className="flex items-center gap-3 min-w-0">
+                        <div className={`h-2 w-2 rounded-full shrink-0 ${
                           run.stage === 'complete' ? 'bg-green-500' :
                           run.stage === 'failed' ? 'bg-red-500' :
                           run.stage === 'hitl_review' ? 'bg-orange-500' :
                           'bg-blue-500 animate-pulse'
                         }`} />
-                        <div>
-                          <p className="text-sm font-medium">{run.id}</p>
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium truncate">{run.id}</p>
                           <p className="text-xs text-muted-foreground">
                             {new Date(run.startedAt).toLocaleString('en-AU')}
                             {run.completedAt && ` - ${new Date(run.completedAt).toLocaleString('en-AU')}`}
                           </p>
                         </div>
                       </div>
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 flex-wrap ml-5 sm:ml-0">
                         <Badge variant="outline" className="text-xs">
                           {run.findingsCount} findings
                         </Badge>
@@ -1939,7 +1942,7 @@ export default function AdminPage() {
 
         {/* Data Sources Tab */}
         <TabsContent value="sources" className="space-y-6">
-          <div className="flex justify-between items-center">
+          <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4">
             <div>
               <h2 className="text-xl font-semibold">Data Sources</h2>
               <p className="text-sm text-muted-foreground">
@@ -1953,7 +1956,7 @@ export default function AdminPage() {
           </div>
 
           {/* Summary Stats */}
-          <div className="grid grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
             <Card>
               <CardContent className="pt-6">
                 <div className="text-center">
@@ -1998,9 +2001,9 @@ export default function AdminPage() {
             {sources.map((source) => (
               <Card key={source.id} className={!source.enabled ? 'opacity-60' : ''}>
                 <CardContent className="pt-6">
-                  <div className="flex items-start justify-between">
-                    <div className="flex items-start gap-4 flex-1">
-                      <div className="flex flex-col items-center gap-2">
+                  <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
+                    <div className="flex items-start gap-4 flex-1 min-w-0">
+                      <div className="flex flex-col items-center gap-2 shrink-0">
                         <div
                           className={`h-3 w-3 rounded-full ${
                             source.enabled && source.status === 'healthy'
@@ -2018,8 +2021,8 @@ export default function AdminPage() {
                           title={source.enabled ? 'Disable source' : 'Enable source'}
                         />
                       </div>
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2 mb-1">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1 flex-wrap">
                           <h3 className="font-semibold">{source.name}</h3>
                           <Badge variant={getScheduleBadgeVariant(source.schedule)}>
                             {source.schedule}
@@ -2030,13 +2033,13 @@ export default function AdminPage() {
                         </div>
                         <a
                           href={source.url}
-                          className="text-sm text-primary hover:underline block"
+                          className="text-sm text-primary hover:underline block truncate"
                           target="_blank"
                           rel="noopener noreferrer"
                         >
                           {source.url}
                         </a>
-                        <div className="mt-2 flex items-center gap-4 text-sm text-muted-foreground">
+                        <div className="mt-2 flex items-center gap-2 sm:gap-4 text-sm text-muted-foreground flex-wrap">
                           {source.status === 'healthy' ? (
                             <div className="flex items-center gap-1">
                               <CheckCircle2 className="h-4 w-4 text-green-500" />
@@ -2048,14 +2051,14 @@ export default function AdminPage() {
                               <span>Error</span>
                             </div>
                           )}
-                          <span>•</span>
+                          <span className="hidden sm:inline">•</span>
                           <span>Last run: {new Date(source.lastRun).toLocaleString('en-AU', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</span>
-                          <span>•</span>
+                          <span className="hidden sm:inline">•</span>
                           <span className="font-medium">{source.itemsFound} items</span>
                         </div>
                       </div>
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 ml-7 sm:ml-0">
                       <Button
                         variant="outline"
                         size="sm"

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -285,7 +285,7 @@ export default function MapPage() {
             </CardHeader>
             <CardContent>
               {selectedJurisdiction ? (
-                <ScrollArea className="h-[550px] pr-4">
+                <ScrollArea className="h-[350px] lg:h-[550px] pr-4">
                   {/* Policies */}
                   <div className="mb-6">
                     <h3 className="font-semibold flex items-center gap-2 mb-3 text-sm">
@@ -396,7 +396,7 @@ export default function MapPage() {
                   </div>
                 </ScrollArea>
               ) : (
-                <div className="flex flex-col items-center justify-center h-[400px] text-center px-4">
+                <div className="flex flex-col items-center justify-center h-[250px] lg:h-[400px] text-center px-4">
                   <div className="h-20 w-20 rounded-full bg-gradient-to-br from-indigo-500/10 to-purple-500/10 flex items-center justify-center mb-4">
                     <MapPin className="h-10 w-10 text-indigo-500/50" />
                   </div>

--- a/src/app/network/page.tsx
+++ b/src/app/network/page.tsx
@@ -696,7 +696,7 @@ export default function NetworkPage() {
 
         {/* Network Graph */}
         <div className="lg:col-span-3">
-          <Card className="h-[700px] overflow-hidden">
+          <Card className="h-[400px] lg:h-[700px] overflow-hidden">
             <CardContent className="p-0 h-full">
               {highlightedNodes.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-full text-center p-8">

--- a/src/app/policies/[id]/page.tsx
+++ b/src/app/policies/[id]/page.tsx
@@ -136,7 +136,7 @@ export default async function PolicyDetailPage({ params }: { params: Promise<{ i
         <ChevronRight className="h-4 w-4" />
         <Link href="/policies" className="hover:text-foreground">Policies</Link>
         <ChevronRight className="h-4 w-4" />
-        <span className="text-foreground truncate max-w-[200px]">{policy.title}</span>
+        <span className="text-foreground truncate max-w-[150px] sm:max-w-[300px]">{policy.title}</span>
       </nav>
 
       {/* Back Button */}
@@ -199,7 +199,7 @@ export default async function PolicyDetailPage({ params }: { params: Promise<{ i
               </div>
 
               {/* Action Buttons */}
-              <div className="flex gap-2 mt-6">
+              <div className="flex flex-wrap gap-2 mt-6">
                 {policy.sourceUrl && (
                   <Button asChild>
                     <a href={policy.sourceUrl} target="_blank" rel="noopener noreferrer">

--- a/src/app/policies/page.tsx
+++ b/src/app/policies/page.tsx
@@ -119,7 +119,7 @@ function PoliciesContent() {
           </div>
           <div className="flex gap-2 flex-wrap">
             <Select value={jurisdictionFilter} onValueChange={setJurisdictionFilter}>
-              <SelectTrigger className="w-[180px]">
+              <SelectTrigger className="w-full sm:w-[180px]">
                 <Filter className="h-4 w-4 mr-2" />
                 <SelectValue placeholder="Jurisdiction" />
               </SelectTrigger>
@@ -134,7 +134,7 @@ function PoliciesContent() {
             </Select>
 
             <Select value={typeFilter} onValueChange={setTypeFilter}>
-              <SelectTrigger className="w-[150px]">
+              <SelectTrigger className="w-[calc(50%-4px)] sm:w-[150px]">
                 <SelectValue placeholder="Type" />
               </SelectTrigger>
               <SelectContent>
@@ -148,7 +148,7 @@ function PoliciesContent() {
             </Select>
 
             <Select value={statusFilter} onValueChange={setStatusFilter}>
-              <SelectTrigger className="w-[140px]">
+              <SelectTrigger className="w-[calc(50%-4px)] sm:w-[140px]">
                 <SelectValue placeholder="Status" />
               </SelectTrigger>
               <SelectContent>


### PR DESCRIPTION
- Admin page: make tabs horizontally scrollable, add responsive grid
  breakpoints for pipeline stats and data source summary, stack source
  cards and pipeline controls on mobile, wrap batch action buttons,
  reduce ScrollArea heights on small screens, make dialog form grids
  stack on mobile, improve text truncation for long URLs and titles
- Policies page: make filter selects full-width on mobile
- Policy detail page: add flex-wrap to action buttons, responsive
  breadcrumb truncation
- Map page: reduce ScrollArea and empty state heights on mobile
- Network page: reduce graph container height on mobile

https://claude.ai/code/session_0147UmNxwJoc2eWzyEzwTrWG