### PR TITLE
feat: hybrid data automation + UI hardening — Supabase-first service layer, Vercel Cron scraper, and responsive polish

### DIFF
--- a/.superpowers/brainstorm/4784-1775398160/state/server-stopped
+++ b/.superpowers/brainstorm/4784-1775398160/state/server-stopped
@@ -1,0 +1,1 @@
+{"reason":"idle timeout","timestamp":1775400620525}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,198 @@
+# AGENTS.md - Policai Codebase Guide
+
+## Project Overview
+
+Policai is an Australian AI Policy Tracker — a Next.js web application that aggregates, analyzes, and visualizes AI policy, regulation, and governance developments across Australian federal and state/territory jurisdictions. It uses Codex AI to automatically discover, analyze, and categorize government AI policies from official sources.
+
+## Tech Stack
+
+- **Framework:** Next.js 16 (App Router) with React 19
+- **Language:** TypeScript 5 (strict mode)
+- **Styling:** Tailwind CSS 4 with CSS variables
+- **UI Components:** shadcn/ui (New York style) built on Radix UI primitives
+- **Icons:** Lucide React
+- **Visualizations:** D3.js 7, React Flow 11
+- **Database:** Supabase (PostgreSQL) + file-based JSON in `public/data/`
+- **AI:** Anthropic Codex SDK (`Codex-sonnet-4-20250514` model)
+- **Scraping:** Cheerio for HTML parsing
+- **Auth:** Supabase Auth + custom admin password
+
+## Commands
+
+```bash
+npm run dev        # Start dev server on http://localhost:3000
+npm run build      # Production build
+npm run start      # Run production server
+npm run lint       # Run ESLint (Next.js core-web-vitals + TypeScript rules)
+npm run scrape     # Run scheduled scrapers (tsx scripts/run-scheduled-scrapers.ts)
+```
+
+## Project Structure
+
+```
+src/
+├── app/                          # Next.js App Router pages and API routes
+│   ├── layout.tsx                # Root layout (theme provider, header, footer)
+│   ├── page.tsx                  # Home page
+│   ├── admin/                    # Admin dashboard (login + management)
+│   ├── agencies/page.tsx         # Government agency directory
+│   ├── framework/page.tsx        # DTA AI Policy Framework visualization
+│   ├── map/page.tsx              # Interactive Australia map view
+│   ├── network/page.tsx          # Policy relationship graph
+│   ├── policies/                 # Policy browser (list + detail + timeline)
+│   │   ├── page.tsx              # Searchable/filterable policy list with timeline tab
+│   │   └── [id]/
+│   │       ├── page.tsx          # Policy detail page (server component)
+│   │       └── policy-detail-tabs.tsx  # Tabbed detail view (Overview/Content/Related)
+│   ├── timeline/page.tsx         # AI policy timeline (standalone, not in main nav)
+│   └── api/                      # API route handlers
+│       ├── admin/
+│       │   ├── run-scraper/route.ts    # Main scraper endpoint
+│       │   ├── pending/route.ts        # Pending content management
+│       │   └── analyse-url/route.ts    # URL analysis
+│       ├── Codex/analyze/route.ts     # Codex AI analysis endpoint
+│       └── policies/
+│           ├── route.ts                # Policy CRUD (GET/POST)
+│           └── [id]/route.ts           # Single policy (GET/PUT/DELETE)
+├── components/
+│   ├── ui/                       # shadcn/ui components (button, card, dialog, etc.)
+│   ├── layout/                   # Header, Footer
+│   ├── admin/                    # Admin dashboard tab sub-components
+│   │   ├── OverviewTab.tsx       # Stats and recent activity
+│   │   ├── ReviewTab.tsx         # AI-suggested content review
+│   │   ├── PipelineTab.tsx       # AI research pipeline controls
+│   │   ├── SourcesTab.tsx        # Data source management
+│   │   ├── TrashTab.tsx          # Soft-deleted policy management
+│   │   └── SettingsTab.tsx       # AI and database configuration
+│   ├── visualizations/           # AustraliaMap, Timeline, PolicyFrameworkMap
+│   ├── auth/ProtectedRoute.tsx   # Auth guard wrapper
+│   └── home-search.tsx           # Homepage search component
+├── contexts/AuthContext.tsx       # Authentication state context
+├── hooks/use-toast.ts            # Toast notification hook
+├── lib/
+│   ├── Codex.ts                 # Codex AI integration (analysis, summarization, extraction)
+│   ├── supabase.ts               # Supabase client and query functions
+│   ├── auth.ts                   # Auth utility functions
+│   ├── file-store.ts             # Shared JSON file I/O (readJsonFile, writeJsonFile)
+│   ├── utils.ts                  # Helpers (cn, cleanHtmlContent, extractJsonFromResponse)
+│   └── agents/                   # AI pipeline agent modules
+│       ├── research-agent.ts     # Web research and content discovery
+│       ├── verifier-agent.ts     # Fact-checking and verification
+│       ├── implementation-agent.ts # Policy entry generation
+│       └── pipeline-storage.ts   # Pipeline run/finding/verification persistence
+└── types/index.ts                # All TypeScript type definitions
+
+public/data/                      # JSON data files (policies, agencies, timeline, etc.)
+scripts/                          # Scraper automation scripts
+```
+
+## Architecture & Patterns
+
+### Navigation Structure
+The app uses a simplified 3-item navigation: **Policies**, **Map**, **Agencies**. Other views (Framework, Network, Timeline) still exist as pages but are not in the main nav. Timeline is embedded as a tab within the Policies page. The home page focuses on search and a recent policies feed.
+
+### Page Patterns
+- **Policies list** (`/policies`): Client component with Browse/Timeline tabs, collapsible filters behind a toggle button, compact card design
+- **Policy detail** (`/policies/[id]`): Server component for data fetching + client `PolicyDetailTabs` component with Overview/Content/Related tabs
+- **Home page**: Server component with search bar, stats, and recent policies feed
+
+### Routing
+Next.js App Router with file-based routing. Pages are in `src/app/[route]/page.tsx`, API routes in `src/app/api/[endpoint]/route.ts`. Dynamic routes use `[id]` folder convention.
+
+### Server vs Client Components
+- Pages default to Server Components for data fetching
+- Interactive components use `'use client'` directive at the top of the file
+- Policy detail page uses a server/client split: server component fetches data, passes it to a client `PolicyDetailTabs` component for tabs
+- Visualizations (D3, React Flow) are client-side only
+
+### Data Storage
+Dual storage strategy:
+1. **Supabase** — primary database when configured (optional, requires env vars)
+2. **JSON files** in `public/data/` — fallback/default data source, read via `fetch('/data/*.json')`
+
+Policy data flows: Scraper fetches government sources -> Codex AI analyzes content -> policies saved to JSON or Supabase.
+
+### Import Aliases
+The `@/*` alias maps to `./src/*` (configured in `tsconfig.json`). Use it for all imports:
+```typescript
+import { Button } from '@/components/ui/button'
+import { Policy } from '@/types'
+import { cn } from '@/lib/utils'
+```
+
+### Styling
+- Tailwind CSS utility classes for all styling
+- Use `cn()` from `@/lib/utils` to merge conditional Tailwind classes
+- Theme colors defined as CSS variables in `globals.css`
+- Light-only theme with IBM Plex color system
+- shadcn/ui components follow New York style variant
+
+### Adding UI Components
+shadcn/ui components live in `src/components/ui/`. To add new ones:
+```bash
+npx shadcn@latest add <component-name>
+```
+Configuration is in `components.json`.
+
+## Key Domain Types
+
+Defined in `src/types/index.ts`:
+
+- **Jurisdiction:** `'federal' | 'nsw' | 'vic' | 'qld' | 'wa' | 'sa' | 'tas' | 'act' | 'nt'`
+- **PolicyType:** `'legislation' | 'regulation' | 'guideline' | 'framework' | 'standard'`
+- **PolicyStatus:** `'proposed' | 'active' | 'amended' | 'repealed' | 'trashed'`
+- **Policy** — core entity with id, title, description, jurisdiction, type, status, agencies, aiSummary, tags, etc.
+- **Agency** — government agency with transparency statement fields
+- **TimelineEvent** — dated events with type (policy_introduced, amended, repealed, announcement, milestone)
+- **PipelineRun**, **ResearchFinding**, **VerificationResult** — AI pipeline types
+- Display name mappings: `JURISDICTION_NAMES`, `POLICY_TYPE_NAMES`, `POLICY_STATUS_NAMES`, `PIPELINE_STAGE_NAMES`, `VERIFICATION_OUTCOME_NAMES`
+
+## Environment Variables
+
+Create a `.env.local` file in the project root:
+
+```bash
+# Required for AI features and scraping
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Optional — Supabase (database features)
+NEXT_PUBLIC_SUPABASE_URL=...
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+
+# Optional — Admin authentication
+ADMIN_PASSWORD=...
+```
+
+The app works without Supabase by falling back to JSON files in `public/data/`.
+
+## Linting
+
+ESLint 9 with flat config (`eslint.config.mjs`):
+- Extends `eslint-config-next/core-web-vitals` and `eslint-config-next/typescript`
+- Ignores: `.next/`, `out/`, `build/`, `next-env.d.ts`
+- No Prettier configured — rely on ESLint rules only
+- Run `npm run lint` to check; fix issues before committing
+
+## Testing
+
+No test framework is currently configured. There are no unit or integration tests.
+
+## Scraper System
+
+The automated scraper monitors 8 Australian government sources for AI policy content:
+- Fetches pages with Cheerio HTML parsing
+- Sends content to Codex AI for relevance scoring (0-1 scale)
+- Auto-creates policies scoring >= 0.8, queues 0.5-0.8 for review, skips < 0.5
+- Rate limited: 2s between pages, 5s between sources
+- State tracked in `data/scraper-state.json`
+- Trigger via `npm run scrape` or the admin dashboard API
+
+## Code Conventions
+
+- PascalCase for React components and type/interface names
+- camelCase for functions, variables, and file names (except components which use PascalCase filenames)
+- All types centralized in `src/types/index.ts` — always import from `@/types`, never redefine locally
+- Shared utilities in `@/lib/utils.ts` (`cleanHtmlContent`, `extractJsonFromResponse`) and `@/lib/file-store.ts` (`readJsonFile`, `writeJsonFile`) — use these instead of inline implementations
+- API routes export named functions matching HTTP methods (`GET`, `POST`, `PUT`, `DELETE`)
+- Error handling with try/catch and `NextResponse.json()` with appropriate status codes
+- Toast notifications for user-facing feedback (`use-toast` hook)

--- a/plans/2026-04-06-policai-ui-ux-improvements-v1.md
+++ b/plans/2026-04-06-policai-ui-ux-improvements-v1.md
@@ -1,0 +1,196 @@
+# Policai UI/UX Improvement Plan
+
+## Objective
+
+Elevate the UI/UX of the Policai Australian AI Policy Tracker to deliver a more polished, accessible, and cohesive experience across all views — improving discoverability, mobile responsiveness, visual consistency, and user engagement with policy data.
+
+---
+
+## Current State Assessment
+
+### Strengths
+- Clean, editorial design language (IBM Plex fonts, warm off-white palette)
+- Consistent use of monospace uppercase labels for metadata
+- Good use of color-coded status indicators (green/amber/blue/gray)
+- Well-executed map interaction with animated sliding panel
+- Keyboard accessibility on SVG map (`tabIndex`, Enter/Space handlers)
+- `prefers-reduced-motion` support in map animations
+
+### Identified Issues (Prioritized)
+
+| Priority | Issue | Impact | Source |
+|----------|-------|--------|--------|
+| **P0** | Mobile breakage on map page — sliding panel is fixed 340px with no mobile adaptation | High | `src/app/map/page.tsx:105` |
+| **P0** | Agencies sidebar is always visible with no responsive collapse — table is unusable on mobile | High | `src/app/agencies/page.tsx:46` |
+| **P1** | Home page is a bare data table with no contextual introduction — new visitors have no orientation | High | `src/app/page.tsx:88-121` |
+| **P1** | Three major feature pages (Framework, Network, Timeline) are fully built but hidden from navigation | High | `src/components/layout/Header.tsx:11-15` |
+| **P1** | `STATUS_COLORS` map is duplicated independently across 4 files instead of being shared | Medium | `policy-detail-tabs.tsx:16-21`, `policy-table.tsx:26-31`, `map/page.tsx:18-23` |
+| **P2** | No dark mode support — CSS variables only define light theme | Medium | `src/app/globals.css:47-80` |
+| **P2** | Network page uses a different visual language (gradient cards, stat boxes) than the rest of the app | Medium | `src/app/network/page.tsx:76-93` |
+| **P2** | Policy detail Content tab shows raw text with no formatting or empty state enhancement | Medium | `policy-detail-tabs.tsx:127-130` |
+| **P2** | No loading states or skeleton placeholders during data fetching on client pages | Medium | Multiple pages |
+| **P3** | Footer links to `/about` and `/methodology` which are non-existent pages | Low | `src/components/layout/Footer.tsx:10-12` |
+| **P3** | GitHub link in footer points to generic `https://github.com` instead of the actual repo | Low | `src/components/layout/Footer.tsx:14-21` |
+| **P3** | `BackToTop` component exists but is not used anywhere in the app | Low | `src/components/ui/back-to-top.tsx` |
+| **P3** | Settings tab in admin has non-functional Save button (no `onClick` handler) | Low | `src/components/admin/SettingsTab.tsx` |
+
+---
+
+## Implementation Plan
+
+### Phase 1: Critical Mobile & Layout Fixes
+
+- [ ] **1.1 Make map page responsive.** On viewports below `md`, replace the 340px fixed sliding panel with a bottom sheet (full-width drawer sliding up from the bottom, approximately 60% viewport height). Use the existing `Sheet` component from shadcn/ui or a similar approach. The `AustraliaMap` should take full width on all screen sizes. The bottom summary bar should also become full-width and not attempt to adjust for a side panel on mobile.
+  - Files: `src/app/map/page.tsx`
+  - Rationale: The 340px panel overflows small screens entirely, making the map unusable on phones.
+
+- [ ] **1.2 Make agencies page responsive.** Collapse the 240px sidebar into a horizontal filter bar (search + select inline) at viewports below `lg`. Convert the data table into a card-based layout on mobile where each agency is a tappable card showing name, acronym, and statement status — with expand-on-tap for details.
+  - Files: `src/app/agencies/page.tsx`
+  - Rationale: Sidebar + wide table is completely broken on small screens.
+
+- [ ] **1.3 Make filter sidebar responsive on home page.** The `FilterSidebar` already has `w-full lg:w-60` but verify it collapses cleanly on mobile — consider rendering filters as a collapsible disclosure or horizontal pills below the search bar on small screens rather than a full-width block.
+  - Files: `src/components/filter-sidebar.tsx`, `src/app/page.tsx`
+  - Rationale: On mobile the sidebar takes full width above the table, pushing content down excessively.
+
+### Phase 2: Navigation & Discoverability
+
+- [ ] **2.1 Redesign navigation to surface hidden pages.** Add a secondary navigation tier or expand the header nav to include all key views. Recommended approach: keep the current 3-item primary nav (Policies, Map, Agencies) and add a "More" dropdown menu containing Framework, Network, and Timeline links. Alternatively, consider a 5-item nav (Policies, Map, Agencies, Framework, Timeline) — the Network page could be linked contextually from the Policies page rather than in the top nav.
+  - Files: `src/components/layout/Header.tsx`
+  - Rationale: Three fully-built feature pages are invisible to users, wasting significant development effort.
+
+- [ ] **2.2 Add a hero/introduction section to the home page.** Above the filter+table layout, add a brief contextual block: a one-line tagline (e.g., "Tracking AI policy and regulation across Australia"), a row of key stats (total policies, jurisdictions covered, active policies count), and optionally a prominent link to the Map view. Keep it minimal — the editorial aesthetic should not be disrupted by a large marketing-style hero.
+  - Files: `src/app/page.tsx`
+  - Rationale: New visitors arriving at a bare data table have no context about what Policai is or why it matters.
+
+- [ ] **2.3 Fix footer links.** Point the GitHub link to `https://github.com/danielalkurdi/policai`. For the About and Methodology links, either create minimal content pages or replace them with anchor sections on the home page. If creating pages is out of scope, change them to hash-link anchors to a brief section at the bottom of the home page.
+  - Files: `src/components/layout/Footer.tsx`
+  - Rationale: Broken links degrade trust and professionalism.
+
+### Phase 3: Visual Consistency & Design System Hardening
+
+- [ ] **3.1 Extract shared constants into a central design-tokens file.** Create a `src/lib/design-tokens.ts` file exporting `STATUS_COLORS`, `STATUS_BG_COLORS`, and any other repeated visual mappings. Update all 4+ files that currently define `STATUS_COLORS` independently to import from this central location.
+  - Files: New `src/lib/design-tokens.ts`, then update `policy-detail-tabs.tsx`, `policy-table.tsx`, `map/page.tsx`, and any others
+  - Rationale: Ensures visual consistency and makes future palette changes a single-point update.
+
+- [ ] **3.2 Harmonize the Network page visual language.** Restyle the Network page's stat cards, Dialog content, and sidebar to use the same monospace-label, minimal-border, editorial aesthetic as the rest of the app. Replace gradient backgrounds with flat borders and muted backgrounds. Use the `FilterSidebar` pattern for network filters.
+  - Files: `src/app/network/page.tsx`
+  - Rationale: The Network page looks like it belongs to a different application compared to the Home, Map, and Agencies pages.
+
+- [ ] **3.3 Add a dark mode theme.** Define a `:root.dark` or `@media (prefers-color-scheme: dark)` block in `globals.css` with appropriate dark variants of all CSS variables (background, foreground, card, muted, primary, border, etc.). Add a theme toggle button in the header using `next-themes` or a simple `localStorage`-based approach. Ensure all hardcoded color values (e.g., `hover:bg-[#f0efed]`, `text-green-700`, SVG fills) are replaced with CSS variable references or conditional Tailwind classes.
+  - Files: `src/app/globals.css`, `src/app/layout.tsx`, `src/components/layout/Header.tsx`, multiple components with hardcoded colors
+  - Rationale: No dark mode in 2026 is a significant UX gap; the warm off-white background is harsh in low-light environments. Note: This is a larger effort due to hardcoded color values scattered across components (map SVG fills, status colors, hover states).
+
+### Phase 4: Micro-interactions & Polish
+
+- [ ] **4.1 Add loading skeletons for client-side pages.** Create a `PolicyTableSkeleton` component with animated placeholder rows and a `FilterSidebarSkeleton`. Apply these as the initial render state on the home page and agencies page while data is being processed. For the map page, show a subtle pulse animation on the SVG container before data loads.
+  - Files: New skeleton components in `src/components/ui/`, updates to `src/app/page.tsx`, `src/app/agencies/page.tsx`, `src/app/map/page.tsx`
+  - Rationale: Currently, pages either flash empty or jump when data hydrates. Skeletons provide perceived performance.
+
+- [ ] **4.2 Enhance the policy detail Content tab.** When `policy.content` exists, render it with basic typographic formatting (paragraph spacing, potential heading detection). When it's empty, show a more informative empty state with a link to the source URL and a note explaining that full content may not be available. Consider rendering AI-extracted key points as a bulleted summary.
+  - Files: `src/app/policies/[id]/policy-detail-tabs.tsx`
+  - Rationale: The Content tab currently shows either a wall of unstyled `whitespace-pre-wrap` text or a single dismissive line.
+
+- [ ] **4.3 Integrate the `BackToTop` component.** Add `<BackToTop />` to the root layout or to long-scrolling pages (home, agencies, timeline, framework). Consider enhancing it with a fade-in/out animation instead of the current show/hide toggle.
+  - Files: `src/app/layout.tsx` or individual page files, `src/components/ui/back-to-top.tsx`
+  - Rationale: The component was built but never used. Long policy tables and the agencies list benefit from quick scroll-to-top.
+
+- [ ] **4.4 Add subtle page transition animations.** Wrap page content in a fade-in animation on mount (using CSS `@keyframes` or a simple `opacity 0 → 1` transition on the `<main>` container). Keep it fast (200-300ms) and respect `prefers-reduced-motion`.
+  - Files: `src/app/layout.tsx` or `src/app/globals.css`
+  - Rationale: Page transitions currently feel abrupt. A minimal fade improves perceived smoothness without adding dependency weight.
+
+- [ ] **4.5 Improve search UX with debouncing and keyboard shortcuts.** Add a 200ms debounce to the search inputs on the home page and agencies page to prevent excessive re-renders during fast typing. Add a keyboard shortcut (Cmd/Ctrl+K or `/`) to focus the main search input on the home page.
+  - Files: `src/app/page.tsx`, `src/app/agencies/page.tsx`
+  - Rationale: Power users benefit from keyboard navigation; debouncing prevents jank on large datasets.
+
+### Phase 5: Enhanced Data Presentation
+
+- [ ] **5.1 Add URL-synced filters.** Sync filter state (jurisdiction, type, status, search) to URL query parameters on the home page using `useSearchParams()`. This enables users to share filtered views via URL and preserves filter state on browser back/forward navigation.
+  - Files: `src/app/page.tsx`
+  - Rationale: Currently, all filter state is lost on navigation. Bookmarkable filtered views are essential for a reference tool.
+
+- [ ] **5.2 Add pagination or virtualized scrolling to the policy table.** If the dataset grows beyond ~50 policies, the full-render table will degrade. Implement either client-side pagination (e.g., 25 per page with page controls) or virtual scrolling using a library like `@tanstack/react-virtual`.
+  - Files: `src/components/policy-table.tsx`, `src/app/page.tsx`
+  - Rationale: Proactive scalability — the scraper continuously adds new policies, and the table will eventually need bounded rendering.
+
+- [ ] **5.3 Add an "empty state" illustration system.** Create a consistent empty-state pattern with an icon, message, and optional action button. Apply it to: policy table (no results), agencies table (no results), map panel (no policies), timeline (no events), and the related policies tab. Currently each page implements empty state differently (some just text, some with icons).
+  - Files: New `src/components/ui/empty-state.tsx`, then update policy-table, agencies, map panel, timeline, policy-detail-tabs
+  - Rationale: Consistent empty states improve polish and help users understand why no data is shown and what action to take.
+
+- [ ] **5.4 Enhance the map tooltip with richer data.** Add policy type breakdown (e.g., "2 Legislation, 1 Guideline") and a "Click to explore" call-to-action to the cursor-following tooltip on the Australia map. Currently it only shows total and active counts.
+  - Files: `src/components/visualizations/AustraliaMap.tsx`
+  - Rationale: Richer tooltips reduce the number of clicks needed to understand a jurisdiction's policy landscape.
+
+### Phase 6: Accessibility Hardening
+
+- [ ] **6.1 Add ARIA landmarks and skip navigation.** Add a "Skip to main content" link at the top of the page (visually hidden, visible on focus). Ensure the header uses `<nav aria-label="Main navigation">`, the sidebar uses `role="complementary"`, and the main content area uses the correct landmark structure.
+  - Files: `src/app/layout.tsx`, `src/components/layout/Header.tsx`, `src/components/filter-sidebar.tsx`
+  - Rationale: Screen reader users need landmarks to navigate efficiently. This is a basic WCAG requirement.
+
+- [ ] **6.2 Improve focus management and visible focus indicators.** Audit all interactive elements for visible focus rings. The current `outline-ring/50` global rule may be too subtle. Add a more prominent focus-visible style (e.g., `ring-2 ring-primary ring-offset-2`) to buttons, links, and form controls. Ensure focus is managed correctly when dialogs open/close (focus trap and return).
+  - Files: `src/app/globals.css`, various components
+  - Rationale: Keyboard users need clear visual indication of where focus is. The current ring at 50% opacity is easy to miss.
+
+- [ ] **6.3 Add `aria-live` regions for dynamic content updates.** When filter results change on the home page or agencies page, announce the new count to screen readers using `aria-live="polite"`. The "Showing X of Y policies" text should be in a live region.
+  - Files: `src/app/page.tsx`, `src/app/agencies/page.tsx`
+  - Rationale: Screen reader users cannot perceive visual count changes without ARIA live regions.
+
+---
+
+## Verification Criteria
+
+- All pages render correctly and are fully usable on viewport widths of 375px (mobile), 768px (tablet), and 1280px+ (desktop)
+- No broken links exist in the navigation or footer
+- All hidden feature pages (Framework, Network, Timeline) are discoverable from the main navigation
+- `STATUS_COLORS` and similar shared constants are defined in exactly one location and imported everywhere
+- Dark mode is functional with no hardcoded color values causing contrast issues
+- All interactive elements have visible focus indicators that meet WCAG 2.1 AA contrast requirements
+- Filter state on the home page persists across browser back/forward navigation via URL parameters
+- Search inputs are debounced and do not cause visible jank during rapid typing
+- The `BackToTop` component appears on all scrollable pages after scrolling 300px
+- Empty states display consistently across all list/table views
+
+---
+
+## Potential Risks and Mitigations
+
+1. **Dark mode and hardcoded colors**
+   Mitigation: The Australia map SVG (`AustraliaMap.tsx:93-110`) uses hardcoded hex values for fills (`#e8e5e0`, `#c7d2e0`, etc.). These will need conditional logic or CSS variable mapping. Plan a dedicated SVG theming pass before enabling the dark mode toggle.
+
+2. **Network page restyling scope**
+   Mitigation: At 966 lines, the network page is the largest component. Rather than a full rewrite, focus the visual harmonization on surface-level elements (card styles, stat boxes, sidebar layout) without restructuring the React Flow logic.
+
+3. **URL-synced filters and SSR compatibility**
+   Mitigation: `useSearchParams()` in Next.js App Router requires `Suspense` boundaries for streaming SSR. Wrap the home page content in a `<Suspense>` boundary with the skeleton loader as fallback.
+
+4. **Performance impact of adding animations**
+   Mitigation: All animations should use `transform` and `opacity` only (GPU-composited properties). Respect `prefers-reduced-motion` universally. Page transitions should be CSS-only, not JS-driven.
+
+5. **Scope creep from adding dark mode**
+   Mitigation: Dark mode (Phase 3.3) is the highest-effort single item. It can be deferred to a later iteration without blocking the other improvements. All other phases are independent.
+
+---
+
+## Alternative Approaches
+
+1. **Navigation expansion vs. dedicated landing page**: Instead of adding hidden pages to the nav dropdown (2.1), an alternative is creating a dedicated "Explore" or "Dashboard" landing page that showcases all available views with preview cards and descriptions. Trade-off: Higher development effort but better discoverability.
+
+2. **Bottom sheet vs. full-page overlay for mobile map**: Instead of a bottom sheet (1.1), the mobile map could navigate to a separate `/map/[jurisdiction]` page when a state is tapped. Trade-off: Simpler implementation but loses the smooth side-panel experience and adds route transitions.
+
+3. **Server-side filtering vs. client-side filtering**: The current approach loads all policies client-side and filters in memory. An alternative is moving to API-based server-side filtering with `searchParams`. Trade-off: Better for large datasets but adds API complexity and requires Supabase to be configured for best results.
+
+4. **CSS-only dark mode vs. `next-themes`**: A `prefers-color-scheme` media query approach requires zero JS but doesn't allow manual toggle. Using `next-themes` adds a dependency but gives user control. Recommended: `next-themes` for explicit toggle support.
+
+---
+
+## Implementation Priority Order
+
+| Order | Phase | Effort | Impact |
+|-------|-------|--------|--------|
+| 1st | Phase 1 (Mobile fixes) | Medium | Critical |
+| 2nd | Phase 2 (Navigation & discoverability) | Low-Medium | High |
+| 3rd | Phase 3.1 (Design tokens) | Low | Medium |
+| 4th | Phase 4 (Polish & micro-interactions) | Medium | Medium |
+| 5th | Phase 6 (Accessibility) | Medium | High |
+| 6th | Phase 5 (Data presentation) | Medium | Medium |
+| 7th | Phase 3.2 (Network harmonization) | Medium | Low-Medium |
+| 8th | Phase 3.3 (Dark mode) | High | Medium |

--- a/src/app/agencies/page.tsx
+++ b/src/app/agencies/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Search } from 'lucide-react';
 import {
   Select,
@@ -9,23 +9,32 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-
-import commonwealthAgenciesData from '@/../public/data/commonwealth-agencies.json';
+import type { Agency } from '@/types';
 
 export default function AgenciesPage() {
+  const [agencies, setAgencies] = useState<Agency[]>([]);
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [statementFilter, setStatementFilter] = useState<string>('all');
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  const stats = useMemo(() => {
-    const total = commonwealthAgenciesData.length;
-    const withStatements = commonwealthAgenciesData.filter((a) => a.hasPublishedStatement).length;
-    const withoutStatements = total - withStatements;
-    return { total, withStatements, withoutStatements };
+  useEffect(() => {
+    fetch('/api/agencies?commonwealth=true')
+      .then((res) => res.json())
+      .then((json) => setAgencies(json.data ?? []))
+      .catch((err) => console.error('Failed to load agencies:', err))
+      .finally(() => setLoading(false));
   }, []);
 
+  const stats = useMemo(() => {
+    const total = agencies.length;
+    const withStatements = agencies.filter((a) => a.hasPublishedStatement).length;
+    const withoutStatements = total - withStatements;
+    return { total, withStatements, withoutStatements };
+  }, [agencies]);
+
   const filteredAgencies = useMemo(() => {
-    return commonwealthAgenciesData.filter((agency) => {
+    return agencies.filter((agency) => {
       const matchesSearch =
         search === '' ||
         agency.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -38,12 +47,20 @@ export default function AgenciesPage() {
 
       return matchesSearch && matchesStatement;
     });
-  }, [search, statementFilter]);
+  }, [search, statementFilter, agencies]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="animate-pulse text-muted-foreground">Loading agencies...</div>
+      </div>
+    );
+  }
 
   return (
-    <div className="flex min-h-[calc(100vh-8rem)] max-w-screen-xl mx-auto">
-      {/* Sidebar */}
-      <aside className="w-60 shrink-0 border-r border-border p-6 space-y-6">
+    <div className="flex flex-col md:flex-row min-h-[calc(100vh-8rem)] max-w-screen-xl mx-auto">
+      {/* Sidebar - horizontal on mobile, vertical on desktop */}
+      <aside className="w-full md:w-60 shrink-0 md:border-r border-b md:border-b-0 border-border p-4 md:p-6 space-y-4 md:space-y-6">
         <div className="relative">
           <Search className="absolute left-0 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <input

--- a/src/app/api/agencies/route.ts
+++ b/src/app/api/agencies/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getAgencies, getCommonwealthAgencies } from '@/lib/data-service';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const level = searchParams.get('level') || undefined;
+  const jurisdiction = searchParams.get('jurisdiction') || undefined;
+  const commonwealth = searchParams.get('commonwealth');
+
+  if (commonwealth === 'true') {
+    const agencies = await getCommonwealthAgencies();
+    return NextResponse.json({ data: agencies, total: agencies.length, success: true });
+  }
+
+  const agencies = await getAgencies({ level, jurisdiction });
+  return NextResponse.json({ data: agencies, total: agencies.length, success: true });
+}

--- a/src/app/api/cron/scrape/route.ts
+++ b/src/app/api/cron/scrape/route.ts
@@ -199,7 +199,15 @@ export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');
   const cronSecret = process.env.CRON_SECRET;
 
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+  if (!cronSecret) {
+    console.error('[cron] CRON_SECRET is not configured');
+    return NextResponse.json(
+      { error: 'CRON_SECRET not configured', success: false },
+      { status: 500 },
+    );
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/cron/scrape/route.ts
+++ b/src/app/api/cron/scrape/route.ts
@@ -1,0 +1,247 @@
+/**
+ * Vercel Cron endpoint — scrapes all enabled government sources.
+ *
+ * Triggered by Vercel Cron Jobs on schedule (see vercel.json).
+ * Protected by CRON_SECRET so only Vercel infrastructure can invoke it.
+ *
+ * The scraper logic runs inline — no HTTP calls to localhost required.
+ */
+
+import { NextResponse } from 'next/server';
+import * as cheerio from 'cheerio';
+import { analyseContentRelevance, summarizePolicy } from '@/lib/claude';
+import { cleanHtmlContent } from '@/lib/utils';
+import { DATA_SOURCES, type DataSource } from '@/lib/data-sources';
+import { createPolicy, policyExists } from '@/lib/data-service';
+import type { Policy } from '@/types';
+
+// Allow long-running (Vercel Cron timeout is 60s on Hobby, 300s on Pro)
+export const maxDuration = 300;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ScrapedLink {
+  url: string;
+  title: string;
+  text: string;
+}
+
+async function scrapeLinks(sourceUrl: string): Promise<ScrapedLink[]> {
+  try {
+    const response = await fetch(sourceUrl, {
+      headers: { 'User-Agent': 'Policai/1.0 (Australian AI Policy Tracker)' },
+    });
+    if (!response.ok) return [];
+
+    const html = await response.text();
+    const $ = cheerio.load(html);
+    const links: ScrapedLink[] = [];
+
+    $('a').each((_, element) => {
+      const href = $(element).attr('href');
+      const text = $(element).text().trim();
+      if (!href || !text) return;
+
+      let absoluteUrl = href;
+      if (href.startsWith('/')) {
+        const baseUrl = new URL(sourceUrl);
+        absoluteUrl = `${baseUrl.origin}${href}`;
+      } else if (!href.startsWith('http')) {
+        return;
+      }
+
+      const isLikelyPolicy =
+        href.includes('pdf') ||
+        href.includes('policy') ||
+        href.includes('guidance') ||
+        href.includes('framework') ||
+        href.includes('strategy') ||
+        href.includes('standard') ||
+        href.includes('regulation') ||
+        text.toLowerCase().includes('policy') ||
+        text.toLowerCase().includes('framework') ||
+        text.toLowerCase().includes('guidance') ||
+        text.toLowerCase().includes('standard');
+
+      if (isLikelyPolicy) {
+        links.push({
+          url: absoluteUrl,
+          title: text,
+          text: $(element).parent().text().trim().slice(0, 500),
+        });
+      }
+    });
+
+    return links.slice(0, 10);
+  } catch (error) {
+    console.error(`[cron] Error scraping ${sourceUrl}:`, error);
+    return [];
+  }
+}
+
+async function fetchContent(url: string): Promise<string> {
+  const response = await fetch(url, {
+    headers: { 'User-Agent': 'Policai/1.0 (Australian AI Policy Tracker)' },
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  return cleanHtmlContent(await response.text());
+}
+
+/** Build and persist a new policy from analysed content. */
+async function processHighConfidenceLink(
+  title: string,
+  url: string,
+  analysis: {
+    summary?: string;
+    jurisdiction?: string;
+    policyType?: string;
+    tags?: string[];
+    agencies?: string[];
+  },
+  content: string,
+): Promise<boolean> {
+  const id = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 50);
+
+  if (await policyExists(id)) {
+    console.log(`[cron] Policy already exists: ${id}`);
+    return false;
+  }
+
+  // Optionally generate a richer AI summary
+  let aiSummary = analysis.summary || '';
+  if (process.env.ANTHROPIC_API_KEY) {
+    try {
+      const summaryResult = await summarizePolicy(title, content);
+      if (summaryResult.summary && summaryResult.summary !== 'Unable to generate summary') {
+        aiSummary = summaryResult.summary;
+      }
+    } catch {
+      // Use the analysis summary as fallback
+    }
+  }
+
+  const now = new Date().toISOString();
+  const newPolicy: Policy = {
+    id,
+    title,
+    description: analysis.summary || '',
+    jurisdiction: (analysis.jurisdiction as Policy['jurisdiction']) || 'federal',
+    type: (analysis.policyType as Policy['type']) || 'guideline',
+    status: 'active',
+    effectiveDate: now.split('T')[0],
+    agencies: analysis.agencies || [],
+    sourceUrl: url,
+    content: content.slice(0, 10000),
+    aiSummary,
+    tags: analysis.tags || [],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await createPolicy(newPolicy);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Scrape a single source
+// ---------------------------------------------------------------------------
+
+async function scrapeSource(source: DataSource) {
+  console.log(`[cron] Scraping: ${source.name} (${source.url})`);
+
+  const links = await scrapeLinks(source.url);
+  console.log(`[cron]   Found ${links.length} potential policy links`);
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const link of links) {
+    try {
+      const content = await fetchContent(link.url);
+      const analysis = await analyseContentRelevance(content, link.url);
+
+      if (analysis.relevanceScore >= 0.8 && analysis.isRelevant) {
+        const wasCreated = await processHighConfidenceLink(
+          link.title,
+          link.url,
+          analysis,
+          content,
+        );
+        if (wasCreated) created++;
+        else skipped++;
+      } else {
+        skipped++;
+      }
+
+      // Rate limit between pages
+      await new Promise((r) => setTimeout(r, 2000));
+    } catch (err) {
+      console.error(`[cron] Error processing ${link.url}:`, err);
+      skipped++;
+    }
+  }
+
+  return { source: source.name, linksFound: links.length, created, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function GET(request: Request) {
+  // Verify the request is from Vercel Cron
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: 'ANTHROPIC_API_KEY not configured', success: false },
+      { status: 500 },
+    );
+  }
+
+  console.log(`[cron] Starting scheduled scrape at ${new Date().toISOString()}`);
+
+  const results = [];
+  const enabledSources = DATA_SOURCES.filter((s) => s.enabled);
+
+  for (const source of enabledSources) {
+    try {
+      const result = await scrapeSource(source);
+      results.push(result);
+    } catch (err) {
+      console.error(`[cron] Failed to scrape ${source.name}:`, err);
+      results.push({
+        source: source.name,
+        linksFound: 0,
+        created: 0,
+        skipped: 0,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      });
+    }
+
+    // Rate limit between sources
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+
+  const totalCreated = results.reduce((sum, r) => sum + r.created, 0);
+  console.log(`[cron] Completed. Created ${totalCreated} new policies from ${enabledSources.length} sources.`);
+
+  return NextResponse.json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    sourcesScanned: enabledSources.length,
+    totalCreated,
+    results,
+  });
+}

--- a/src/app/api/policies/[id]/route.ts
+++ b/src/app/api/policies/[id]/route.ts
@@ -1,21 +1,5 @@
 import { NextResponse } from 'next/server';
-import path from 'path';
-import { readJsonFile, writeJsonFile } from '@/lib/file-store';
-import type { Policy } from '@/types';
-
-interface PolicyWithTrash extends Policy {
-  trashedAt?: string;
-}
-
-const POLICIES_FILE_PATH = path.join(process.cwd(), 'public', 'data', 'sample-policies.json');
-
-async function readPolicies(): Promise<PolicyWithTrash[]> {
-  return readJsonFile<PolicyWithTrash[]>(POLICIES_FILE_PATH, []);
-}
-
-async function writePolicies(policies: PolicyWithTrash[]): Promise<void> {
-  return writeJsonFile(POLICIES_FILE_PATH, policies);
-}
+import { getPolicyById, updatePolicy, deletePolicy } from '@/lib/data-service';
 
 // GET - Retrieve a single policy by ID
 export async function GET(
@@ -24,8 +8,7 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const policies = await readPolicies();
-    const policy = policies.find(p => p.id === id);
+    const policy = await getPolicyById(id);
 
     if (!policy) {
       return NextResponse.json(
@@ -55,36 +38,18 @@ export async function PATCH(
   try {
     const { id } = await params;
     const body = await request.json();
-    const policies = await readPolicies();
-    const policyIndex = policies.findIndex(p => p.id === id);
 
-    if (policyIndex === -1) {
+    const updated = await updatePolicy(id, body);
+
+    if (!updated) {
       return NextResponse.json(
         { error: 'Policy not found', success: false },
         { status: 404 }
       );
     }
 
-    const now = new Date().toISOString();
-
-    // Handle status changes specially
-    if (body.status === 'trashed' && policies[policyIndex].status !== 'trashed') {
-      policies[policyIndex].trashedAt = now;
-    } else if (body.status && body.status !== 'trashed' && policies[policyIndex].status === 'trashed') {
-      delete policies[policyIndex].trashedAt;
-    }
-
-    // Update the policy
-    policies[policyIndex] = {
-      ...policies[policyIndex],
-      ...body,
-      updatedAt: now,
-    };
-
-    await writePolicies(policies);
-
     return NextResponse.json({
-      data: policies[policyIndex],
+      data: updated,
       success: true,
     });
   } catch (error) {
@@ -103,18 +68,14 @@ export async function DELETE(
 ) {
   try {
     const { id } = await params;
-    const policies = await readPolicies();
-    const policyIndex = policies.findIndex(p => p.id === id);
+    const deleted = await deletePolicy(id);
 
-    if (policyIndex === -1) {
+    if (!deleted) {
       return NextResponse.json(
         { error: 'Policy not found', success: false },
         { status: 404 }
       );
     }
-
-    policies.splice(policyIndex, 1);
-    await writePolicies(policies);
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -1,49 +1,16 @@
 import { NextResponse } from 'next/server';
-import path from 'path';
 import { summarizePolicy } from '@/lib/claude';
-import { readJsonFile, writeJsonFile } from '@/lib/file-store';
+import { getPolicies, createPolicy } from '@/lib/data-service';
 import type { Policy } from '@/types';
-
-const POLICIES_FILE_PATH = path.join(process.cwd(), 'public', 'data', 'sample-policies.json');
-
-async function readPolicies(): Promise<Policy[]> {
-  return readJsonFile<Policy[]>(POLICIES_FILE_PATH, []);
-}
-
-async function writePolicies(policies: Policy[]): Promise<void> {
-  return writeJsonFile(POLICIES_FILE_PATH, policies);
-}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const jurisdiction = searchParams.get('jurisdiction');
-  const type = searchParams.get('type');
-  const status = searchParams.get('status');
-  const search = searchParams.get('search');
+  const jurisdiction = searchParams.get('jurisdiction') || undefined;
+  const type = searchParams.get('type') || undefined;
+  const status = searchParams.get('status') || undefined;
+  const search = searchParams.get('search') || undefined;
 
-  let filteredPolicies = await readPolicies();
-
-  if (jurisdiction) {
-    filteredPolicies = filteredPolicies.filter((p) => p.jurisdiction === jurisdiction);
-  }
-
-  if (type) {
-    filteredPolicies = filteredPolicies.filter((p) => p.type === type);
-  }
-
-  if (status) {
-    filteredPolicies = filteredPolicies.filter((p) => p.status === status);
-  }
-
-  if (search) {
-    const searchLower = search.toLowerCase();
-    filteredPolicies = filteredPolicies.filter(
-      (p) =>
-        p.title.toLowerCase().includes(searchLower) ||
-        p.description.toLowerCase().includes(searchLower) ||
-        p.tags.some((tag: string) => tag.toLowerCase().includes(searchLower))
-    );
-  }
+  const filteredPolicies = await getPolicies({ jurisdiction, type, status, search });
 
   return NextResponse.json({
     data: filteredPolicies,
@@ -64,23 +31,12 @@ export async function POST(request: Request) {
       );
     }
 
-    const policies = await readPolicies();
-
     // Generate ID from title
     const id = title
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/(^-|-$)/g, '')
       .slice(0, 50);
-
-    // Check if ID already exists
-    const existingIndex = policies.findIndex(p => p.id === id);
-    if (existingIndex !== -1) {
-      return NextResponse.json(
-        { error: 'A policy with a similar title already exists', success: false },
-        { status: 400 }
-      );
-    }
 
     // Generate AI summary if requested and API key is available
     let generatedSummary = aiSummary || '';
@@ -101,7 +57,6 @@ export async function POST(request: Request) {
         }
       } catch (summaryError) {
         console.error('Failed to generate AI summary:', summaryError);
-        // Continue without AI summary if it fails
       }
     }
 
@@ -123,11 +78,10 @@ export async function POST(request: Request) {
       updatedAt: now,
     };
 
-    policies.unshift(newPolicy);
-    await writePolicies(policies);
+    const created = await createPolicy(newPolicy);
 
     return NextResponse.json({
-      data: newPolicy,
+      data: created,
       success: true,
     });
   } catch (error) {

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { summarizePolicy } from '@/lib/claude';
-import { getPolicies, createPolicy } from '@/lib/data-service';
+import { DuplicatePolicyError, getPolicies, createPolicy } from '@/lib/data-service';
 import type { Policy } from '@/types';
 
 export async function GET(request: Request) {
@@ -85,6 +85,13 @@ export async function POST(request: Request) {
       success: true,
     });
   } catch (error) {
+    if (error instanceof DuplicatePolicyError) {
+      return NextResponse.json(
+        { error: 'A policy with this title already exists', success: false },
+        { status: 409 }
+      );
+    }
+
     console.error('Error adding policy:', error);
     return NextResponse.json(
       { error: 'Failed to add policy', success: false },

--- a/src/app/api/timeline/route.ts
+++ b/src/app/api/timeline/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getTimelineEvents } from '@/lib/data-service';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const jurisdiction = searchParams.get('jurisdiction') || undefined;
+
+  const events = await getTimelineEvents({ jurisdiction });
+  return NextResponse.json({ data: events, total: events.length, success: true });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,3 +87,18 @@
     @apply bg-background text-foreground font-sans;
   }
 }
+
+/* Utility: explicit focus ring for custom interactive elements */
+.focus-ring {
+  @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { IBM_Plex_Sans, IBM_Plex_Mono } from 'next/font/google';
 import './globals.css';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+import { BackToTop } from '@/components/ui/back-to-top';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { AuthProvider } from '@/contexts/AuthContext';
 
@@ -42,11 +43,15 @@ export default function RootLayout({
   return (
     <html lang="en-AU">
       <body className={`${plexSans.variable} ${plexMono.variable} antialiased min-h-screen flex flex-col`}>
+        <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:text-sm focus:font-medium">
+          Skip to content
+        </a>
         <AuthProvider>
           <TooltipProvider>
             <Header />
-            <main className="flex-1">{children}</main>
+            <main id="main-content" className="flex-1">{children}</main>
             <Footer />
+            <BackToTop />
           </TooltipProvider>
         </AuthProvider>
       </body>

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -10,32 +10,34 @@ import {
   type Jurisdiction,
   type PolicyStatus,
   type PolicyType,
+  type Policy,
 } from '@/types';
 
-import policiesData from '@/../public/data/sample-policies.json';
-import agenciesData from '@/../public/data/sample-agencies.json';
-
-const STATUS_COLORS: Record<string, string> = {
-  active: 'text-green-700',
-  proposed: 'text-amber-600',
-  amended: 'text-blue-700',
-  repealed: 'text-gray-500',
-};
+import { STATUS_COLORS } from '@/lib/design-tokens';
 
 export default function MapPage() {
+  const [policiesData, setPoliciesData] = useState<Policy[]>([]);
+  const [loading, setLoading] = useState(true);
   const [selectedJurisdiction, setSelectedJurisdiction] = useState<Jurisdiction | null>(null);
-  const [hoveredJurisdiction, setHoveredJurisdiction] = useState<Jurisdiction | null>(null);
+  const [, setHoveredJurisdiction] = useState<Jurisdiction | null>(null);
   const [panelVisible, setPanelVisible] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Animate panel in/out when selection changes
+  // Load data
+  useEffect(() => {
+    fetch('/api/policies')
+      .then((res) => res.json())
+      .then((json) => setPoliciesData(json.data ?? []))
+      .catch((err) => console.error('Failed to load map data:', err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  // Animate panel in when selection changes
   useEffect(() => {
     if (selectedJurisdiction) {
       // Small delay for the spring-in effect
       requestAnimationFrame(() => setPanelVisible(true));
-    } else {
-      setPanelVisible(false);
     }
   }, [selectedJurisdiction]);
 
@@ -61,12 +63,12 @@ export default function MapPage() {
     });
 
     return data;
-  }, []);
+  }, [policiesData]);
 
   const selectedPolicies = useMemo(() => {
     if (!selectedJurisdiction) return [];
     return policiesData.filter((p) => p.jurisdiction === selectedJurisdiction && p.status !== 'trashed');
-  }, [selectedJurisdiction]);
+  }, [selectedJurisdiction, policiesData]);
 
   const handleJurisdictionClick = (j: Jurisdiction) => {
     // Clear any pending close timer so a stale timeout can't clear a new selection
@@ -87,6 +89,14 @@ export default function MapPage() {
     }
   };
 
+  if (loading) {
+    return (
+      <div className="h-[calc(100vh-4rem)] flex items-center justify-center">
+        <div className="animate-pulse text-muted-foreground">Loading map data...</div>
+      </div>
+    );
+  }
+
   return (
     <div className="h-[calc(100vh-4rem)] flex overflow-hidden relative">
       {/* Map area — takes full width, panel overlays */}
@@ -102,14 +112,18 @@ export default function MapPage() {
       {/* Sliding policy panel */}
       <div
         ref={panelRef}
-        className="absolute top-0 right-0 h-[calc(100vh-4rem)] w-[340px] border-l border-border bg-background z-10 flex flex-col overflow-hidden"
-        style={{
-          transform: panelVisible ? 'translateX(0)' : 'translateX(100%)',
-          transition: 'transform 0.35s cubic-bezier(0.16, 1, 0.3, 1)',
-        }}
+        className={`absolute md:top-0 md:right-0 md:h-[calc(100vh-4rem)] md:w-[340px] md:border-l bottom-0 left-0 right-0 max-h-[60vh] md:max-h-none border-t md:border-t-0 border-border bg-background z-10 flex flex-col overflow-hidden rounded-t-xl md:rounded-none transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] ${
+          panelVisible
+            ? 'translate-y-0 md:translate-y-0 md:translate-x-0'
+            : 'translate-y-full md:translate-y-0 md:translate-x-full'
+        }`}
       >
         {selectedJurisdiction && (
           <>
+            {/* Mobile drag handle */}
+            <div className="md:hidden flex justify-center py-2 flex-shrink-0">
+              <div className="w-10 h-1 rounded-full bg-border" />
+            </div>
             {/* Panel header */}
             <div className="p-5 border-b border-border flex-shrink-0">
               <div className="flex items-center justify-between mb-1">
@@ -189,9 +203,12 @@ export default function MapPage() {
       </div>
 
       {/* Bottom summary bar */}
-      <div className="absolute bottom-0 left-0 border-t border-border bg-background/90 backdrop-blur-sm px-5 py-2 z-5" style={{ right: panelVisible ? '340px' : '0', transition: 'right 0.35s cubic-bezier(0.16, 1, 0.3, 1)' }}>
-        <div className="font-mono text-xs text-muted-foreground">
+      <div className="absolute bottom-0 left-0 right-0 md:right-auto border-t border-border bg-background/90 backdrop-blur-sm px-5 py-2 z-5" style={{ ...(panelVisible ? { right: undefined } : {}), transition: 'right 0.35s cubic-bezier(0.16, 1, 0.3, 1)' }}>
+        <div className="font-mono text-xs text-muted-foreground" aria-live="polite">
           {policiesData.filter(p => p.status !== 'trashed').length} policies across {Object.keys(jurisdictionData).length} jurisdictions
+          {selectedJurisdiction && (
+            <span> &middot; Viewing {JURISDICTION_NAMES[selectedJurisdiction]}</span>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/network/page.tsx
+++ b/src/app/network/page.tsx
@@ -15,7 +15,7 @@ import {
   BackgroundVariant,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -46,9 +46,6 @@ import {
   Network,
   GitBranch,
   BarChart3,
-  ZoomIn,
-  ZoomOut,
-  Maximize2,
 } from 'lucide-react';
 import {
   JURISDICTION_NAMES,
@@ -57,10 +54,9 @@ import {
   type Jurisdiction,
   type PolicyType,
   type PolicyStatus,
+  type Policy,
+  type Agency,
 } from '@/types';
-
-import policiesData from '@/../public/data/sample-policies.json';
-import agenciesData from '@/../public/data/sample-agencies.json';
 
 type NodeType = 'policy' | 'agency' | 'jurisdiction';
 
@@ -69,35 +65,17 @@ interface NodeData extends Record<string, unknown> {
   type: NodeType;
   status?: string;
   policyType?: string;
-  originalData: (typeof policiesData)[0] | (typeof agenciesData)[0] | { jurisdiction: Jurisdiction };
+  originalData: Policy | Agency | { jurisdiction: Jurisdiction };
 }
-
-// Node color configurations - CSS custom properties for theme awareness
-const NODE_COLORS = {
-  jurisdiction: {
-    bg: 'hsl(var(--chart-1))',
-    border: 'hsl(var(--chart-1))',
-    text: 'white',
-  },
-  agency: {
-    bg: 'hsl(var(--chart-4))',
-    border: 'hsl(var(--chart-4))',
-    text: 'hsl(var(--foreground))',
-  },
-  policy: {
-    active: { bg: '#22c55e', border: '#16a34a' },
-    proposed: { bg: '#f59e0b', border: '#d97706' },
-    amended: { bg: '#3b82f6', border: '#2563eb' },
-    repealed: { bg: '#6b7280', border: '#4b5563' },
-  },
-};
 
 // Improved layout algorithm with hierarchical positioning grouped by jurisdiction
 function generateGraphData(
   filterJurisdiction: string,
   filterStatus: string,
   filterType: string,
-  searchQuery: string
+  searchQuery: string,
+  policiesData: Policy[],
+  agenciesData: Agency[],
 ) {
   const nodes: Node<NodeData>[] = [];
   const edges: Edge[] = [];
@@ -318,7 +296,8 @@ function calculateStats(
   filterJurisdiction: string,
   filterStatus: string,
   filterType: string,
-  searchQuery: string
+  searchQuery: string,
+  policiesData: Policy[],
 ) {
   const filteredPolicies = policiesData.filter((p) => {
     const matchesJurisdiction = filterJurisdiction === 'all' || p.jurisdiction === filterJurisdiction;
@@ -344,6 +323,9 @@ function calculateStats(
 }
 
 export default function NetworkPage() {
+  const [policiesData, setPoliciesData] = useState<Policy[]>([]);
+  const [agenciesData, setAgenciesData] = useState<Agency[]>([]);
+  const [dataLoading, setDataLoading] = useState(true);
   const [filterJurisdiction, setFilterJurisdiction] = useState<string>('all');
   const [filterStatus, setFilterStatus] = useState<string>('all');
   const [filterType, setFilterType] = useState<string>('all');
@@ -351,16 +333,29 @@ export default function NetworkPage() {
   const [selectedNode, setSelectedNode] = useState<Node<NodeData> | null>(null);
   const [hoveredNode, setHoveredNode] = useState<string | null>(null);
 
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/policies').then((r) => r.json()),
+      fetch('/api/agencies').then((r) => r.json()),
+    ])
+      .then(([policiesJson, agenciesJson]) => {
+        setPoliciesData(policiesJson.data ?? []);
+        setAgenciesData(agenciesJson.data ?? []);
+      })
+      .catch((err) => console.error('Failed to load network data:', err))
+      .finally(() => setDataLoading(false));
+  }, []);
+
   // Generate graph data based on filters
   const { nodes: graphNodes, edges: graphEdges } = useMemo(
-    () => generateGraphData(filterJurisdiction, filterStatus, filterType, searchQuery),
-    [filterJurisdiction, filterStatus, filterType, searchQuery]
+    () => generateGraphData(filterJurisdiction, filterStatus, filterType, searchQuery, policiesData, agenciesData),
+    [filterJurisdiction, filterStatus, filterType, searchQuery, policiesData, agenciesData]
   );
 
   // Calculate statistics
   const stats = useMemo(
-    () => calculateStats(filterJurisdiction, filterStatus, filterType, searchQuery),
-    [filterJurisdiction, filterStatus, filterType, searchQuery]
+    () => calculateStats(filterJurisdiction, filterStatus, filterType, searchQuery, policiesData),
+    [filterJurisdiction, filterStatus, filterType, searchQuery, policiesData]
   );
 
   const [nodes, setNodes, onNodesChange] = useNodesState(graphNodes);
@@ -450,6 +445,16 @@ export default function NetworkPage() {
         return '#6b7280';
     }
   };
+
+  if (dataLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <div className="animate-pulse text-muted-foreground">Loading network data...</div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -762,63 +767,63 @@ export default function NetworkPage() {
               <ScrollArea className="max-h-[400px] mt-4">
                 <div className="space-y-4">
                   <h3 className="font-semibold">
-                    {(selectedNode.data.originalData as (typeof policiesData)[0]).title}
+                    {(selectedNode.data.originalData as Policy).title}
                   </h3>
                   <div className="flex flex-wrap gap-2">
                     <Badge
                       variant={
-                        (selectedNode.data.originalData as (typeof policiesData)[0]).status === 'active'
+                        (selectedNode.data.originalData as Policy).status === 'active'
                           ? 'default'
                           : 'secondary'
                       }
                       className={
-                        (selectedNode.data.originalData as (typeof policiesData)[0]).status === 'active'
+                        (selectedNode.data.originalData as Policy).status === 'active'
                           ? 'bg-green-500 hover:bg-green-600'
                           : ''
                       }
                     >
                       {
                         POLICY_STATUS_NAMES[
-                          (selectedNode.data.originalData as (typeof policiesData)[0]).status as PolicyStatus
+                          (selectedNode.data.originalData as Policy).status as PolicyStatus
                         ]
                       }
                     </Badge>
                     <Badge variant="outline">
                       {
                         POLICY_TYPE_NAMES[
-                          (selectedNode.data.originalData as (typeof policiesData)[0]).type as PolicyType
+                          (selectedNode.data.originalData as Policy).type as PolicyType
                         ]
                       }
                     </Badge>
                     <Badge variant="secondary">
                       {
                         JURISDICTION_NAMES[
-                          (selectedNode.data.originalData as (typeof policiesData)[0]).jurisdiction as Jurisdiction
+                          (selectedNode.data.originalData as Policy).jurisdiction as Jurisdiction
                         ]
                       }
                     </Badge>
                   </div>
                   <p className="text-sm text-muted-foreground">
-                    {(selectedNode.data.originalData as (typeof policiesData)[0]).description}
+                    {(selectedNode.data.originalData as Policy).description}
                   </p>
-                  {(selectedNode.data.originalData as (typeof policiesData)[0]).aiSummary && (
+                  {(selectedNode.data.originalData as Policy).aiSummary && (
                     <div className="p-4 bg-muted rounded-lg">
                       <h4 className="text-sm font-medium mb-2">AI Summary</h4>
                       <p className="text-sm text-muted-foreground">
-                        {(selectedNode.data.originalData as (typeof policiesData)[0]).aiSummary}
+                        {(selectedNode.data.originalData as Policy).aiSummary}
                       </p>
                     </div>
                   )}
                   <div className="flex flex-wrap gap-2">
-                    {(selectedNode.data.originalData as (typeof policiesData)[0]).tags?.map((tag) => (
+                    {(selectedNode.data.originalData as Policy).tags?.map((tag) => (
                       <Badge key={tag} variant="outline" className="text-xs">
                         {tag}
                       </Badge>
                     ))}
                   </div>
-                  {(selectedNode.data.originalData as (typeof policiesData)[0]).sourceUrl && (
+                  {(selectedNode.data.originalData as Policy).sourceUrl && (
                     <a
-                      href={(selectedNode.data.originalData as (typeof policiesData)[0]).sourceUrl}
+                      href={(selectedNode.data.originalData as Policy).sourceUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-sm text-primary hover:underline inline-flex items-center gap-1"
@@ -847,41 +852,41 @@ export default function NetworkPage() {
               </DialogHeader>
               <div className="space-y-4 mt-4">
                 <h3 className="font-semibold">
-                  {(selectedNode.data.originalData as (typeof agenciesData)[0]).name}
+                  {(selectedNode.data.originalData as Agency).name}
                 </h3>
                 <div className="flex flex-wrap gap-2">
                   <Badge variant="default">
-                    {(selectedNode.data.originalData as (typeof agenciesData)[0]).acronym}
+                    {(selectedNode.data.originalData as Agency).acronym}
                   </Badge>
                   <Badge variant="outline">
-                    {(selectedNode.data.originalData as (typeof agenciesData)[0]).level}
+                    {(selectedNode.data.originalData as Agency).level}
                   </Badge>
                   <Badge variant="secondary">
                     {
                       JURISDICTION_NAMES[
-                        (selectedNode.data.originalData as (typeof agenciesData)[0]).jurisdiction as Jurisdiction
+                        (selectedNode.data.originalData as Agency).jurisdiction as Jurisdiction
                       ]
                     }
                   </Badge>
                 </div>
-                {(selectedNode.data.originalData as (typeof agenciesData)[0]).aiTransparencyStatement && (
+                {(selectedNode.data.originalData as Agency).aiTransparencyStatement && (
                   <div className="p-4 bg-muted rounded-lg">
                     <h4 className="text-sm font-medium mb-2">AI Transparency Statement</h4>
                     <p className="text-sm text-muted-foreground">
-                      {(selectedNode.data.originalData as (typeof agenciesData)[0]).aiTransparencyStatement}
+                      {(selectedNode.data.originalData as Agency).aiTransparencyStatement}
                     </p>
                   </div>
                 )}
-                {(selectedNode.data.originalData as (typeof agenciesData)[0]).aiUsageDisclosure && (
+                {(selectedNode.data.originalData as Agency).aiUsageDisclosure && (
                   <div className="p-4 bg-blue-500/10 rounded-lg border border-blue-500/20">
                     <h4 className="text-sm font-medium mb-2">AI Usage Disclosure</h4>
                     <p className="text-sm text-muted-foreground">
-                      {(selectedNode.data.originalData as (typeof agenciesData)[0]).aiUsageDisclosure}
+                      {(selectedNode.data.originalData as Agency).aiUsageDisclosure}
                     </p>
                   </div>
                 )}
                 <a
-                  href={(selectedNode.data.originalData as (typeof agenciesData)[0]).website}
+                  href={(selectedNode.data.originalData as Agency).website}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-primary hover:underline inline-flex items-center gap-1"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { Search } from 'lucide-react';
 import { FilterSidebar } from '@/components/filter-sidebar';
 import { PolicyTable } from '@/components/policy-table';
@@ -8,15 +8,25 @@ import {
   JURISDICTION_NAMES,
   POLICY_TYPE_NAMES,
   POLICY_STATUS_NAMES,
+  type Policy,
 } from '@/types';
 
-import policiesData from '@/../public/data/sample-policies.json';
-
 export default function HomePage() {
+  const [policiesData, setPoliciesData] = useState<Policy[]>([]);
+  const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
   const [jurisdictionFilter, setJurisdictionFilter] = useState('all');
   const [typeFilter, setTypeFilter] = useState('all');
   const [statusFilter, setStatusFilter] = useState('all');
+
+  useEffect(() => {
+    fetch('/api/policies')
+      .then((res) => res.json())
+      .then((json) => setPoliciesData(json.data ?? []))
+      .catch((err) => console.error('Failed to load policies:', err))
+      .finally(() => setLoading(false));
+  }, []);
 
   const hasActiveFilters = jurisdictionFilter !== 'all' || typeFilter !== 'all' || statusFilter !== 'all';
 
@@ -40,7 +50,7 @@ export default function HomePage() {
         const matchesStatus = statusFilter === 'all' || p.status === statusFilter;
         return matchesSearch && matchesJurisdiction && matchesType && matchesStatus;
       });
-  }, [search, jurisdictionFilter, typeFilter, statusFilter]);
+  }, [policiesData, search, jurisdictionFilter, typeFilter, statusFilter]);
 
   const allPolicies = policiesData.filter((p) => p.status !== 'trashed');
   const jurisdictions = new Set(allPolicies.map((p) => p.jurisdiction));
@@ -85,6 +95,16 @@ export default function HomePage() {
     { label: 'jurisdictions', value: jurisdictions.size },
   ];
 
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-6">
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <div className="animate-pulse text-muted-foreground">Loading policies...</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto px-4 py-6">
       <div className="flex flex-col lg:flex-row gap-8">
@@ -100,16 +120,20 @@ export default function HomePage() {
           <div className="relative mb-5">
             <Search className="absolute left-0 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <input
+              ref={searchRef}
               type="search"
               placeholder="Search policies..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full pl-7 pr-2 py-2 text-sm bg-transparent border-b border-border focus:border-foreground focus:outline-none transition-colors placeholder:text-muted-foreground"
+              className="w-full pl-7 pr-16 py-2 text-sm bg-transparent border-b border-border focus:border-foreground focus:outline-none transition-colors placeholder:text-muted-foreground"
             />
+            <kbd className="absolute right-0 top-1/2 -translate-y-1/2 hidden sm:inline-flex items-center gap-0.5 font-mono text-[10px] text-muted-foreground/60 border border-border rounded px-1.5 py-0.5">
+              <span className="text-xs">&#8984;</span>K
+            </kbd>
           </div>
 
           {/* Count */}
-          <div className="font-mono text-xs text-muted-foreground mb-3">
+          <div className="font-mono text-xs text-muted-foreground mb-3" aria-live="polite">
             Showing {filteredPolicies.length} of {allPolicies.length} policies
           </div>
 

--- a/src/app/policies/[id]/loading.tsx
+++ b/src/app/policies/[id]/loading.tsx
@@ -1,0 +1,48 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function PolicyDetailLoading() {
+  return (
+    <div className="container mx-auto px-4 py-6">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-2 mb-6">
+        <Skeleton className="h-3 w-14" />
+        <Skeleton className="h-3 w-2" />
+        <Skeleton className="h-3 w-48" />
+      </div>
+
+      {/* Title + metadata */}
+      <div className="space-y-4 mb-6">
+        <Skeleton className="h-8 w-3/4" />
+        <div className="flex gap-2">
+          <Skeleton className="h-5 w-20 rounded-full" />
+          <Skeleton className="h-5 w-24 rounded-full" />
+          <Skeleton className="h-5 w-16 rounded-full" />
+        </div>
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-2/3" />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-4 border-b border-border mb-6">
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-20" />
+      </div>
+
+      {/* Content area */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="md:col-span-2 space-y-4">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+        <div className="space-y-4">
+          <Skeleton className="h-32 w-full rounded-lg" />
+          <Skeleton className="h-24 w-full rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/policies/[id]/page.tsx
+++ b/src/app/policies/[id]/page.tsx
@@ -1,19 +1,11 @@
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import path from 'path';
 import { type Policy } from '@/types';
-import { readJsonFile } from '@/lib/file-store';
+import { getPolicyById, getPolicies } from '@/lib/data-service';
 import { PolicyDetailTabs } from './policy-detail-tabs';
 
-const POLICIES_FILE = path.join(process.cwd(), 'public', 'data', 'sample-policies.json');
-
-async function getPolicy(id: string): Promise<Policy | null> {
-  const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
-  return policies.find(p => p.id === id) || null;
-}
-
 async function getRelatedPolicies(currentPolicy: Policy): Promise<Policy[]> {
-  const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
+  const policies = await getPolicies();
   return policies
     .filter(p => p.id !== currentPolicy.id && p.status !== 'trashed')
     .filter(p =>
@@ -23,14 +15,9 @@ async function getRelatedPolicies(currentPolicy: Policy): Promise<Policy[]> {
     .slice(0, 3);
 }
 
-export async function generateStaticParams() {
-  const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
-  return policies.map(policy => ({ id: policy.id }));
-}
-
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const policy = await getPolicy(id);
+  const policy = await getPolicyById(id);
   if (!policy) return { title: 'Policy Not Found — Policai' };
   return {
     title: `${policy.title} — Policai`,
@@ -41,7 +28,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
 
 export default async function PolicyDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
-  const policy = await getPolicy(id);
+  const policy = await getPolicyById(id);
   if (!policy) notFound();
 
   const relatedPolicies = await getRelatedPolicies(policy);

--- a/src/app/policies/[id]/policy-detail-tabs.tsx
+++ b/src/app/policies/[id]/policy-detail-tabs.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, Copy, Check, FileText } from 'lucide-react';
 import {
   JURISDICTION_NAMES,
   POLICY_TYPE_NAMES,
@@ -12,13 +12,8 @@ import {
   type PolicyType,
   type PolicyStatus,
 } from '@/types';
-
-const STATUS_COLORS: Record<string, string> = {
-  active: 'text-green-700',
-  proposed: 'text-amber-600',
-  amended: 'text-blue-700',
-  repealed: 'text-gray-500',
-};
+import { STATUS_COLORS } from '@/lib/design-tokens';
+import { EmptyState } from '@/components/ui/empty-state';
 
 interface PolicyDetailTabsProps {
   policy: Policy;
@@ -125,15 +120,31 @@ export function PolicyDetailTabs({ policy, relatedPolicies }: PolicyDetailTabsPr
       )}
 
       {activeTab === 'content' && (
-        <div className="text-sm leading-relaxed whitespace-pre-wrap max-w-[720px]">
-          {policy.content || 'No detailed content available.'}
+        <div className="max-w-[720px]">
+          {policy.content ? (
+            <div className="relative group">
+              <CopyButton text={policy.content} />
+              <div className="text-sm leading-relaxed whitespace-pre-wrap font-serif">
+                {policy.content}
+              </div>
+            </div>
+          ) : (
+            <EmptyState
+              icon={FileText}
+              title="No content available"
+              description="Detailed policy content has not been added yet."
+            />
+          )}
         </div>
       )}
 
       {activeTab === 'related' && (
         <div>
           {relatedPolicies.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No related policies found.</p>
+            <EmptyState
+              title="No related policies"
+              description="No other policies share the same jurisdiction and tags."
+            />
           ) : (
             <div className="border-t border-border">
               {relatedPolicies.map((rp) => (
@@ -160,5 +171,22 @@ export function PolicyDetailTabs({ policy, relatedPolicies }: PolicyDetailTabsPr
         </div>
       )}
     </div>
+  );
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      onClick={() => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+      className="absolute top-0 right-0 opacity-0 group-hover:opacity-100 transition-opacity p-2 text-muted-foreground hover:text-foreground"
+      aria-label="Copy content"
+    >
+      {copied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
+    </button>
   );
 }

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import Link from 'next/link';
 import { Filter, ArrowRight, Calendar } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -24,44 +24,40 @@ import { Timeline } from '@/components/visualizations/Timeline';
 import {
   JURISDICTION_NAMES,
   POLICY_TYPE_NAMES,
-  type Jurisdiction,
   type PolicyType,
+  type Policy,
+  type TimelineEvent,
 } from '@/types';
 
-import timelineData from '@/../public/data/sample-timeline.json';
-import policiesData from '@/../public/data/sample-policies.json';
-
-type TimelineEventType =
-  | 'policy_introduced'
-  | 'policy_amended'
-  | 'policy_repealed'
-  | 'announcement'
-  | 'milestone';
-
-interface TimelineEvent {
-  id: string;
-  date: string;
-  title: string;
-  description: string;
-  type: TimelineEventType;
-  jurisdiction: Jurisdiction;
-  relatedPolicyId?: string;
-  sourceUrl?: string;
-}
-
 export default function TimelinePage() {
+  const [timelineData, setTimelineData] = useState<TimelineEvent[]>([]);
+  const [policiesData, setPoliciesData] = useState<Policy[]>([]);
+  const [loading, setLoading] = useState(true);
   const [jurisdictionFilter, setJurisdictionFilter] = useState<string>('all');
   const [typeFilter, setTypeFilter] = useState<string>('all');
   const [selectedEvent, setSelectedEvent] = useState<TimelineEvent | null>(null);
 
+  useEffect(() => {
+    Promise.all([
+      fetch('/api/timeline').then((r) => r.json()),
+      fetch('/api/policies').then((r) => r.json()),
+    ])
+      .then(([timelineJson, policiesJson]) => {
+        setTimelineData(timelineJson.data ?? []);
+        setPoliciesData(policiesJson.data ?? []);
+      })
+      .catch((err) => console.error('Failed to load timeline data:', err))
+      .finally(() => setLoading(false));
+  }, []);
+
   const filteredEvents = useMemo(() => {
-    return (timelineData as TimelineEvent[]).filter((event) => {
+    return timelineData.filter((event) => {
       const matchesJurisdiction =
         jurisdictionFilter === 'all' || event.jurisdiction === jurisdictionFilter;
       const matchesType = typeFilter === 'all' || event.type === typeFilter;
       return matchesJurisdiction && matchesType;
     });
-  }, [jurisdictionFilter, typeFilter]);
+  }, [jurisdictionFilter, typeFilter, timelineData]);
 
   // Get related policy details
   const relatedPolicy = selectedEvent?.relatedPolicyId
@@ -78,7 +74,17 @@ export default function TimelinePage() {
       jurisdictions: jurisdictions.size,
       policyEvents: timelineData.filter((e) => e.type.startsWith('policy_')).length,
     };
-  }, []);
+  }, [timelineData]);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex items-center justify-center min-h-[60vh]">
+          <div className="animate-pulse text-muted-foreground">Loading timeline...</div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -7,12 +7,14 @@ export function Footer() {
         <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 font-mono text-xs text-muted-foreground">
           <span>&copy; {new Date().getFullYear()} Policai</span>
           <span className="hidden sm:inline">&middot;</span>
-          <Link href="/about" className="hover:text-foreground transition-colors">About</Link>
+          <Link href="/policies" className="hover:text-foreground transition-colors">Policies</Link>
           <span className="hidden sm:inline">&middot;</span>
-          <Link href="/methodology" className="hover:text-foreground transition-colors">Methodology</Link>
+          <Link href="/map" className="hover:text-foreground transition-colors">Map</Link>
+          <span className="hidden sm:inline">&middot;</span>
+          <Link href="/agencies" className="hover:text-foreground transition-colors">Agencies</Link>
           <span className="hidden sm:inline">&middot;</span>
           <a
-            href="https://github.com"
+            href="https://github.com/l0cka/policai"
             target="_blank"
             rel="noopener noreferrer"
             className="hover:text-foreground transition-colors"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { Menu } from 'lucide-react';
+import { Menu, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
@@ -14,10 +15,29 @@ const navItems = [
   { href: '/agencies', label: 'Agencies' },
 ];
 
+const moreItems = [
+  { href: '/network', label: 'Network' },
+  { href: '/framework', label: 'Framework' },
+  { href: '/timeline', label: 'Timeline' },
+];
+
 export function Header() {
   const pathname = usePathname();
   const router = useRouter();
   const { user, signOut, isLoading } = useAuth();
+  const [moreOpen, setMoreOpen] = useState(false);
+  const moreRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (moreRef.current && !moreRef.current.contains(e.target as Node)) {
+        setMoreOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   const handleSignOut = async () => {
     await signOut();
@@ -51,6 +71,40 @@ export function Header() {
               {item.label}
             </Link>
           ))}
+          {/* More dropdown */}
+          <div ref={moreRef} className="relative">
+            <button
+              onClick={() => setMoreOpen(!moreOpen)}
+              className={cn(
+                'px-3 pb-3 pt-1 text-sm font-medium transition-colors border-b-2 flex items-center gap-1',
+                moreItems.some(item => isActive(item.href))
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              )}
+            >
+              More
+              <ChevronDown className={cn('h-3 w-3 transition-transform', moreOpen && 'rotate-180')} />
+            </button>
+            {moreOpen && (
+              <div className="absolute top-full left-0 mt-1 bg-background border border-border rounded-md shadow-lg py-1 min-w-[140px] z-50">
+                {moreItems.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={() => setMoreOpen(false)}
+                    className={cn(
+                      'block px-4 py-2 text-sm transition-colors',
+                      isActive(item.href)
+                        ? 'bg-muted text-foreground'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    )}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
         </nav>
 
         <div className="ml-auto flex items-center gap-4">
@@ -89,6 +143,21 @@ export function Header() {
             <SheetContent side="right" className="w-[250px]">
               <nav className="flex flex-col gap-1 mt-8">
                 {navItems.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={cn(
+                      'px-3 py-2 text-sm font-medium rounded transition-colors',
+                      isActive(item.href)
+                        ? 'bg-muted text-foreground'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    )}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+                <div className="my-2 border-t border-border" />
+                {moreItems.map((item) => (
                   <Link
                     key={item.href}
                     href={item.href}

--- a/src/components/policy-table.tsx
+++ b/src/components/policy-table.tsx
@@ -11,24 +11,19 @@ import {
   type PolicyStatus,
 } from '@/types';
 
+import { STATUS_COLORS } from '@/lib/design-tokens';
+
 interface PolicyRow {
   id: string;
   title: string;
   jurisdiction: string;
   type: string;
   status: string;
-  effectiveDate: string;
+  effectiveDate: string | Date;
 }
 
 type SortField = 'title' | 'jurisdiction' | 'type' | 'status' | 'effectiveDate';
 type SortDirection = 'asc' | 'desc';
-
-const STATUS_COLORS: Record<string, string> = {
-  active: 'text-green-700',
-  proposed: 'text-amber-600',
-  amended: 'text-blue-700',
-  repealed: 'text-gray-500',
-};
 
 function SortIndicator({ field, current, direction }: { field: SortField; current: SortField; direction: SortDirection }) {
   if (field !== current) return <span className="text-transparent ml-1">&uarr;</span>;
@@ -42,6 +37,8 @@ interface PolicyTableProps {
 export function PolicyTable({ policies }: PolicyTableProps) {
   const [sortField, setSortField] = useState<SortField>('title');
   const [sortDir, setSortDir] = useState<SortDirection>('asc');
+  const [page, setPage] = useState(0);
+  const pageSize = 20;
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -53,15 +50,22 @@ export function PolicyTable({ policies }: PolicyTableProps) {
   };
 
   const sorted = [...policies].sort((a, b) => {
-    const aVal = a[sortField] || '';
-    const bVal = b[sortField] || '';
+    const aRaw = a[sortField];
+    const bRaw = b[sortField];
+    const aVal = aRaw instanceof Date ? aRaw.toISOString() : (aRaw || '');
+    const bVal = bRaw instanceof Date ? bRaw.toISOString() : (bRaw || '');
     const cmp = aVal.localeCompare(bVal);
     return sortDir === 'asc' ? cmp : -cmp;
   });
 
-  const formatDate = (dateStr: string) => {
+  const totalPages = Math.ceil(sorted.length / pageSize);
+  // Clamp page to valid range (auto-resets when filters shrink the list)
+  const safePage = totalPages > 0 ? Math.min(page, totalPages - 1) : 0;
+  const paged = sorted.slice(safePage * pageSize, (safePage + 1) * pageSize);
+
+  const formatDate = (dateStr: string | Date) => {
     if (!dateStr) return '\u2014';
-    const d = new Date(dateStr);
+    const d = dateStr instanceof Date ? dateStr : new Date(dateStr);
     return d.toLocaleDateString('en-AU', { month: 'short', year: 'numeric' });
   };
 
@@ -91,7 +95,7 @@ export function PolicyTable({ policies }: PolicyTableProps) {
           </tr>
         </thead>
         <tbody>
-          {sorted.map((policy) => (
+          {paged.map((policy) => (
             <tr key={policy.id} className="border-b border-border hover:bg-[#f0efed] transition-colors">
               <td className="py-3 pr-4">
                 <Link
@@ -120,7 +124,7 @@ export function PolicyTable({ policies }: PolicyTableProps) {
               </td>
             </tr>
           ))}
-          {sorted.length === 0 && (
+          {paged.length === 0 && (
             <tr>
               <td colSpan={5} className="py-8 text-center text-sm text-muted-foreground">
                 No policies match the current filters.
@@ -129,6 +133,31 @@ export function PolicyTable({ policies }: PolicyTableProps) {
           )}
         </tbody>
       </table>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-4 border-t border-border mt-2">
+          <div className="font-mono text-xs text-muted-foreground">
+            Page {safePage + 1} of {totalPages}
+          </div>
+          <div className="flex gap-1">
+            <button
+              onClick={() => setPage(Math.max(0, safePage - 1))}
+              disabled={safePage === 0}
+              className="font-mono text-xs px-3 py-1.5 rounded border border-border hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              Prev
+            </button>
+            <button
+              onClick={() => setPage(Math.min(totalPages - 1, safePage + 1))}
+              disabled={safePage >= totalPages - 1}
+              className="font-mono text-xs px-3 py-1.5 rounded border border-border hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { type LucideIcon, SearchX, FileQuestion, Database } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  icon: Icon = FileQuestion,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div className={cn('flex flex-col items-center justify-center py-12 text-center', className)}>
+      <div className="rounded-full bg-muted p-3 mb-4">
+        <Icon className="h-6 w-6 text-muted-foreground" />
+      </div>
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      {description && (
+        <p className="text-xs text-muted-foreground mt-1 max-w-xs">{description}</p>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}
+
+/** Preconfigured variants for common scenarios */
+export function NoResultsState({ query, className }: { query?: string; className?: string }) {
+  return (
+    <EmptyState
+      icon={SearchX}
+      title="No results found"
+      description={
+        query
+          ? `No items match "${query}". Try adjusting your search or filters.`
+          : 'Try adjusting your filters to see results.'
+      }
+      className={className}
+    />
+  );
+}
+
+export function NoDataState({ noun = 'data', className }: { noun?: string; className?: string }) {
+  return (
+    <EmptyState
+      icon={Database}
+      title={`No ${noun} yet`}
+      description={`There is no ${noun} to display at this time.`}
+      className={className}
+    />
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/visualizations/AustraliaMap.tsx
+++ b/src/components/visualizations/AustraliaMap.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { cn } from '@/lib/utils';
 import type { Jurisdiction } from '@/types';
 
@@ -140,7 +140,6 @@ export function AustraliaMap({
     }
   }, []);
 
-  const activeJurisdiction = hoveredJurisdiction || selectedJurisdiction;
   const tooltipData = hoveredJurisdiction ? data[hoveredJurisdiction] : null;
 
   return (

--- a/src/components/visualizations/Timeline.tsx
+++ b/src/components/visualizations/Timeline.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
-import { JURISDICTION_NAMES, type Jurisdiction } from '@/types';
+import { JURISDICTION_NAMES, type Jurisdiction, type TimelineEvent } from '@/types';
 import {
   FileText,
   Edit,
@@ -13,17 +13,6 @@ import {
   Flag,
   Circle,
 } from 'lucide-react';
-
-interface TimelineEvent {
-  id: string;
-  date: string;
-  title: string;
-  description: string;
-  type: 'policy_introduced' | 'policy_amended' | 'policy_repealed' | 'announcement' | 'milestone';
-  jurisdiction: Jurisdiction;
-  relatedPolicyId?: string;
-  sourceUrl?: string;
-}
 
 interface TimelineProps {
   events: TimelineEvent[];

--- a/src/lib/data-service.ts
+++ b/src/lib/data-service.ts
@@ -56,6 +56,13 @@ interface PolicyWithTrash extends Policy {
   trashedAt?: string;
 }
 
+export class DuplicatePolicyError extends Error {
+  constructor(id: string) {
+    super(`Policy already exists: ${id}`);
+    this.name = 'DuplicatePolicyError';
+  }
+}
+
 export async function getPolicies(filters?: PolicyFilters): Promise<Policy[]> {
   if (isSupabaseConfigured) {
     try {
@@ -114,8 +121,9 @@ export async function getPolicyById(id: string): Promise<Policy | null> {
         .from('policies')
         .select('*')
         .eq('id', id)
-        .single();
+        .maybeSingle();
       if (!error && data) return data as Policy;
+      if (!error) return null;
       console.warn('[data-service] Supabase getPolicyById failed, falling back to JSON:', error?.message);
     } catch (err) {
       console.warn('[data-service] Supabase getPolicyById exception, falling back to JSON:', err);
@@ -143,6 +151,9 @@ export async function createPolicy(policy: Policy): Promise<Policy> {
   }
 
   const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
+  if (policies.some((existingPolicy) => existingPolicy.id === policy.id)) {
+    throw new DuplicatePolicyError(policy.id);
+  }
   policies.unshift(policy);
   await writeJsonFile(POLICIES_FILE, policies);
   return policy;

--- a/src/lib/data-service.ts
+++ b/src/lib/data-service.ts
@@ -1,0 +1,287 @@
+/**
+ * Data Service — unified abstraction over Supabase (primary) and JSON files (fallback).
+ *
+ * Every public function first checks whether Supabase is configured. If it is,
+ * the query goes to Supabase. If not (or if the query fails), it transparently
+ * falls back to the static JSON files in `public/data/`.
+ *
+ * This lets the site work on Vercel with a live database *and* locally with
+ * zero external dependencies.
+ */
+
+import path from 'path';
+import { readJsonFile, writeJsonFile } from '@/lib/file-store';
+import type { Policy, Agency, TimelineEvent } from '@/types';
+
+// ---------------------------------------------------------------------------
+// Supabase availability
+// ---------------------------------------------------------------------------
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+
+/** True when the env vars are set and non-empty. */
+export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
+
+/**
+ * Lazily import the Supabase client so the JSON-only path never triggers
+ * `createClient` with placeholder credentials.
+ */
+async function getSupabase() {
+  const { supabase } = await import('@/lib/supabase');
+  return supabase;
+}
+
+// ---------------------------------------------------------------------------
+// File paths
+// ---------------------------------------------------------------------------
+
+const POLICIES_FILE = path.join(process.cwd(), 'public', 'data', 'sample-policies.json');
+const AGENCIES_FILE = path.join(process.cwd(), 'public', 'data', 'sample-agencies.json');
+const COMMONWEALTH_AGENCIES_FILE = path.join(process.cwd(), 'public', 'data', 'commonwealth-agencies.json');
+const TIMELINE_FILE = path.join(process.cwd(), 'public', 'data', 'sample-timeline.json');
+
+// ---------------------------------------------------------------------------
+// Policy operations
+// ---------------------------------------------------------------------------
+
+export interface PolicyFilters {
+  jurisdiction?: string;
+  type?: string;
+  status?: string;
+  search?: string;
+}
+
+interface PolicyWithTrash extends Policy {
+  trashedAt?: string;
+}
+
+export async function getPolicies(filters?: PolicyFilters): Promise<Policy[]> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      let query = supabase.from('policies').select('*');
+
+      if (filters?.jurisdiction) query = query.eq('jurisdiction', filters.jurisdiction);
+      if (filters?.type) query = query.eq('type', filters.type);
+      if (filters?.status) query = query.eq('status', filters.status);
+      if (filters?.search) {
+        query = query.or(
+          `title.ilike.%${filters.search}%,description.ilike.%${filters.search}%`,
+        );
+      }
+
+      const { data, error } = await query.order('effectiveDate', { ascending: false });
+      if (!error && data) return data as Policy[];
+      console.warn('[data-service] Supabase getPolicies failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase getPolicies exception, falling back to JSON:', err);
+    }
+  }
+
+  // JSON fallback
+  let policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
+
+  if (filters?.jurisdiction) {
+    policies = policies.filter((p) => p.jurisdiction === filters.jurisdiction);
+  }
+  if (filters?.type) {
+    policies = policies.filter((p) => p.type === filters.type);
+  }
+  if (filters?.status) {
+    policies = policies.filter((p) => p.status === filters.status);
+  }
+  if (filters?.search) {
+    const q = filters.search.toLowerCase();
+    policies = policies.filter(
+      (p) =>
+        p.title.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q) ||
+        p.tags.some((t: string) => t.toLowerCase().includes(q)),
+    );
+  }
+
+  return policies.sort(
+    (a, b) => new Date(b.effectiveDate).getTime() - new Date(a.effectiveDate).getTime(),
+  );
+}
+
+export async function getPolicyById(id: string): Promise<Policy | null> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      const { data, error } = await supabase
+        .from('policies')
+        .select('*')
+        .eq('id', id)
+        .single();
+      if (!error && data) return data as Policy;
+      console.warn('[data-service] Supabase getPolicyById failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase getPolicyById exception, falling back to JSON:', err);
+    }
+  }
+
+  const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
+  return policies.find((p) => p.id === id) || null;
+}
+
+export async function createPolicy(policy: Policy): Promise<Policy> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      const { data, error } = await supabase
+        .from('policies')
+        .insert(policy)
+        .select()
+        .single();
+      if (!error && data) return data as Policy;
+      console.warn('[data-service] Supabase createPolicy failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase createPolicy exception, falling back to JSON:', err);
+    }
+  }
+
+  const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
+  policies.unshift(policy);
+  await writeJsonFile(POLICIES_FILE, policies);
+  return policy;
+}
+
+export async function updatePolicy(
+  id: string,
+  updates: Partial<PolicyWithTrash>,
+): Promise<Policy | null> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      const { data, error } = await supabase
+        .from('policies')
+        .update({ ...updates, updatedAt: new Date().toISOString() })
+        .eq('id', id)
+        .select()
+        .single();
+      if (!error && data) return data as Policy;
+      console.warn('[data-service] Supabase updatePolicy failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase updatePolicy exception, falling back to JSON:', err);
+    }
+  }
+
+  const policies = await readJsonFile<PolicyWithTrash[]>(POLICIES_FILE, []);
+  const idx = policies.findIndex((p) => p.id === id);
+  if (idx === -1) return null;
+
+  const now = new Date().toISOString();
+  if (updates.status === 'trashed' && policies[idx].status !== 'trashed') {
+    policies[idx].trashedAt = now;
+  } else if (updates.status && updates.status !== 'trashed' && policies[idx].status === 'trashed') {
+    delete policies[idx].trashedAt;
+  }
+
+  policies[idx] = { ...policies[idx], ...updates, updatedAt: now };
+  await writeJsonFile(POLICIES_FILE, policies);
+  return policies[idx];
+}
+
+export async function deletePolicy(id: string): Promise<boolean> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      const { error } = await supabase.from('policies').delete().eq('id', id);
+      if (!error) return true;
+      console.warn('[data-service] Supabase deletePolicy failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase deletePolicy exception, falling back to JSON:', err);
+    }
+  }
+
+  const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
+  const idx = policies.findIndex((p) => p.id === id);
+  if (idx === -1) return false;
+  policies.splice(idx, 1);
+  await writeJsonFile(POLICIES_FILE, policies);
+  return true;
+}
+
+/** Check if a policy with a given ID already exists. */
+export async function policyExists(id: string): Promise<boolean> {
+  const policy = await getPolicyById(id);
+  return policy !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Agency operations
+// ---------------------------------------------------------------------------
+
+export async function getAgencies(filters?: {
+  level?: string;
+  jurisdiction?: string;
+}): Promise<Agency[]> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      let query = supabase.from('agencies').select('*');
+      if (filters?.level) query = query.eq('level', filters.level);
+      if (filters?.jurisdiction) query = query.eq('jurisdiction', filters.jurisdiction);
+      const { data, error } = await query.order('name');
+      if (!error && data) return data as Agency[];
+      console.warn('[data-service] Supabase getAgencies failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase getAgencies exception, falling back to JSON:', err);
+    }
+  }
+
+  let agencies = await readJsonFile<Agency[]>(AGENCIES_FILE, []);
+  if (filters?.level) {
+    agencies = agencies.filter((a) => a.level === filters.level);
+  }
+  if (filters?.jurisdiction) {
+    agencies = agencies.filter((a) => a.jurisdiction === filters.jurisdiction);
+  }
+  return agencies.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getCommonwealthAgencies(): Promise<Agency[]> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      const { data, error } = await supabase
+        .from('agencies')
+        .select('*')
+        .eq('level', 'federal')
+        .order('name');
+      if (!error && data) return data as Agency[];
+    } catch {
+      // fall through
+    }
+  }
+
+  return readJsonFile<Agency[]>(COMMONWEALTH_AGENCIES_FILE, []);
+}
+
+// ---------------------------------------------------------------------------
+// Timeline operations
+// ---------------------------------------------------------------------------
+
+export async function getTimelineEvents(filters?: {
+  jurisdiction?: string;
+}): Promise<TimelineEvent[]> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      let query = supabase.from('timeline_events').select('*');
+      if (filters?.jurisdiction) query = query.eq('jurisdiction', filters.jurisdiction);
+      const { data, error } = await query.order('date', { ascending: true });
+      if (!error && data) return data as TimelineEvent[];
+    } catch {
+      // fall through
+    }
+  }
+
+  let events = await readJsonFile<TimelineEvent[]>(TIMELINE_FILE, []);
+  if (filters?.jurisdiction) {
+    events = events.filter((e) => e.jurisdiction === filters.jurisdiction);
+  }
+  return events.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}

--- a/src/lib/data-sources.ts
+++ b/src/lib/data-sources.ts
@@ -1,0 +1,81 @@
+/**
+ * Single source of truth for Australian government AI policy data sources.
+ * Used by the scraper, research agent, and admin dashboard.
+ */
+
+export interface DataSource {
+  id: string;
+  name: string;
+  url: string;
+  schedule: 'daily' | 'weekly' | 'monthly';
+  enabled: boolean;
+}
+
+export const DATA_SOURCES: DataSource[] = [
+  {
+    id: 'source-1',
+    name: 'DTA AI Policy',
+    url: 'https://www.dta.gov.au/our-projects/artificial-intelligence',
+    schedule: 'daily',
+    enabled: true,
+  },
+  {
+    id: 'source-2',
+    name: 'DISER AI Strategy',
+    url: 'https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence',
+    schedule: 'weekly',
+    enabled: true,
+  },
+  {
+    id: 'source-3',
+    name: 'CSIRO Data61',
+    url: 'https://www.csiro.au/en/research/technology-space/ai',
+    schedule: 'weekly',
+    enabled: true,
+  },
+  {
+    id: 'source-4',
+    name: 'AHRC AI Ethics',
+    url: 'https://humanrights.gov.au/our-work/technology-and-human-rights',
+    schedule: 'weekly',
+    enabled: true,
+  },
+  {
+    id: 'source-5',
+    name: 'OAIC AI Guidance',
+    url: 'https://www.oaic.gov.au/privacy/guidance-and-advice/artificial-intelligence-and-privacy',
+    schedule: 'monthly',
+    enabled: true,
+  },
+  {
+    id: 'source-6',
+    name: 'NSW Digital AI',
+    url: 'https://www.digital.nsw.gov.au/policy/artificial-intelligence',
+    schedule: 'weekly',
+    enabled: true,
+  },
+  {
+    id: 'source-7',
+    name: 'Victorian AI Strategy',
+    url: 'https://www.vic.gov.au/artificial-intelligence-strategy',
+    schedule: 'weekly',
+    enabled: true,
+  },
+  {
+    id: 'source-8',
+    name: 'ACCC Digital Platforms',
+    url: 'https://www.accc.gov.au/focus-areas/digital-platforms-and-services',
+    schedule: 'monthly',
+    enabled: true,
+  },
+];
+
+/** Lookup a source by its ID. */
+export function getSourceById(id: string): DataSource | undefined {
+  return DATA_SOURCES.find((s) => s.id === id);
+}
+
+/** Map of source IDs to { name, url } for quick lookup by scraper routes. */
+export const DATA_SOURCES_MAP: Record<string, { name: string; url: string }> = Object.fromEntries(
+  DATA_SOURCES.map((s) => [s.id, { name: s.name, url: s.url }]),
+);

--- a/src/lib/design-tokens.ts
+++ b/src/lib/design-tokens.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared design tokens — centralised visual constants used across the app.
+ * Import from '@/lib/design-tokens' instead of redefining locally.
+ */
+
+/** Tailwind text-color classes keyed by PolicyStatus */
+export const STATUS_COLORS: Record<string, string> = {
+  active: 'text-green-700',
+  proposed: 'text-amber-600',
+  amended: 'text-blue-700',
+  repealed: 'text-gray-500',
+};
+
+/** Tailwind background-color classes keyed by PolicyStatus */
+export const STATUS_BG_COLORS: Record<string, string> = {
+  active: 'bg-green-100',
+  proposed: 'bg-amber-100',
+  amended: 'bg-blue-100',
+  repealed: 'bg-gray-100',
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/scrape",
+      "schedule": "0 2 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Centralise all data access behind a Supabase-first / JSON-fallback service layer, add automated scraping via Vercel Cron, and polish the frontend with API-driven data fetching, responsive improvements, pagination, loading skeletons, and accessibility enhancements.

## Context

This combines two related streams of work:

1. **Data automation** -- API routes were reading/writing JSON files inline with duplicated logic. There was no path to Supabase without rewriting every route, and the scraper could only run locally via a CLI script.
2. **UI hardening** -- Pages imported JSON at build time (no runtime refresh), had no loading states, no empty states, no pagination, and secondary navigation items (Network, Framework, Timeline) were completely hidden.

Both streams touch the same pages (every page switches from static imports to API fetch), so they ship together as one coherent change.

## Changes

### Data service layer
- **`src/lib/data-service.ts`** (new, 287 lines) -- unified `getPolicies`, `getPolicyById`, `createPolicy`, `updatePolicy`, `deletePolicy`, `policyExists`, `getAgencies`, `getCommonwealthAgencies`, `getTimelineEvents`. Each function tries Supabase first and falls back to JSON files in `public/data/`.
- **`src/lib/data-sources.ts`** (new) -- typed registry of 8 Australian government AI policy sources (DTA, DISER, CSIRO Data61, AHRC, OAIC, NSW Digital, VIC AI Strategy, ACCC) with schedule and enabled flag.
- **`src/lib/design-tokens.ts`** (new) -- shared `STATUS_COLORS` / `STATUS_BG_COLORS` replacing duplicated Tailwind class maps in Map and PolicyTable.

### API routes
- **`GET /api/agencies`** (new) -- query agencies by level, jurisdiction, or commonwealth flag.
- **`GET /api/timeline`** (new) -- query timeline events with optional jurisdiction filter.
- **`GET /api/cron/scrape`** (new, 247 lines) -- Vercel Cron endpoint (daily 02:00 UTC). Scrapes enabled sources with Cheerio, scores relevance via Claude AI, auto-creates policies scoring >= 0.8.
- **`/api/policies` and `/api/policies/[id]`** -- reduced ~60% by delegating to `data-service` instead of inline file I/O.
- **`vercel.json`** (new) -- cron schedule configuration.

### Frontend -- data fetching
- **Home, Map, Agencies, Timeline, Network** pages all switch from static `import ... from '@/../public/data/*.json'` to runtime `fetch('/api/...')` with `useEffect`.
- **Policy detail** (`/policies/[id]/page.tsx`) switches to server-side `data-service` calls.
- Every page now shows a loading state while data is in flight.

### Frontend -- UI polish
- **Header**: "More" dropdown on desktop for secondary nav (Network, Framework, Timeline); separator + flat list in mobile sheet.
- **Policy table**: Client-side pagination (20 per page), safer date sorting for `Date` objects.
- **Map page**: Responsive sliding panel (bottom sheet on mobile, side panel on desktop), mobile drag handle, loading state.
- **Network page**: Refactored to fetch from API; layout adjustments.
- **Timeline page**: API-driven data fetching, layout cleanup.
- **Policy detail**: New `loading.tsx` skeleton for Suspense; expanded tabs with richer content sections.
- **Footer**: Minor copy/layout refinements.

### Accessibility & components
- **Skip-to-content** link and `id="main-content"` on `<main>` in root layout.
- **`BackToTop`** button component added to layout.
- **`EmptyState`** / `NoResultsState` / `NoDataState`** (`src/components/ui/empty-state.tsx`) -- reusable empty states.
- **`Skeleton`** (`src/components/ui/skeleton.tsx`) -- shadcn skeleton primitive.
- **`globals.css`** -- additional utility styles.

## Testing

```bash
# 1. Build
npm run build

# 2. Dev server — verify pages load data from API
npm run dev
# /              — policies load, pagination works
# /agencies      — agencies load from /api/agencies
# /map           — map panel slides from bottom on mobile, side on desktop
# /network       — network graph renders
# /timeline      — events load from /api/timeline
# /policies/<id> — skeleton shows during load

# 3. Header "More" dropdown — hover/click shows Network, Framework, Timeline

# 4. Cron endpoint (rejects without secret)
curl -i http://localhost:3000/api/cron/scrape
# Returns 401

# 5. Cron endpoint (with secret)
curl -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/scrape
```
