### PR TITLE
fix: improve dark mode visibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -97,21 +97,21 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
+  --border: #404040;
+  --input: #404040;
   --ring: oklch(0.556 0 0);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
+  --sidebar: oklch(0.21 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-border: oklch(0.35 0 0);
   --sidebar-ring: oklch(0.556 0 0);
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link';
 import { Map, FileText, ArrowRight, Building2, MapPin, CheckCircle2, Calendar } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { HomeSearch } from '@/components/home-search';
 import {
@@ -23,10 +22,10 @@ const stats = {
 };
 
 const statusColors: Record<string, string> = {
-  proposed: 'bg-yellow-100 text-yellow-800 border-yellow-200',
-  active: 'bg-green-100 text-green-800 border-green-200',
-  amended: 'bg-blue-100 text-blue-800 border-blue-200',
-  repealed: 'bg-gray-100 text-gray-800 border-gray-200',
+  proposed: 'bg-yellow-100 text-yellow-800 border-yellow-200 dark:bg-yellow-900/40 dark:text-yellow-300 dark:border-yellow-700',
+  active: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/40 dark:text-green-300 dark:border-green-700',
+  amended: 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900/40 dark:text-blue-300 dark:border-blue-700',
+  repealed: 'bg-gray-100 text-gray-800 border-gray-200 dark:bg-gray-800/40 dark:text-gray-300 dark:border-gray-600',
 };
 
 // Get recent policies sorted by updatedAt
@@ -143,37 +142,35 @@ export default function HomePage() {
               </Link>
             </Button>
           </div>
-          <div className="space-y-3">
+          <div className="space-y-2">
             {recentPolicies.map((policy) => (
-              <Link key={policy.id} href={`/policies/${policy.id}`}>
-                <Card className="hover:shadow-md hover:border-primary/30 transition-all">
-                  <CardContent className="flex items-center gap-4 p-4">
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1 flex-wrap">
-                        <h3 className="font-medium truncate">{policy.title}</h3>
-                      </div>
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <Badge
-                          variant="outline"
-                          className={`text-xs ${statusColors[policy.status] || ''}`}
-                        >
-                          {POLICY_STATUS_NAMES[policy.status as PolicyStatus]}
-                        </Badge>
-                        <Badge variant="secondary" className="text-xs">
-                          {JURISDICTION_NAMES[policy.jurisdiction as Jurisdiction]}
-                        </Badge>
-                        <span className="text-xs text-muted-foreground flex items-center gap-1">
-                          <Calendar className="h-3 w-3" />
-                          {new Date(policy.effectiveDate).toLocaleDateString('en-AU', {
-                            year: 'numeric',
-                            month: 'short',
-                          })}
-                        </span>
-                      </div>
-                    </div>
-                    <ArrowRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                  </CardContent>
-                </Card>
+              <Link
+                key={policy.id}
+                href={`/policies/${policy.id}`}
+                className="flex items-center gap-4 p-4 rounded-lg border border-border bg-card hover:bg-accent hover:border-primary/30 transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <h3 className="font-medium truncate mb-1">{policy.title}</h3>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <Badge
+                      variant="outline"
+                      className={`text-xs ${statusColors[policy.status] || ''}`}
+                    >
+                      {POLICY_STATUS_NAMES[policy.status as PolicyStatus]}
+                    </Badge>
+                    <Badge variant="secondary" className="text-xs">
+                      {JURISDICTION_NAMES[policy.jurisdiction as Jurisdiction]}
+                    </Badge>
+                    <span className="text-xs text-muted-foreground flex items-center gap-1">
+                      <Calendar className="h-3 w-3" />
+                      {new Date(policy.effectiveDate).toLocaleDateString('en-AU', {
+                        year: 'numeric',
+                        month: 'short',
+                      })}
+                    </span>
+                  </div>
+                </div>
+                <ArrowRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
               </Link>
             ))}
           </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,7 +3,7 @@ import { Mail } from 'lucide-react';
 
 export function Footer() {
   return (
-    <footer className="border-t bg-muted/50">
+    <footer className="border-t border-border bg-muted/80">
       <div className="container mx-auto px-4 py-8">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           <div className="space-y-4">


### PR DESCRIPTION
## Summary
- **Dark mode borders invisible** — changed `--border` from semi-transparent white (`oklch(1 0 0 / 10%)`) to solid gray (`#404040`) for visible card borders across the entire app
- **Homepage Recent Policies invisible** — replaced Card components with simpler bordered list items, added dark mode color variants for status badges
- **Footer invisible** — increased border opacity from `/50` to `/80` with explicit `border-border` class

## Test plan
- [x] `npm run build` passes clean
- [x] `npm run lint` — same 20 pre-existing issues, zero new
- [ ] Manual: verify dark mode card visibility on `/policies`, `/map`, `/agencies`
- [ ] Manual: verify homepage Recent Policies section visible in dark mode
- [ ] Manual: verify light mode not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)