### PR TITLE
Polish map layouts and normalize visualization pages

### DIFF
--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -1,9 +1,9 @@
 import { PolicyFrameworkMap } from '@/components/visualizations/PolicyFrameworkMap';
 import frameworkData from '@/../public/data/dta-ai-policy-framework.json';
 import Link from 'next/link';
-import { ArrowLeft, ExternalLink, FileText, Download } from 'lucide-react';
+import { ArrowLeft, ExternalLink, FileText, Download, Landmark } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 export const metadata = {
   title: 'AI in Government Policy Framework | Policai',
@@ -12,7 +12,7 @@ export const metadata = {
 
 export default function FrameworkPage() {
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto max-w-6xl px-4 py-8 md:py-10">
       {/* Breadcrumb */}
       <div className="mb-6">
         <Link
@@ -24,84 +24,101 @@ export default function FrameworkPage() {
         </Link>
       </div>
 
-      {/* Info Banner */}
-      <Card className="mb-8 bg-primary/5 border-primary/20">
-        <CardContent className="p-6">
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <div className="flex-1">
-              <h1 className="text-xl font-semibold mb-2">
-                Australian Government AI Policy Visual Map
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                This interactive visualization breaks down the DTA&apos;s Policy for the Responsible Use of AI
-                in Government (Version 2.0). Click on pillars to explore principles and requirements.
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Button variant="outline" size="sm" asChild>
-                <a
-                  href="https://www.digital.gov.au/ai/ai-in-government-policy"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <FileText className="mr-2 h-4 w-4" />
-                  View Original
-                  <ExternalLink className="ml-2 h-3 w-3" />
-                </a>
-              </Button>
-              <Button variant="outline" size="sm" asChild>
-                <a
-                  href="https://www.digital.gov.au/sites/default/files/documents/2025-12/Policy%20for%20the%20responsible%20use%20of%20AI%20in%20Government%202.0_0.pdf"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Download className="mr-2 h-4 w-4" />
-                  Download PDF
-                </a>
-              </Button>
-            </div>
+      <div className="mb-8 space-y-6">
+        <div className="flex items-start gap-4">
+          <div className="rounded-xl bg-primary/10 p-3">
+            <Landmark className="h-6 w-6 text-primary" />
           </div>
-        </CardContent>
-      </Card>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold tracking-tight">AI in Government Framework</h1>
+            <p className="max-w-3xl text-sm text-muted-foreground md:text-base">
+              Explore the structure, obligations, and accountability model behind the Australian Government&apos;s policy for responsible AI use.
+            </p>
+          </div>
+        </div>
+
+        <Card className="border-primary/20 bg-primary/5 shadow-sm">
+          <CardContent className="p-6">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div className="flex-1">
+                <h2 className="mb-2 text-xl font-semibold">
+                  Australian Government AI Policy Visual Map
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                  This interactive visualization breaks down the DTA&apos;s Policy for the Responsible Use of AI
+                  in Government (Version 2.0). Click on pillars to explore principles and requirements.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button variant="outline" size="sm" asChild>
+                  <a
+                    href="https://www.digital.gov.au/ai/ai-in-government-policy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <FileText className="mr-2 h-4 w-4" />
+                    View Original
+                    <ExternalLink className="ml-2 h-3 w-3" />
+                  </a>
+                </Button>
+                <Button variant="outline" size="sm" asChild>
+                  <a
+                    href="https://www.digital.gov.au/sites/default/files/documents/2025-12/Policy%20for%20the%20responsible%20use%20of%20AI%20in%20Government%202.0_0.pdf"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Download className="mr-2 h-4 w-4" />
+                    Download PDF
+                  </a>
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
 
       {/* Framework Visualization */}
       <PolicyFrameworkMap data={frameworkData} />
 
       {/* Footer Note */}
-      <div className="mt-12 p-6 bg-muted/50 rounded-lg">
-        <h3 className="font-semibold mb-2">About This Visualization</h3>
-        <p className="text-sm text-muted-foreground">
-          This visual map represents the structure and requirements of the Australian Government&apos;s
-          AI policy as published by the Digital Transformation Agency. The policy applies to all
-          non-corporate Commonwealth entities and provides a framework for responsible AI adoption.
-          For the authoritative source, please refer to the{' '}
-          <a
-            href="https://www.digital.gov.au/ai/ai-in-government-policy"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-primary hover:underline"
-          >
-            official DTA website
-          </a>
-          .
-        </p>
-        <div className="mt-4 flex flex-wrap gap-4 text-xs text-muted-foreground">
-          <div>
-            <span className="font-medium">Last Updated:</span>{' '}
-            {new Date(frameworkData.effectiveDate).toLocaleDateString('en-AU', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
+      <Card className="mt-10 shadow-sm">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">About This Visualization</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            This visual map represents the structure and requirements of the Australian Government&apos;s
+            AI policy as published by the Digital Transformation Agency. The policy applies to all
+            non-corporate Commonwealth entities and provides a framework for responsible AI adoption.
+            For the authoritative source, please refer to the{' '}
+            <a
+              href="https://www.digital.gov.au/ai/ai-in-government-policy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              official DTA website
+            </a>
+            .
+          </p>
+          <div className="flex flex-wrap gap-x-6 gap-y-2 text-xs text-muted-foreground">
+            <div>
+              <span className="font-medium">Last Updated:</span>{' '}
+              {new Date(frameworkData.effectiveDate).toLocaleDateString('en-AU', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </div>
+            <div>
+              <span className="font-medium">Version:</span> {frameworkData.version}
+            </div>
+            <div>
+              <span className="font-medium">Authority:</span> {frameworkData.authority}
+            </div>
           </div>
-          <div>
-            <span className="font-medium">Version:</span> {frameworkData.version}
-          </div>
-          <div>
-            <span className="font-medium">Authority:</span> {frameworkData.authority}
-          </div>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -91,16 +91,16 @@ export default function MapPage() {
 
   if (loading) {
     return (
-      <div className="h-[calc(100vh-4rem)] flex items-center justify-center">
+      <div className="flex min-h-[calc(100svh-4rem)] items-center justify-center">
         <div className="animate-pulse text-muted-foreground">Loading map data...</div>
       </div>
     );
   }
 
   return (
-    <div className="h-[calc(100vh-4rem)] flex overflow-hidden relative">
+    <div className="relative flex min-h-[calc(100svh-4rem)] overflow-hidden bg-background">
       {/* Map area — takes full width, panel overlays */}
-      <div className="flex-1 relative">
+      <div className="relative flex flex-1 min-w-0 items-start justify-center px-4 pt-4 pb-28 md:px-8 md:pt-6 md:pb-16">
         <AustraliaMap
           data={jurisdictionData}
           selectedJurisdiction={selectedJurisdiction}
@@ -112,7 +112,7 @@ export default function MapPage() {
       {/* Sliding policy panel */}
       <div
         ref={panelRef}
-        className={`absolute md:top-0 md:right-0 md:h-[calc(100vh-4rem)] md:w-[340px] md:border-l bottom-0 left-0 right-0 max-h-[60vh] md:max-h-none border-t md:border-t-0 border-border bg-background z-10 flex flex-col overflow-hidden rounded-t-xl md:rounded-none transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] ${
+        className={`absolute inset-x-0 bottom-0 z-10 flex max-h-[60vh] flex-col overflow-hidden rounded-t-xl border-t border-border bg-background shadow-2xl transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] md:top-6 md:right-6 md:left-auto md:h-[calc(100%-3rem)] md:max-h-none md:w-[22rem] md:rounded-2xl md:border md:bg-card/95 md:shadow-xl md:backdrop-blur-sm ${
           panelVisible
             ? 'translate-y-0 md:translate-y-0 md:translate-x-0'
             : 'translate-y-full md:translate-y-0 md:translate-x-full'
@@ -125,9 +125,9 @@ export default function MapPage() {
               <div className="w-10 h-1 rounded-full bg-border" />
             </div>
             {/* Panel header */}
-            <div className="p-5 border-b border-border flex-shrink-0">
+            <div className="flex-shrink-0 border-b border-border bg-muted/30 p-5 md:p-6">
               <div className="flex items-center justify-between mb-1">
-                <h2 className="font-sans text-lg font-bold">
+                <h2 className="font-sans text-xl font-bold tracking-tight">
                   {JURISDICTION_NAMES[selectedJurisdiction]}
                 </h2>
                 <button
@@ -142,7 +142,7 @@ export default function MapPage() {
                       closeTimerRef.current = null;
                     }, 300);
                   }}
-                  className="font-mono text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  className="font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
                 >
                   Close
                 </button>
@@ -161,22 +161,22 @@ export default function MapPage() {
                   No policies found for this jurisdiction.
                 </div>
               ) : (
-                <div className="divide-y divide-border">
+                <div className="divide-y divide-border/80">
                   {selectedPolicies.map((policy, idx) => (
                     <Link
                       key={policy.id}
                       href={`/policies/${policy.id}`}
-                      className="block p-4 hover:bg-muted/50 transition-colors"
+                      className="block p-4 transition-colors hover:bg-muted/40 md:px-6 md:py-5"
                       style={{
                         opacity: panelVisible ? 1 : 0,
                         transform: panelVisible ? 'translateX(0)' : 'translateX(20px)',
                         transition: `opacity 0.3s ease ${idx * 0.05 + 0.15}s, transform 0.3s ease ${idx * 0.05 + 0.15}s`,
                       }}
                     >
-                      <div className="text-sm font-medium text-primary hover:underline leading-snug">
+                      <div className="text-base font-medium leading-snug text-foreground">
                         {policy.title}
                       </div>
-                      <div className="font-mono text-xs text-muted-foreground mt-1.5 flex items-center gap-2">
+                      <div className="mt-2 flex items-center gap-2 font-mono text-xs text-muted-foreground">
                         <span className={STATUS_COLORS[policy.status] || 'text-muted-foreground'}>
                           {POLICY_STATUS_NAMES[policy.status as PolicyStatus]}
                         </span>
@@ -190,7 +190,7 @@ export default function MapPage() {
             </div>
 
             {/* Panel footer */}
-            <div className="p-4 border-t border-border flex-shrink-0">
+            <div className="flex-shrink-0 border-t border-border bg-muted/20 p-4 md:px-6">
               <Link
                 href="/"
                 className="font-mono text-xs text-primary hover:underline"
@@ -203,7 +203,11 @@ export default function MapPage() {
       </div>
 
       {/* Bottom summary bar */}
-      <div className="absolute bottom-0 left-0 right-0 md:right-auto border-t border-border bg-background/90 backdrop-blur-sm px-5 py-2 z-5" style={{ ...(panelVisible ? { right: undefined } : {}), transition: 'right 0.35s cubic-bezier(0.16, 1, 0.3, 1)' }}>
+      <div
+        className={`absolute right-0 bottom-0 left-0 border-t border-border bg-background/90 px-5 py-2 backdrop-blur-sm transition-[right] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] ${
+          panelVisible ? 'md:right-[calc(22rem+1.5rem)]' : 'md:right-0'
+        }`}
+      >
         <div className="font-mono text-xs text-muted-foreground" aria-live="polite">
           {policiesData.filter(p => p.status !== 'trashed').length} policies across {Object.keys(jurisdictionData).length} jurisdictions
           {selectedJurisdiction && (

--- a/src/app/network/page.tsx
+++ b/src/app/network/page.tsx
@@ -448,7 +448,7 @@ export default function NetworkPage() {
 
   if (dataLoading) {
     return (
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto max-w-7xl px-4 py-8 md:py-10">
         <div className="flex items-center justify-center min-h-[60vh]">
           <div className="animate-pulse text-muted-foreground">Loading network data...</div>
         </div>
@@ -457,69 +457,69 @@ export default function NetworkPage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto max-w-7xl px-4 py-8 md:py-10">
       {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-center gap-3 mb-2">
-          <div className="p-2 rounded-lg bg-primary/10">
+      <div className="mb-8 space-y-2">
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl bg-primary/10 p-3">
             <Network className="h-6 w-6 text-primary" />
           </div>
-          <h1 className="text-3xl font-bold">Relationship Network</h1>
+          <h1 className="text-3xl font-bold tracking-tight">Relationship Network</h1>
         </div>
-        <p className="text-muted-foreground">
+        <p className="max-w-3xl text-muted-foreground">
           Visualise connections between AI policies, government agencies, and jurisdictions across Australia
         </p>
       </div>
 
       {/* Statistics Cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <Card className="bg-gradient-to-br from-indigo-500/10 to-indigo-500/5 border-indigo-500/20">
+        <Card className="border-indigo-500/15 bg-indigo-500/5 shadow-sm">
           <CardContent className="pt-4 pb-3">
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-indigo-500/20">
                 <Map className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
               </div>
               <div>
-                <div className="text-2xl font-bold">{stats.jurisdictions}</div>
+                <div className="text-2xl font-bold tabular-nums">{stats.jurisdictions}</div>
                 <p className="text-xs text-muted-foreground">Jurisdictions</p>
               </div>
             </div>
           </CardContent>
         </Card>
-        <Card className="bg-gradient-to-br from-green-500/10 to-green-500/5 border-green-500/20">
+        <Card className="border-green-500/15 bg-green-500/5 shadow-sm">
           <CardContent className="pt-4 pb-3">
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-green-500/20">
                 <FileText className="h-4 w-4 text-green-600 dark:text-green-400" />
               </div>
               <div>
-                <div className="text-2xl font-bold">{stats.activePolicies}</div>
+                <div className="text-2xl font-bold tabular-nums">{stats.activePolicies}</div>
                 <p className="text-xs text-muted-foreground">Active Policies</p>
               </div>
             </div>
           </CardContent>
         </Card>
-        <Card className="bg-gradient-to-br from-amber-500/10 to-amber-500/5 border-amber-500/20">
+        <Card className="border-amber-500/15 bg-amber-500/5 shadow-sm">
           <CardContent className="pt-4 pb-3">
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-amber-500/20">
                 <GitBranch className="h-4 w-4 text-amber-600 dark:text-amber-400" />
               </div>
               <div>
-                <div className="text-2xl font-bold">{stats.proposedPolicies}</div>
+                <div className="text-2xl font-bold tabular-nums">{stats.proposedPolicies}</div>
                 <p className="text-xs text-muted-foreground">Proposed</p>
               </div>
             </div>
           </CardContent>
         </Card>
-        <Card className="bg-gradient-to-br from-purple-500/10 to-purple-500/5 border-purple-500/20">
+        <Card className="border-purple-500/15 bg-purple-500/5 shadow-sm">
           <CardContent className="pt-4 pb-3">
             <div className="flex items-center gap-3">
               <div className="p-2 rounded-lg bg-purple-500/20">
                 <BarChart3 className="h-4 w-4 text-purple-600 dark:text-purple-400" />
               </div>
               <div>
-                <div className="text-2xl font-bold">{stats.totalPolicies}</div>
+                <div className="text-2xl font-bold tabular-nums">{stats.totalPolicies}</div>
                 <p className="text-xs text-muted-foreground">Total Policies</p>
               </div>
             </div>
@@ -529,9 +529,9 @@ export default function NetworkPage() {
 
       <div className="grid lg:grid-cols-4 gap-6">
         {/* Sidebar: Filters & Legend */}
-        <div className="lg:col-span-1 space-y-4">
+        <div className="space-y-4 lg:col-span-1 lg:sticky lg:top-24 lg:self-start">
           {/* Search */}
-          <Card>
+          <Card className="shadow-sm">
             <CardHeader className="pb-3">
               <CardTitle className="text-sm flex items-center gap-2">
                 <Search className="h-4 w-4" />
@@ -559,7 +559,7 @@ export default function NetworkPage() {
           </Card>
 
           {/* Filters */}
-          <Card>
+          <Card className="shadow-sm">
             <CardHeader className="pb-3">
               <CardTitle className="text-sm flex items-center gap-2">
                 <Filter className="h-4 w-4" />
@@ -628,7 +628,7 @@ export default function NetworkPage() {
           </Card>
 
           {/* Legend */}
-          <Card>
+          <Card className="shadow-sm">
             <CardHeader className="pb-3">
               <CardTitle className="text-sm flex items-center gap-2">
                 <Info className="h-4 w-4" />
@@ -685,7 +685,7 @@ export default function NetworkPage() {
           </Card>
 
           {/* How to Use */}
-          <Card>
+          <Card className="shadow-sm">
             <CardHeader className="pb-3">
               <CardTitle className="text-sm">Controls</CardTitle>
             </CardHeader>
@@ -702,7 +702,7 @@ export default function NetworkPage() {
 
         {/* Network Graph */}
         <div className="lg:col-span-3">
-          <Card className="h-[400px] lg:h-[700px] overflow-hidden">
+          <Card className="h-[440px] overflow-hidden shadow-sm lg:h-[700px]">
             <CardContent className="p-0 h-full">
               {highlightedNodes.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-full text-center p-8">

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useEffect } from 'react';
 import Link from 'next/link';
-import { Filter, ArrowRight, Calendar } from 'lucide-react';
+import { Filter, ArrowRight, Calendar, Clock3 } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -78,7 +78,7 @@ export default function TimelinePage() {
 
   if (loading) {
     return (
-      <div className="container mx-auto px-4 py-8">
+      <div className="container mx-auto max-w-6xl px-4 py-8 md:py-10">
         <div className="flex items-center justify-center min-h-[60vh]">
           <div className="animate-pulse text-muted-foreground">Loading timeline...</div>
         </div>
@@ -87,37 +87,42 @@ export default function TimelinePage() {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold">Policy Timeline</h1>
-        <p className="mt-2 text-muted-foreground">
+    <div className="container mx-auto max-w-6xl px-4 py-8 md:py-10">
+      <div className="mb-8 space-y-2">
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl bg-primary/10 p-3">
+            <Clock3 className="h-6 w-6 text-primary" />
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight">Policy Timeline</h1>
+        </div>
+        <p className="max-w-3xl text-muted-foreground">
           Track the evolution of Australian AI policy through key events and milestones
         </p>
       </div>
 
       {/* Stats */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{stats.totalEvents}</div>
+        <Card className="bg-muted/30 shadow-sm">
+          <CardContent className="pt-5 pb-4">
+            <div className="text-2xl font-bold tabular-nums">{stats.totalEvents}</div>
             <p className="text-sm text-muted-foreground">Total Events</p>
           </CardContent>
         </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{stats.years}</div>
+        <Card className="bg-muted/30 shadow-sm">
+          <CardContent className="pt-5 pb-4">
+            <div className="text-2xl font-bold tabular-nums">{stats.years}</div>
             <p className="text-sm text-muted-foreground">Years Covered</p>
           </CardContent>
         </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{stats.jurisdictions}</div>
+        <Card className="bg-muted/30 shadow-sm">
+          <CardContent className="pt-5 pb-4">
+            <div className="text-2xl font-bold tabular-nums">{stats.jurisdictions}</div>
             <p className="text-sm text-muted-foreground">Jurisdictions</p>
           </CardContent>
         </Card>
-        <Card>
-          <CardContent className="pt-6">
-            <div className="text-2xl font-bold">{stats.policyEvents}</div>
+        <Card className="bg-muted/30 shadow-sm">
+          <CardContent className="pt-5 pb-4">
+            <div className="text-2xl font-bold tabular-nums">{stats.policyEvents}</div>
             <p className="text-sm text-muted-foreground">Policy Events</p>
           </CardContent>
         </Card>
@@ -125,8 +130,8 @@ export default function TimelinePage() {
 
       <div className="grid lg:grid-cols-4 gap-8">
         {/* Filters Sidebar */}
-        <div className="lg:col-span-1">
-          <Card>
+        <div className="space-y-4 lg:col-span-1 lg:sticky lg:top-24 lg:self-start">
+          <Card className="shadow-sm">
             <CardHeader>
               <CardTitle className="text-lg flex items-center gap-2">
                 <Filter className="h-4 w-4" />
@@ -182,6 +187,7 @@ export default function TimelinePage() {
                     setJurisdictionFilter('all');
                     setTypeFilter('all');
                   }}
+                  className="w-full"
                 >
                   Clear Filters
                 </Button>
@@ -190,7 +196,7 @@ export default function TimelinePage() {
           </Card>
 
           {/* Legend */}
-          <Card className="mt-4">
+          <Card className="shadow-sm">
             <CardHeader>
               <CardTitle className="text-lg">Legend</CardTitle>
             </CardHeader>
@@ -221,8 +227,8 @@ export default function TimelinePage() {
 
         {/* Timeline */}
         <div className="lg:col-span-3">
-          <Card>
-            <CardHeader>
+          <Card className="shadow-sm">
+            <CardHeader className="pb-4">
               <CardTitle>Timeline</CardTitle>
               <CardDescription>Click on an event to see more details</CardDescription>
             </CardHeader>

--- a/src/components/visualizations/AustraliaMap.tsx
+++ b/src/components/visualizations/AustraliaMap.tsx
@@ -145,7 +145,7 @@ export function AustraliaMap({
   return (
     <div
       ref={containerRef}
-      className="relative w-full h-full"
+      className="relative flex h-full w-full min-h-0 items-start justify-center overflow-visible pb-24 md:pb-20"
       onMouseMove={handleMouseMove}
     >
       <style>{`
@@ -183,15 +183,12 @@ export function AustraliaMap({
 
       <svg
         viewBox="-603 -163 1955 1795"
-        className="w-full h-full"
+        className="h-auto w-full max-w-[1040px] max-h-[62svh] md:max-h-[68svh]"
         role="img"
         aria-label="Interactive map of Australian jurisdictions showing AI policy density"
         preserveAspectRatio="xMidYMid meet"
       >
         <title>Australian AI Policy Map</title>
-
-        {/* Clean background */}
-        <rect x="-603" y="-163" width="1955" height="1795" fill="#f0efed" />
 
         {/* Render each jurisdiction */}
         {renderOrder.map((jurisdiction, idx) => {
@@ -334,7 +331,7 @@ export function AustraliaMap({
         onMouseEnter={() => handleMouseEnter('federal')}
         onMouseLeave={handleMouseLeave}
         className={cn(
-          'absolute bottom-10 left-4 right-4 px-5 py-3 flex items-center justify-between',
+          'absolute bottom-10 left-1/2 flex w-[min(1040px,calc(100%-2rem))] -translate-x-1/2 items-center justify-between px-5 py-3',
           'border rounded font-mono text-sm transition-all duration-300',
           selectedJurisdiction === 'federal'
             ? 'bg-[#1e40af] text-white border-[#1e40af]'


### PR DESCRIPTION
## Summary
- Fix the map page layout by removing the oversized SVG background, reducing the map stage, and preventing footer/bottom-bar clipping
- Refine the map detail drawer into an inset desktop panel with improved spacing, typography, and responsive positioning
- Normalize the framework, network, and timeline pages with consistent container widths, page headers, stat cards, sticky sidebars, and card elevation
- Apply final polish touches such as tabular metric figures, cleaner spacing rhythm, and tighter visual hierarchy across visualization pages

## Testing
- `npx eslint src/app/map/page.tsx src/app/network/page.tsx src/app/framework/page.tsx src/app/timeline/page.tsx`
- `npx eslint src/app/network/page.tsx src/app/framework/page.tsx src/app/timeline/page.tsx`
- `npx eslint src/components/visualizations/AustraliaMap.tsx src/app/map/page.tsx`