### PR TITLE
data: refresh policy coverage and current records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Policai
 
-Policai is an Australian AI policy tracker for monitoring regulation, government guidance, and Commonwealth agency activity.
+Policai is an Australian AI policy tracker that aggregates and visualizes AI policy, regulation, and governance developments across federal and state jurisdictions. It monitors government guidance and Commonwealth agency activity.
 
 **Current scope:**
 - searchable Australian AI policy explorer
 - Commonwealth agencies directory
 - interactive view of the DTA's **Policy for the Responsible Use of AI in Government** (effective **15 December 2025**)
-
-Policai is a web application that aggregates and visualizes AI policy, regulation, and governance developments across Australian federal and state jurisdictions.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Policai
 
+Policai is an Australian AI policy tracker for monitoring regulation, government guidance, and Commonwealth agency activity.
+
+**Current scope:**
+- searchable Australian AI policy explorer
+- Commonwealth agencies directory
+- interactive view of the DTA's **Policy for the Responsible Use of AI in Government** (effective **15 December 2025**)
+
 Policai is a web application that aggregates and visualizes AI policy, regulation, and governance developments across Australian federal and state jurisdictions.
 
 ## Features

--- a/public/data/dta-ai-policy-framework.json
+++ b/public/data/dta-ai-policy-framework.json
@@ -3,6 +3,7 @@
   "title": "Policy for the Responsible Use of AI in Government",
   "version": "2.0",
   "effectiveDate": "2025-12-15",
+  "lastUpdated": "2025-12-01",
   "authority": "Digital Transformation Agency",
   "sourceUrl": "https://www.digital.gov.au/ai/ai-in-government-policy",
   "application": {

--- a/public/data/sample-agencies.json
+++ b/public/data/sample-agencies.json
@@ -8,7 +8,7 @@
     "aiTransparencyStatement": "DISER is committed to the responsible use of AI in policy development and service delivery.",
     "aiUsageDisclosure": "We use AI-assisted tools for document analysis and policy research.",
     "website": "https://www.industry.gov.au",
-    "policies": ["1"]
+    "policies": ["australias-ai-ethics-framework", "national-ai-plan-2025", "voluntary-ai-safety-standard", "safe-and-responsible-ai-australia-proposals-paper"]
   },
   {
     "id": "dta",
@@ -19,7 +19,7 @@
     "aiTransparencyStatement": "DTA leads the government's approach to responsible AI adoption and maintains the Policy for the Responsible Use of AI in Government.",
     "aiUsageDisclosure": "AI tools are used to improve digital services and analyse citizen feedback.",
     "website": "https://www.dta.gov.au",
-    "policies": ["dta-ai-policy-v2", "1", "6"]
+    "policies": ["policy-responsible-use-ai-government-v2", "implementation-plan-policy-responsible-use-ai-government-2025", "aps-ai-plan-2025"]
   },
   {
     "id": "agd",
@@ -29,7 +29,7 @@
     "jurisdiction": "federal",
     "aiTransparencyStatement": "AGD ensures AI regulation protects rights while enabling innovation.",
     "website": "https://www.ag.gov.au",
-    "policies": ["2", "4"]
+    "policies": ["automated-decision-making-ai-regulation-issues-paper", "government-response-privacy-act-review-report"]
   },
   {
     "id": "oaic",
@@ -39,7 +39,7 @@
     "jurisdiction": "federal",
     "aiTransparencyStatement": "OAIC provides guidance on privacy implications of AI systems.",
     "website": "https://www.oaic.gov.au",
-    "policies": ["4"]
+    "policies": ["government-response-privacy-act-review-report"]
   },
   {
     "id": "csiro",
@@ -50,7 +50,7 @@
     "aiTransparencyStatement": "CSIRO conducts responsible AI research for Australia's benefit.",
     "aiUsageDisclosure": "AI is used extensively in research projects across all domains.",
     "website": "https://www.csiro.au",
-    "policies": ["8"]
+    "policies": []
   },
   {
     "id": "nsw-dcs",
@@ -61,7 +61,7 @@
     "aiTransparencyStatement": "NSW DCS ensures AI improves services while protecting citizen rights.",
     "aiUsageDisclosure": "AI chatbots and document processing are used in citizen services.",
     "website": "https://www.digital.nsw.gov.au",
-    "policies": ["3"]
+    "policies": ["nsw-artificial-intelligence-assessment-framework"]
   },
   {
     "id": "vic-dpc",
@@ -71,7 +71,7 @@
     "jurisdiction": "vic",
     "aiTransparencyStatement": "Victoria is committed to ethical AI in government.",
     "website": "https://www.vic.gov.au/department-premier-and-cabinet",
-    "policies": ["5"]
+    "policies": ["victoria-genai-guideline-vps"]
   },
   {
     "id": "qld-dsiti",
@@ -81,6 +81,6 @@
     "jurisdiction": "qld",
     "aiTransparencyStatement": "Queensland embraces AI for economic growth and improved services.",
     "website": "https://www.qld.gov.au",
-    "policies": ["7"]
+    "policies": ["queensland-ai-governance-policy"]
   }
 ]

--- a/public/data/sample-policies.json
+++ b/public/data/sample-policies.json
@@ -1,237 +1,208 @@
 [
   {
-    "id": "2025-implementation-plan-data-and-digital",
-    "title": "2025 Implementation Plan | Data and Digital",
-    "description": "This is Australia's 2025 Implementation Plan for the Data and Digital Government Strategy, with Artificial Intelligence as one of four key priorities. It outlines how the Australian government plans to capture AI opportunities for productivity gains and improved digital service delivery as part of their 2030 vision for government services.",
-    "jurisdiction": "federal",
-    "type": "framework",
-    "status": "active",
-    "effectiveDate": "2026-01-20",
-    "agencies": [],
-    "sourceUrl": "https://www.dataanddigital.gov.au/implementation-plan/2025",
-    "content": "",
-    "aiSummary": "Australia's 2025 Implementation Plan for the Data and Digital Government Strategy identifies Artificial Intelligence as one of four key strategic priorities. The plan focuses on leveraging AI opportunities to achieve productivity gains and enhance digital service delivery as part of the government's broader 2030 vision for modernized government services.",
-    "tags": [
-      "AI policy",
-      "government strategy",
-      "implementation plan",
-      "digital transformation",
-      "productivity",
-      "service delivery"
-    ],
-    "createdAt": "2026-01-20T13:16:56.099Z",
-    "updatedAt": "2026-01-20T13:16:56.099Z"
-  },
-  {
-    "id": "dta-ai-policy-v2",
+    "id": "policy-responsible-use-ai-government-v2",
     "title": "Policy for the Responsible Use of AI in Government",
-    "description": "The Australian Government's comprehensive policy framework for safe, ethical and responsible AI adoption across federal agencies. Version 2.0 introduces enhanced governance requirements, mandatory impact assessments, and accountability structures.",
+    "description": "Whole-of-government policy setting mandatory requirements for the safe, transparent, and accountable use of AI by Australian Government agencies.",
     "jurisdiction": "federal",
-    "type": "framework",
+    "type": "policy",
     "status": "active",
     "effectiveDate": "2025-12-15",
     "agencies": [
-      "dta"
+      "Digital Transformation Agency",
+      "Data and Digital Government Strategy Branch"
     ],
-    "sourceUrl": "https://www.digital.gov.au/ai/ai-in-government-policy",
-    "content": "This policy provides a framework to enable accelerated and sustainable AI adoption by agencies. It covers three main pillars: Strategy and Oversight (transparency statements, accountable officials, use case registers), Preparedness and Operations (responsible AI practices, staff training), and AI Use Case Impact Assessment (risk-based approach with mandatory, medium and high-risk classifications). Applies to all non-corporate Commonwealth entities.",
-    "aiSummary": "Australia's mandatory policy for responsible AI in government, requiring transparency statements, designated accountable officials, internal AI use case registers, impact assessments, and risk-based governance. Effective December 2025.",
-    "tags": [
-      "mandatory",
-      "governance",
-      "transparency",
-      "accountability",
-      "risk-assessment",
-      "federal",
-      "dta",
-      "impact-assessment"
-    ],
-    "createdAt": "2025-12-15",
-    "updatedAt": "2025-12-15"
+    "sourceUrl": "https://www.digital.gov.au/node/795",
+    "content": "The Australian Government policy for the responsible use of AI in government took effect on 15 December 2025 and applies across Commonwealth agencies. It establishes requirements for governance, transparency, risk management, and human oversight.",
+    "aiSummary": "Core Commonwealth policy governing responsible AI use in government from 15 December 2025.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T07:59:40.767Z"
   },
   {
-    "id": "1",
-    "title": "Australia's AI Ethics Framework",
-    "description": "The AI Ethics Framework provides guidance for designing, developing, and implementing AI systems in Australia. It outlines 8 core principles for responsible AI use.",
+    "id": "implementation-plan-policy-responsible-use-ai-government-2025",
+    "title": "2025 Implementation Plan for the Policy for the Responsible Use of AI in Government",
+    "description": "Companion implementation plan that sets out how Commonwealth agencies should operationalise the responsible use of AI policy.",
     "jurisdiction": "federal",
-    "type": "framework",
+    "type": "policy",
     "status": "active",
-    "effectiveDate": "2019-11-01",
+    "effectiveDate": "2025-12-15",
     "agencies": [
-      "diser",
-      "dta"
+      "Data and Digital Government Strategy Branch"
     ],
-    "sourceUrl": "https://www.industry.gov.au/publications/australias-artificial-intelligence-ethics-framework",
-    "content": "The AI Ethics Framework outlines 8 voluntary principles: Human, societal and environmental wellbeing; Human-centred values; Fairness; Privacy protection and security; Reliability and safety; Transparency and explainability; Contestability; Accountability.",
-    "aiSummary": "Australia's voluntary AI Ethics Framework establishes 8 principles for responsible AI development and deployment, focusing on human wellbeing, fairness, privacy, and accountability.",
-    "tags": [
-      "ethics",
-      "framework",
-      "voluntary",
-      "principles"
-    ],
-    "createdAt": "2024-01-15",
-    "updatedAt": "2024-01-15"
+    "sourceUrl": "https://www.dataanddigital.gov.au/policy-responsible-use-artificial-intelligence-government-2025-implementation-plan",
+    "content": "The implementation plan accompanies the Commonwealth AI policy and outlines delivery, capability uplift, assurance, procurement, and operating expectations for agencies implementing AI systems.",
+    "aiSummary": "Companion implementation plan for rolling out the Commonwealth responsible AI policy across agencies.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
   },
   {
-    "id": "2",
-    "title": "Automated Decision-Making and AI Regulation Issues Paper",
-    "description": "Attorney-General's Department issues paper examining regulatory options for AI and automated decision-making systems in Australia.",
+    "id": "aps-ai-plan-2025",
+    "title": "AI Plan for the Australian Public Service 2025",
+    "description": "APS-wide plan for lifting AI capability, adoption, governance, and public-sector delivery readiness across the Australian Public Service.",
     "jurisdiction": "federal",
-    "type": "guideline",
+    "type": "policy",
     "status": "active",
-    "effectiveDate": "2023-06-01",
+    "effectiveDate": "2025-11-12",
     "agencies": [
-      "agd"
+      "Digital Transformation Agency",
+      "Australian Public Service"
     ],
-    "sourceUrl": "https://www.ag.gov.au/rights-and-protections/human-rights-and-anti-discrimination/automated-decision-making-and-ai-regulation",
-    "content": "The issues paper explores potential regulatory approaches to AI and automated decision-making, including mandatory guardrails, sectoral regulation, and principles-based frameworks.",
-    "aiSummary": "The AG Department's issues paper explores regulatory options for AI and automated decision-making in Australia, considering mandatory guardrails and sector-specific approaches.",
-    "tags": [
-      "regulation",
-      "automated-decision-making",
-      "consultation"
-    ],
-    "createdAt": "2024-01-15",
-    "updatedAt": "2024-01-15"
+    "sourceUrl": "https://www.digital.gov.au/policy/ai/australian-public-service-ai-plan-2025",
+    "content": "The APS AI Plan 2025 sets direction for how the Australian Public Service should adopt AI responsibly, improve capability, and embed whole-of-service operating practices.",
+    "aiSummary": "APS-wide plan for responsible AI adoption, capability, and operating model uplift.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
   },
   {
-    "id": "3",
-    "title": "NSW AI Assurance Framework",
-    "description": "The NSW Government's framework for assessing and assuring AI systems used in government services.",
-    "jurisdiction": "nsw",
-    "type": "framework",
-    "status": "active",
-    "effectiveDate": "2022-03-15",
-    "agencies": [
-      "nsw-dcs"
-    ],
-    "sourceUrl": "https://www.digital.nsw.gov.au/policy/artificial-intelligence/nsw-ai-assurance-framework",
-    "content": "The NSW AI Assurance Framework provides a structured approach for NSW government agencies to assess AI systems against key criteria including fairness, transparency, accountability, and privacy.",
-    "aiSummary": "NSW's AI Assurance Framework provides government agencies with a structured methodology to assess AI systems for fairness, transparency, and accountability before deployment.",
-    "tags": [
-      "assurance",
-      "government",
-      "assessment",
-      "state"
-    ],
-    "createdAt": "2024-01-15",
-    "updatedAt": "2024-01-15"
-  },
-  {
-    "id": "4",
-    "title": "Privacy Act Review - AI Provisions",
-    "description": "Proposed amendments to the Privacy Act 1988 addressing AI and automated decision-making systems.",
+    "id": "national-ai-plan-2025",
+    "title": "National AI Plan",
+    "description": "Australian Government national plan setting the broader policy agenda for AI capability, adoption, investment, and safeguards across the economy.",
     "jurisdiction": "federal",
-    "type": "legislation",
-    "status": "proposed",
-    "effectiveDate": "2024-06-01",
-    "agencies": [
-      "agd",
-      "oaic"
-    ],
-    "sourceUrl": "https://www.ag.gov.au/rights-and-protections/privacy",
-    "content": "Proposed changes include requirements for transparency about AI use in decision-making, rights to human review of automated decisions, and enhanced privacy impact assessments for AI systems.",
-    "aiSummary": "Proposed Privacy Act amendments would require transparency about AI use, provide rights to human review of automated decisions, and mandate privacy impact assessments for AI systems.",
-    "tags": [
-      "privacy",
-      "legislation",
-      "automated-decision-making",
-      "reform"
-    ],
-    "createdAt": "2024-01-15",
-    "updatedAt": "2024-01-15"
-  },
-  {
-    "id": "5",
-    "title": "Victorian Public Sector AI Guidelines",
-    "description": "Guidelines for the use of artificial intelligence in the Victorian public sector.",
-    "jurisdiction": "vic",
-    "type": "guideline",
+    "type": "policy",
     "status": "active",
-    "effectiveDate": "2023-09-01",
+    "effectiveDate": "2025-12-02",
     "agencies": [
-      "vic-dpc"
+      "Department of Industry, Science and Resources"
     ],
-    "sourceUrl": "https://www.vic.gov.au/ai-guidelines",
-    "content": "The guidelines establish principles and practices for Victorian public sector agencies using AI, including requirements for human oversight, bias testing, and community consultation.",
-    "aiSummary": "Victoria's public sector AI guidelines mandate human oversight, bias testing, and community consultation for government AI deployments.",
-    "tags": [
-      "government",
-      "guidelines",
-      "public-sector",
-      "state"
-    ],
-    "createdAt": "2024-01-15",
-    "updatedAt": "2024-01-15"
+    "sourceUrl": "https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence",
+    "content": "The National AI Plan is the Commonwealth’s broader economy-wide AI policy plan, covering adoption, capability, ecosystem development, and national coordination.",
+    "aiSummary": "National-level AI plan covering economy-wide adoption, capability, and policy direction.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
   },
   {
-    "id": "6",
-    "title": "DTA Responsible AI Network",
-    "description": "Digital Transformation Agency's initiative to coordinate responsible AI practices across federal government.",
-    "jurisdiction": "federal",
-    "type": "framework",
-    "status": "active",
-    "effectiveDate": "2023-01-01",
-    "agencies": [
-      "dta"
-    ],
-    "sourceUrl": "https://www.dta.gov.au/our-projects/responsible-ai",
-    "content": "The Responsible AI Network brings together federal agencies to share best practices, develop common standards, and coordinate AI governance across government.",
-    "aiSummary": "The DTA's Responsible AI Network coordinates AI governance practices across federal agencies, promoting shared standards and best practices.",
-    "tags": [
-      "government",
-      "coordination",
-      "network",
-      "federal"
-    ],
-    "createdAt": "2024-01-15",
-    "updatedAt": "2024-01-15"
-  },
-  {
-    "id": "7",
-    "title": "Queensland AI Strategy",
-    "description": "Queensland's strategy for AI adoption and governance in the state.",
-    "jurisdiction": "qld",
-    "type": "framework",
-    "status": "active",
-    "effectiveDate": "2023-07-01",
-    "agencies": [
-      "qld-dsiti"
-    ],
-    "sourceUrl": "https://www.qld.gov.au/ai-strategy",
-    "content": "The Queensland AI Strategy outlines the state's approach to AI adoption, focusing on economic opportunities, workforce development, and ethical governance.",
-    "aiSummary": "Queensland's AI Strategy balances economic opportunity with ethical governance, emphasizing workforce development and responsible AI adoption.",
-    "tags": [
-      "strategy",
-      "state",
-      "economic",
-      "workforce"
-    ],
-    "createdAt": "2024-01-15",
-    "updatedAt": "2024-01-15"
-  },
-  {
-    "id": "8",
-    "title": "CSIRO AI Ethics Principles",
-    "description": "CSIRO's internal principles for ethical AI research and development.",
+    "id": "voluntary-ai-safety-standard",
+    "title": "Voluntary AI Safety Standard",
+    "description": "Australian Government standard intended to help organisations developing or deploying AI systems adopt practical safety guardrails.",
     "jurisdiction": "federal",
     "type": "standard",
     "status": "active",
-    "effectiveDate": "2020-06-01",
+    "effectiveDate": "2024-09-05",
     "agencies": [
-      "csiro"
+      "Department of Industry, Science and Resources"
     ],
-    "sourceUrl": "https://www.csiro.au/en/research/technology-space/ai/responsible-ai",
-    "content": "CSIRO's AI Ethics Principles guide research activities, covering responsible innovation, community benefit, transparency, and environmental sustainability in AI development.",
-    "aiSummary": "CSIRO's AI Ethics Principles establish standards for responsible AI research, emphasizing community benefit, transparency, and environmental sustainability.",
-    "tags": [
-      "research",
-      "ethics",
-      "csiro",
-      "innovation"
+    "sourceUrl": "https://www.industry.gov.au/publications/voluntary-ai-safety-standard",
+    "content": "The Voluntary AI Safety Standard provides baseline practices for organisations building and deploying AI, including governance, testing, transparency, and risk management expectations.",
+    "aiSummary": "Practical Australian government AI safety standard for organisations building or deploying AI systems.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
+  },
+  {
+    "id": "australias-ai-ethics-framework",
+    "title": "Australia's AI Ethics Framework",
+    "description": "Foundational Australian framework outlining ethics principles for the design and deployment of AI systems.",
+    "jurisdiction": "federal",
+    "type": "framework",
+    "status": "active",
+    "effectiveDate": "2019-11-07",
+    "agencies": [
+      "Department of Industry, Science and Resources"
     ],
-    "createdAt": "2024-01-15",
-    "updatedAt": "2024-01-15"
+    "sourceUrl": "https://consult.industry.gov.au/australias-ai-ethics-framework",
+    "content": "Australia’s AI Ethics Framework remains an important foundational reference point for responsible AI principles, even though newer Commonwealth policies now sit on top of it.",
+    "aiSummary": "Foundational Australian AI ethics framework that predates newer Commonwealth policy instruments.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
+  },
+  {
+    "id": "government-response-privacy-act-review-report",
+    "title": "Government Response to the Privacy Act Review Report",
+    "description": "Australian Government response to the Privacy Act Review, including implications for automated decision-making, profiling, and AI-enabled privacy harms.",
+    "jurisdiction": "federal",
+    "type": "policy",
+    "status": "active",
+    "effectiveDate": "2025-03-12",
+    "agencies": [
+      "Attorney-General’s Department"
+    ],
+    "sourceUrl": "https://www.ag.gov.au/rights-and-protections/publications/government-response-privacy-act-review-report",
+    "content": "The Government Response sets the current federal position on Privacy Act reform and is more current and decision-useful than the review report alone for AI/privacy policy tracking.",
+    "aiSummary": "Current Commonwealth response on Privacy Act reform with direct relevance to AI, profiling, and automated decision-making.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
+  },
+  {
+    "id": "safe-and-responsible-ai-australia-proposals-paper",
+    "title": "Safe and Responsible AI in Australia — Proposals Paper",
+    "description": "Commonwealth proposals paper outlining options for AI guardrails and regulatory settings in Australia.",
+    "jurisdiction": "federal",
+    "type": "policy",
+    "status": "proposed",
+    "effectiveDate": "2024-01-17",
+    "agencies": [
+      "Department of Industry, Science and Resources"
+    ],
+    "sourceUrl": "https://www.industry.gov.au/publications/safe-and-responsible-ai-australia-proposals-paper",
+    "content": "The proposals paper outlines Commonwealth thinking on AI guardrails and regulatory intervention. It is best treated as a policy development / consultation artefact rather than settled policy.",
+    "aiSummary": "Federal proposals paper on AI guardrails and regulation; useful, but not settled policy.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
+  },
+  {
+    "id": "automated-decision-making-ai-regulation-issues-paper",
+    "title": "Automated Decision-Making and AI Regulation Issues Paper",
+    "description": "Attorney-General’s Department issues paper exploring regulatory responses to automated decision-making and AI.",
+    "jurisdiction": "federal",
+    "type": "policy",
+    "status": "proposed",
+    "effectiveDate": "2024-09-01",
+    "agencies": [
+      "Attorney-General’s Department"
+    ],
+    "sourceUrl": "https://www.ag.gov.au/rights-and-protections/publications/automated-decision-making-and-ai-regulation-issues-paper",
+    "content": "This issues paper is a policy development document, not a final rule. It is still important to track because it frames possible future regulation of ADM and AI systems.",
+    "aiSummary": "Federal issues paper on regulating automated decision-making and AI; should be tracked as proposed policy work.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
+  },
+  {
+    "id": "nsw-artificial-intelligence-assessment-framework",
+    "title": "NSW Artificial Intelligence Assessment Framework",
+    "description": "Current NSW whole-of-government framework for assessing AI use cases, risks, and controls across the public sector.",
+    "jurisdiction": "nsw",
+    "type": "framework",
+    "status": "active",
+    "effectiveDate": "2025-08-01",
+    "agencies": [
+      "Digital NSW"
+    ],
+    "sourceUrl": "https://www.digital.nsw.gov.au/policy/artificial-intelligence/nsw-artificial-intelligence-assessment-framework",
+    "content": "The NSW Artificial Intelligence Assessment Framework is the current Digital NSW framework for evaluating AI use, replacing older shorthand references to an “AI Assurance Framework.”",
+    "aiSummary": "Current NSW framework for assessing public-sector AI use cases, risk, and safeguards.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
+  },
+  {
+    "id": "victoria-genai-guideline-vps",
+    "title": "Administrative Guideline for the Safe and Responsible Use of Generative AI in the Victorian Public Sector",
+    "description": "Current Victorian public-sector guidance on the safe and responsible use of generative AI.",
+    "jurisdiction": "vic",
+    "type": "guideline",
+    "status": "active",
+    "effectiveDate": "2025-02-28",
+    "agencies": [
+      "Victorian Government"
+    ],
+    "sourceUrl": "https://www.vic.gov.au/administrative-guideline-safe-responsible-use-gen-ai-vps",
+    "content": "Victoria’s current official guidance focuses specifically on generative AI use in the Victorian Public Sector and is more current than the older generic “AI guidelines” wording.",
+    "aiSummary": "Current Victorian guidance for safe and responsible generative AI use in the public sector.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
+  },
+  {
+    "id": "queensland-ai-governance-policy",
+    "title": "QGEA Artificial Intelligence Governance Policy",
+    "description": "Queensland whole-of-government policy for AI governance under the Queensland Government Enterprise Architecture.",
+    "jurisdiction": "qld",
+    "type": "policy",
+    "status": "active",
+    "effectiveDate": "2025-02-01",
+    "agencies": [
+      "Queensland Government Customer and Digital Group"
+    ],
+    "sourceUrl": "https://www.forgov.qld.gov.au/information-technology/queensland-government-enterprise-architecture-qgea/qgea-directions-and-guidance/qgea-policies-standards-and-guidelines/artificial-intelligence-governance-policy",
+    "content": "Queensland’s current whole-of-government AI governance instrument sits under QGEA and should be tracked instead of a vague “Queensland AI Strategy” label.",
+    "aiSummary": "Current Queensland whole-of-government AI governance policy under QGEA.",
+    "createdAt": "2026-04-06T16:50:00Z",
+    "updatedAt": "2026-04-06T16:50:00Z"
   }
 ]

--- a/public/data/sample-policies.json
+++ b/public/data/sample-policies.json
@@ -11,8 +11,8 @@
       "Digital Transformation Agency",
       "Data and Digital Government Strategy Branch"
     ],
-    "sourceUrl": "https://www.digital.gov.au/node/795",
-    "content": "The Australian Government policy for the responsible use of AI in government took effect on 15 December 2025 and applies across Commonwealth agencies. It establishes requirements for governance, transparency, risk management, and human oversight.",
+    "sourceUrl": "https://www.digital.gov.au/ai/ai-in-government-policy",
+    "content": "Version 2.0 of the Australian Government policy for the responsible use of AI in government took effect on 15 December 2025. It applies to all non-corporate Commonwealth entities, with limited carve-outs, and establishes mandatory requirements for accountability, transparency, staff training, strategic AI adoption, and risk-based impact assessment.",
     "aiSummary": "Core Commonwealth policy governing responsible AI use in government from 15 December 2025.",
     "tags": ["responsible AI", "governance", "transparency", "commonwealth"],
     "createdAt": "2026-04-06T07:59:40.767Z",
@@ -20,18 +20,18 @@
   },
   {
     "id": "implementation-plan-policy-responsible-use-ai-government-2025",
-    "title": "2025 Implementation Plan for the Policy for the Responsible Use of AI in Government",
-    "description": "Companion implementation plan that sets out how Commonwealth agencies should operationalise the responsible use of AI policy.",
+    "title": "Artificial intelligence | 2025 Implementation Plan",
+    "description": "Artificial intelligence chapter of the Data and Digital Government Strategy 2025 Implementation Plan, covering APS AI adoption, policy updates, standards, and related implementation priorities.",
     "jurisdiction": "federal",
     "type": "guideline",
     "status": "active",
-    "effectiveDate": "2025-12-15",
+    "effectiveDate": "2025-11-17",
     "agencies": [
       "Data and Digital Government Strategy Branch"
     ],
-    "sourceUrl": "https://www.dataanddigital.gov.au/policy-responsible-use-artificial-intelligence-government-2025-implementation-plan",
-    "content": "The implementation plan accompanies the Commonwealth AI policy and outlines delivery, capability uplift, assurance, procurement, and operating expectations for agencies implementing AI systems.",
-    "aiSummary": "Companion implementation plan for rolling out the Commonwealth responsible AI policy across agencies.",
+    "sourceUrl": "https://www.dataanddigital.gov.au/implementation-plan/2025/artificial-intelligence",
+    "content": "The 2025 Implementation Plan's artificial intelligence section summarises how the APS is accelerating AI adoption, lifting workforce capability, implementing the AI Plan for the Australian Public Service, and applying the updated AI in government policy, impact assessment tool, and technical standard. The 2025 implementation-plan page was last updated on 17 November 2025.",
+    "aiSummary": "2025 implementation-plan chapter covering APS AI adoption, governance, and enabling actions, last updated on 17 November 2025.",
     "tags": ["implementation", "responsible AI", "capability uplift", "procurement"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
@@ -66,8 +66,8 @@
     "agencies": [
       "Department of Industry, Science and Resources"
     ],
-    "sourceUrl": "https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence",
-    "content": "The National AI Plan is the Commonwealth's broader economy-wide AI policy plan, covering adoption, capability, ecosystem development, and national coordination.",
+    "sourceUrl": "https://www.industry.gov.au/publications/national-ai-plan",
+    "content": "The National AI Plan is the Australian Government's plan to grow the AI industry in Australia. It sets out steps to build an AI-enabled economy that is more competitive, productive and resilient, with 3 goals: capture the opportunity, spread the benefits, and keep Australians safe.",
     "aiSummary": "National-level AI plan covering economy-wide adoption, capability, and policy direction.",
     "tags": ["national plan", "AI adoption", "investment", "safeguards"],
     "createdAt": "2026-04-06T16:50:00Z",
@@ -93,8 +93,8 @@
   },
   {
     "id": "australias-ai-ethics-framework",
-    "title": "Australia's AI Ethics Framework",
-    "description": "Foundational Australian framework outlining ethics principles for the design and deployment of AI systems.",
+    "title": "Australia's AI Ethics Principles",
+    "description": "Foundational Australian principles outlining responsible design, development, deployment, and oversight expectations for AI systems.",
     "jurisdiction": "federal",
     "type": "framework",
     "status": "active",
@@ -102,9 +102,9 @@
     "agencies": [
       "Department of Industry, Science and Resources"
     ],
-    "sourceUrl": "https://consult.industry.gov.au/australias-ai-ethics-framework",
-    "content": "Australia's AI Ethics Framework remains an important foundational reference point for responsible AI principles, even though newer Commonwealth policies now sit on top of it.",
-    "aiSummary": "Foundational Australian AI ethics framework that predates newer Commonwealth policy instruments.",
+    "sourceUrl": "https://www.industry.gov.au/publications/australias-ai-ethics-principles",
+    "content": "Australia's AI Ethics Principles were published on 7 November 2019 and updated on 2 December 2025. They set out 8 voluntary principles to guide businesses and governments in responsibly designing, developing, and implementing AI.",
+    "aiSummary": "Foundational Australian AI ethics principles published in 2019 and maintained as a current reference point.",
     "tags": ["AI ethics", "framework", "responsible AI", "principles"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
@@ -116,103 +116,103 @@
     "jurisdiction": "federal",
     "type": "regulation",
     "status": "active",
-    "effectiveDate": "2025-03-12",
+    "effectiveDate": "2023-09-28",
     "agencies": [
       "Attorney-General's Department"
     ],
     "sourceUrl": "https://www.ag.gov.au/rights-and-protections/publications/government-response-privacy-act-review-report",
-    "content": "The Government Response sets the current federal position on Privacy Act reform and is more current and decision-useful than the review report alone for AI/privacy policy tracking.",
-    "aiSummary": "Current Commonwealth response on Privacy Act reform with direct relevance to AI, profiling, and automated decision-making.",
+    "content": "The Australian Government released its response to the Privacy Act Review Report on 28 September 2023 and last updated the publication page on 12 March 2025. The response remains relevant to AI policy because it addresses profiling, automated decision-making, and other privacy reforms with downstream implications for AI systems.",
+    "aiSummary": "Commonwealth privacy reform response published on 28 September 2023, with continuing relevance to AI and automated decision-making.",
     "tags": ["privacy", "automated decision-making", "regulation", "Privacy Act"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
   {
     "id": "safe-and-responsible-ai-australia-proposals-paper",
-    "title": "Safe and Responsible AI in Australia — Proposals Paper",
-    "description": "Commonwealth proposals paper outlining options for AI guardrails and regulatory settings in Australia.",
+    "title": "Introducing mandatory guardrails for AI in high-risk settings: proposals paper",
+    "description": "Commonwealth proposals paper consulting on mandatory guardrails, high-risk definitions, and regulatory options for AI in Australia.",
     "jurisdiction": "federal",
     "type": "guideline",
     "status": "proposed",
-    "effectiveDate": "2024-01-17",
+    "effectiveDate": "2024-09-05",
     "agencies": [
       "Department of Industry, Science and Resources"
     ],
-    "sourceUrl": "https://www.industry.gov.au/publications/safe-and-responsible-ai-australia-proposals-paper",
-    "content": "The proposals paper outlines Commonwealth thinking on AI guardrails and regulatory intervention. It is best treated as a policy development / consultation artefact rather than settled policy.",
-    "aiSummary": "Federal proposals paper on AI guardrails and regulation; useful, but not settled policy.",
+    "sourceUrl": "https://consult.industry.gov.au/ai-mandatory-guardrails",
+    "content": "This 2024 proposals paper sought views on proposed mandatory guardrails for AI in high-risk settings, how high-risk AI should be defined, and regulatory options for implementing the guardrails. The consultation opened on 5 September 2024 and has since closed. The current update on the official consultation page states that the Australian Government will not proceed at this time with the previous guardrail proposals, and that feedback informed development of the National AI Plan.",
+    "aiSummary": "2024 federal proposals paper on mandatory AI guardrails in high-risk settings; the government later said it will not proceed with those proposals at this time.",
     "tags": ["AI guardrails", "consultation", "proposals", "responsible AI"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
   {
     "id": "automated-decision-making-ai-regulation-issues-paper",
-    "title": "Automated Decision-Making and AI Regulation Issues Paper",
-    "description": "Attorney-General's Department issues paper exploring regulatory responses to automated decision-making and AI.",
+    "title": "Positioning Australia as a leader in digital economy regulation — Automated Decision Making and AI Regulation",
+    "description": "2022 issues paper consulting on Australia's regulatory settings for automated decision-making and AI.",
     "jurisdiction": "federal",
     "type": "regulation",
     "status": "proposed",
-    "effectiveDate": "2024-09-01",
+    "effectiveDate": "2022-03-17",
     "agencies": [
-      "Attorney-General's Department"
+      "Department of the Prime Minister and Cabinet"
     ],
-    "sourceUrl": "https://www.ag.gov.au/rights-and-protections/publications/automated-decision-making-and-ai-regulation-issues-paper",
-    "content": "This issues paper is a policy development document, not a final rule. It is still important to track because it frames possible future regulation of ADM and AI systems.",
-    "aiSummary": "Federal issues paper on regulating automated decision-making and AI; should be tracked as proposed policy work.",
+    "sourceUrl": "https://consult.industry.gov.au/automated-decision-making-ai-regulation-issues-paper",
+    "content": "The Digital Technology Taskforce consultation on automated decision-making and AI regulation opened on 17 March 2022 and closed on 20 May 2022. It examined how Australia's regulatory settings could better support responsible use of AI and automated decision-making.",
+    "aiSummary": "2022 federal issues paper on regulatory settings for automated decision-making and AI.",
     "tags": ["automated decision-making", "regulation", "AI governance"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
   {
     "id": "nsw-artificial-intelligence-assessment-framework",
-    "title": "NSW Artificial Intelligence Assessment Framework",
+    "title": "NSW AI Assessment Framework",
     "description": "Current NSW whole-of-government framework for assessing AI use cases, risks, and controls across the public sector.",
     "jurisdiction": "nsw",
     "type": "framework",
     "status": "active",
-    "effectiveDate": "2025-08-01",
+    "effectiveDate": "2024-07-01",
     "agencies": [
       "Digital NSW"
     ],
-    "sourceUrl": "https://www.digital.nsw.gov.au/policy/artificial-intelligence/nsw-artificial-intelligence-assessment-framework",
-    "content": "The NSW Artificial Intelligence Assessment Framework is the current Digital NSW framework for evaluating AI use, replacing older shorthand references to an 'AI Assurance Framework.'",
-    "aiSummary": "Current NSW framework for assessing public-sector AI use cases, risk, and safeguards.",
+    "sourceUrl": "https://www.digital.nsw.gov.au/policy/artificial-intelligence/ai-governance-assurance-and-frameworks/nsw-ai-assessment-framework",
+    "content": "The NSW AI Assessment Framework (AIAF) is the current mandatory NSW Government self-assessment framework for AI systems. It operates under Circular DCS-2024-04, issued on 1 July 2024, and is used to identify risks, define mitigations, and escalate higher-risk systems to the AI Review Committee.",
+    "aiSummary": "Current mandatory NSW framework for assessing AI systems under Circular DCS-2024-04.",
     "tags": ["NSW", "assessment framework", "risk management", "public sector"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
   {
     "id": "victoria-genai-guideline-vps",
-    "title": "Administrative Guideline for the Safe and Responsible Use of Generative AI in the Victorian Public Sector",
+    "title": "Administrative Guideline for the safe and responsible use of Generative Artificial Intelligence in the Victorian Public Sector",
     "description": "Current Victorian public-sector guidance on the safe and responsible use of generative AI.",
     "jurisdiction": "vic",
     "type": "guideline",
     "status": "active",
-    "effectiveDate": "2025-02-28",
+    "effectiveDate": "2024-11-27",
     "agencies": [
-      "Victorian Government"
+      "Department of Government Services"
     ],
     "sourceUrl": "https://www.vic.gov.au/administrative-guideline-safe-responsible-use-gen-ai-vps",
-    "content": "Victoria's current official guidance focuses specifically on generative AI use in the Victorian Public Sector and is more current than the older generic 'AI guidelines' wording.",
-    "aiSummary": "Current Victorian guidance for safe and responsible generative AI use in the public sector.",
+    "content": "This guideline was endorsed by the Victorian Secretaries Board on 24 September 2024 and made by the Secretary, Department of Premier and Cabinet, on 27 November 2024. The public page was updated on 12 February 2025. It sets minimum requirements for safe and responsible use of generative AI in the Victorian Public Sector.",
+    "aiSummary": "Victorian public-sector generative AI guideline made in November 2024 and updated in February 2025.",
     "tags": ["Victoria", "generative AI", "guideline", "public sector"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
   {
     "id": "queensland-ai-governance-policy",
-    "title": "QGEA Artificial Intelligence Governance Policy",
+    "title": "Artificial intelligence governance policy",
     "description": "Queensland whole-of-government policy for AI governance under the Queensland Government Enterprise Architecture.",
     "jurisdiction": "qld",
     "type": "guideline",
     "status": "active",
-    "effectiveDate": "2025-02-01",
+    "effectiveDate": "2024-09-01",
     "agencies": [
-      "Queensland Government Customer and Digital Group"
+      "Department of Customer Services, Open Data and Small and Family Business"
     ],
     "sourceUrl": "https://www.forgov.qld.gov.au/information-technology/queensland-government-enterprise-architecture-qgea/qgea-directions-and-guidance/qgea-policies-standards-and-guidelines/artificial-intelligence-governance-policy",
-    "content": "Queensland's current whole-of-government AI governance instrument sits under QGEA and should be tracked instead of a vague 'Queensland AI Strategy' label.",
-    "aiSummary": "Current Queensland whole-of-government AI governance policy under QGEA.",
+    "content": "Queensland's current QGEA artificial intelligence governance policy is a current mandated policy, version 1.0.0, effective from September 2024. It requires agencies to use a consistent evidence-based process for evaluating AI and to establish AI governance arrangements based on ISO 38507. The page was last updated on 8 August 2025.",
+    "aiSummary": "Current mandated Queensland AI governance policy under QGEA, effective from September 2024.",
     "tags": ["Queensland", "AI governance", "QGEA", "public sector"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"

--- a/public/data/sample-policies.json
+++ b/public/data/sample-policies.json
@@ -4,7 +4,7 @@
     "title": "Policy for the Responsible Use of AI in Government",
     "description": "Whole-of-government policy setting mandatory requirements for the safe, transparent, and accountable use of AI by Australian Government agencies.",
     "jurisdiction": "federal",
-    "type": "policy",
+    "type": "guideline",
     "status": "active",
     "effectiveDate": "2025-12-15",
     "agencies": [
@@ -14,7 +14,8 @@
     "sourceUrl": "https://www.digital.gov.au/node/795",
     "content": "The Australian Government policy for the responsible use of AI in government took effect on 15 December 2025 and applies across Commonwealth agencies. It establishes requirements for governance, transparency, risk management, and human oversight.",
     "aiSummary": "Core Commonwealth policy governing responsible AI use in government from 15 December 2025.",
-    "createdAt": "2026-04-06T16:50:00Z",
+    "tags": ["responsible AI", "governance", "transparency", "commonwealth"],
+    "createdAt": "2026-04-06T07:59:40.767Z",
     "updatedAt": "2026-04-06T07:59:40.767Z"
   },
   {
@@ -22,7 +23,7 @@
     "title": "2025 Implementation Plan for the Policy for the Responsible Use of AI in Government",
     "description": "Companion implementation plan that sets out how Commonwealth agencies should operationalise the responsible use of AI policy.",
     "jurisdiction": "federal",
-    "type": "policy",
+    "type": "guideline",
     "status": "active",
     "effectiveDate": "2025-12-15",
     "agencies": [
@@ -31,6 +32,7 @@
     "sourceUrl": "https://www.dataanddigital.gov.au/policy-responsible-use-artificial-intelligence-government-2025-implementation-plan",
     "content": "The implementation plan accompanies the Commonwealth AI policy and outlines delivery, capability uplift, assurance, procurement, and operating expectations for agencies implementing AI systems.",
     "aiSummary": "Companion implementation plan for rolling out the Commonwealth responsible AI policy across agencies.",
+    "tags": ["implementation", "responsible AI", "capability uplift", "procurement"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
@@ -39,7 +41,7 @@
     "title": "AI Plan for the Australian Public Service 2025",
     "description": "APS-wide plan for lifting AI capability, adoption, governance, and public-sector delivery readiness across the Australian Public Service.",
     "jurisdiction": "federal",
-    "type": "policy",
+    "type": "guideline",
     "status": "active",
     "effectiveDate": "2025-11-12",
     "agencies": [
@@ -49,6 +51,7 @@
     "sourceUrl": "https://www.digital.gov.au/policy/ai/australian-public-service-ai-plan-2025",
     "content": "The APS AI Plan 2025 sets direction for how the Australian Public Service should adopt AI responsibly, improve capability, and embed whole-of-service operating practices.",
     "aiSummary": "APS-wide plan for responsible AI adoption, capability, and operating model uplift.",
+    "tags": ["public service", "AI adoption", "capability", "governance"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
@@ -57,15 +60,16 @@
     "title": "National AI Plan",
     "description": "Australian Government national plan setting the broader policy agenda for AI capability, adoption, investment, and safeguards across the economy.",
     "jurisdiction": "federal",
-    "type": "policy",
+    "type": "guideline",
     "status": "active",
     "effectiveDate": "2025-12-02",
     "agencies": [
       "Department of Industry, Science and Resources"
     ],
     "sourceUrl": "https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence",
-    "content": "The National AI Plan is the Commonwealth’s broader economy-wide AI policy plan, covering adoption, capability, ecosystem development, and national coordination.",
+    "content": "The National AI Plan is the Commonwealth's broader economy-wide AI policy plan, covering adoption, capability, ecosystem development, and national coordination.",
     "aiSummary": "National-level AI plan covering economy-wide adoption, capability, and policy direction.",
+    "tags": ["national plan", "AI adoption", "investment", "safeguards"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
@@ -83,6 +87,7 @@
     "sourceUrl": "https://www.industry.gov.au/publications/voluntary-ai-safety-standard",
     "content": "The Voluntary AI Safety Standard provides baseline practices for organisations building and deploying AI, including governance, testing, transparency, and risk management expectations.",
     "aiSummary": "Practical Australian government AI safety standard for organisations building or deploying AI systems.",
+    "tags": ["AI safety", "standard", "risk management", "testing"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
@@ -98,8 +103,9 @@
       "Department of Industry, Science and Resources"
     ],
     "sourceUrl": "https://consult.industry.gov.au/australias-ai-ethics-framework",
-    "content": "Australia’s AI Ethics Framework remains an important foundational reference point for responsible AI principles, even though newer Commonwealth policies now sit on top of it.",
+    "content": "Australia's AI Ethics Framework remains an important foundational reference point for responsible AI principles, even though newer Commonwealth policies now sit on top of it.",
     "aiSummary": "Foundational Australian AI ethics framework that predates newer Commonwealth policy instruments.",
+    "tags": ["AI ethics", "framework", "responsible AI", "principles"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
@@ -108,15 +114,16 @@
     "title": "Government Response to the Privacy Act Review Report",
     "description": "Australian Government response to the Privacy Act Review, including implications for automated decision-making, profiling, and AI-enabled privacy harms.",
     "jurisdiction": "federal",
-    "type": "policy",
+    "type": "regulation",
     "status": "active",
     "effectiveDate": "2025-03-12",
     "agencies": [
-      "Attorney-General’s Department"
+      "Attorney-General's Department"
     ],
     "sourceUrl": "https://www.ag.gov.au/rights-and-protections/publications/government-response-privacy-act-review-report",
     "content": "The Government Response sets the current federal position on Privacy Act reform and is more current and decision-useful than the review report alone for AI/privacy policy tracking.",
     "aiSummary": "Current Commonwealth response on Privacy Act reform with direct relevance to AI, profiling, and automated decision-making.",
+    "tags": ["privacy", "automated decision-making", "regulation", "Privacy Act"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
@@ -125,7 +132,7 @@
     "title": "Safe and Responsible AI in Australia — Proposals Paper",
     "description": "Commonwealth proposals paper outlining options for AI guardrails and regulatory settings in Australia.",
     "jurisdiction": "federal",
-    "type": "policy",
+    "type": "guideline",
     "status": "proposed",
     "effectiveDate": "2024-01-17",
     "agencies": [
@@ -134,23 +141,25 @@
     "sourceUrl": "https://www.industry.gov.au/publications/safe-and-responsible-ai-australia-proposals-paper",
     "content": "The proposals paper outlines Commonwealth thinking on AI guardrails and regulatory intervention. It is best treated as a policy development / consultation artefact rather than settled policy.",
     "aiSummary": "Federal proposals paper on AI guardrails and regulation; useful, but not settled policy.",
+    "tags": ["AI guardrails", "consultation", "proposals", "responsible AI"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
   {
     "id": "automated-decision-making-ai-regulation-issues-paper",
     "title": "Automated Decision-Making and AI Regulation Issues Paper",
-    "description": "Attorney-General’s Department issues paper exploring regulatory responses to automated decision-making and AI.",
+    "description": "Attorney-General's Department issues paper exploring regulatory responses to automated decision-making and AI.",
     "jurisdiction": "federal",
-    "type": "policy",
+    "type": "regulation",
     "status": "proposed",
     "effectiveDate": "2024-09-01",
     "agencies": [
-      "Attorney-General’s Department"
+      "Attorney-General's Department"
     ],
     "sourceUrl": "https://www.ag.gov.au/rights-and-protections/publications/automated-decision-making-and-ai-regulation-issues-paper",
     "content": "This issues paper is a policy development document, not a final rule. It is still important to track because it frames possible future regulation of ADM and AI systems.",
     "aiSummary": "Federal issues paper on regulating automated decision-making and AI; should be tracked as proposed policy work.",
+    "tags": ["automated decision-making", "regulation", "AI governance"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
@@ -166,8 +175,9 @@
       "Digital NSW"
     ],
     "sourceUrl": "https://www.digital.nsw.gov.au/policy/artificial-intelligence/nsw-artificial-intelligence-assessment-framework",
-    "content": "The NSW Artificial Intelligence Assessment Framework is the current Digital NSW framework for evaluating AI use, replacing older shorthand references to an “AI Assurance Framework.”",
+    "content": "The NSW Artificial Intelligence Assessment Framework is the current Digital NSW framework for evaluating AI use, replacing older shorthand references to an 'AI Assurance Framework.'",
     "aiSummary": "Current NSW framework for assessing public-sector AI use cases, risk, and safeguards.",
+    "tags": ["NSW", "assessment framework", "risk management", "public sector"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
@@ -183,8 +193,9 @@
       "Victorian Government"
     ],
     "sourceUrl": "https://www.vic.gov.au/administrative-guideline-safe-responsible-use-gen-ai-vps",
-    "content": "Victoria’s current official guidance focuses specifically on generative AI use in the Victorian Public Sector and is more current than the older generic “AI guidelines” wording.",
+    "content": "Victoria's current official guidance focuses specifically on generative AI use in the Victorian Public Sector and is more current than the older generic 'AI guidelines' wording.",
     "aiSummary": "Current Victorian guidance for safe and responsible generative AI use in the public sector.",
+    "tags": ["Victoria", "generative AI", "guideline", "public sector"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   },
@@ -193,15 +204,16 @@
     "title": "QGEA Artificial Intelligence Governance Policy",
     "description": "Queensland whole-of-government policy for AI governance under the Queensland Government Enterprise Architecture.",
     "jurisdiction": "qld",
-    "type": "policy",
+    "type": "guideline",
     "status": "active",
     "effectiveDate": "2025-02-01",
     "agencies": [
       "Queensland Government Customer and Digital Group"
     ],
     "sourceUrl": "https://www.forgov.qld.gov.au/information-technology/queensland-government-enterprise-architecture-qgea/qgea-directions-and-guidance/qgea-policies-standards-and-guidelines/artificial-intelligence-governance-policy",
-    "content": "Queensland’s current whole-of-government AI governance instrument sits under QGEA and should be tracked instead of a vague “Queensland AI Strategy” label.",
+    "content": "Queensland's current whole-of-government AI governance instrument sits under QGEA and should be tracked instead of a vague 'Queensland AI Strategy' label.",
     "aiSummary": "Current Queensland whole-of-government AI governance policy under QGEA.",
+    "tags": ["Queensland", "AI governance", "QGEA", "public sector"],
     "createdAt": "2026-04-06T16:50:00Z",
     "updatedAt": "2026-04-06T16:50:00Z"
   }

--- a/public/data/sample-timeline.json
+++ b/public/data/sample-timeline.json
@@ -6,7 +6,7 @@
     "description": "Australia releases its voluntary AI Ethics Framework, establishing 8 core principles for responsible AI.",
     "type": "policy_introduced",
     "jurisdiction": "federal",
-    "relatedPolicyId": "1",
+    "relatedPolicyId": "australias-ai-ethics-framework",
     "sourceUrl": "https://www.industry.gov.au/publications/australias-artificial-intelligence-ethics-framework"
   },
   {
@@ -15,17 +15,16 @@
     "title": "CSIRO AI Ethics Principles Adopted",
     "description": "CSIRO adopts internal AI Ethics Principles to guide research activities.",
     "type": "policy_introduced",
-    "jurisdiction": "federal",
-    "relatedPolicyId": "8"
+    "jurisdiction": "federal"
   },
   {
     "id": "3",
-    "date": "2022-03-15",
-    "title": "NSW AI Assurance Framework Launched",
-    "description": "NSW becomes the first Australian state to release a comprehensive AI assurance framework.",
+    "date": "2025-08-01",
+    "title": "NSW Artificial Intelligence Assessment Framework Published",
+    "description": "NSW publishes its current whole-of-government AI assessment framework for public-sector use cases.",
     "type": "policy_introduced",
     "jurisdiction": "nsw",
-    "relatedPolicyId": "3"
+    "relatedPolicyId": "nsw-artificial-intelligence-assessment-framework"
   },
   {
     "id": "4",
@@ -33,35 +32,34 @@
     "title": "DTA Responsible AI Network Established",
     "description": "Federal government establishes the Responsible AI Network to coordinate AI governance.",
     "type": "milestone",
-    "jurisdiction": "federal",
-    "relatedPolicyId": "6"
+    "jurisdiction": "federal"
   },
   {
     "id": "5",
-    "date": "2023-06-01",
+    "date": "2024-09-01",
     "title": "AG Issues Paper on AI Regulation",
     "description": "Attorney-General's Department releases issues paper exploring AI regulatory options.",
     "type": "announcement",
     "jurisdiction": "federal",
-    "relatedPolicyId": "2"
+    "relatedPolicyId": "automated-decision-making-ai-regulation-issues-paper"
   },
   {
     "id": "6",
-    "date": "2023-07-01",
-    "title": "Queensland AI Strategy Released",
-    "description": "Queensland releases its state AI strategy focusing on economic opportunity and governance.",
+    "date": "2025-02-01",
+    "title": "Queensland AI Governance Policy Published",
+    "description": "Queensland publishes its whole-of-government AI governance policy under QGEA.",
     "type": "policy_introduced",
     "jurisdiction": "qld",
-    "relatedPolicyId": "7"
+    "relatedPolicyId": "queensland-ai-governance-policy"
   },
   {
     "id": "7",
-    "date": "2023-09-01",
-    "title": "Victorian AI Guidelines Published",
-    "description": "Victoria publishes guidelines for AI use in the public sector.",
+    "date": "2025-02-28",
+    "title": "Victorian Generative AI Guideline Published",
+    "description": "Victoria publishes its current administrative guideline for safe and responsible generative AI use in the public sector.",
     "type": "policy_introduced",
     "jurisdiction": "vic",
-    "relatedPolicyId": "5"
+    "relatedPolicyId": "victoria-genai-guideline-vps"
   },
   {
     "id": "8",
@@ -73,12 +71,12 @@
   },
   {
     "id": "9",
-    "date": "2024-06-01",
-    "title": "Privacy Act AI Amendments Proposed",
-    "description": "Proposed amendments to Privacy Act addressing AI and automated decision-making.",
+    "date": "2025-03-12",
+    "title": "Privacy Act Review Response Released",
+    "description": "The Australian Government releases its response to the Privacy Act Review, including positions relevant to AI and automated decision-making.",
     "type": "policy_introduced",
     "jurisdiction": "federal",
-    "relatedPolicyId": "4"
+    "relatedPolicyId": "government-response-privacy-act-review-report"
   },
   {
     "id": "10",
@@ -95,7 +93,7 @@
     "description": "Digital Transformation Agency releases Version 2.0 of the Policy for the Responsible Use of AI in Government, introducing mandatory requirements for transparency statements, accountable officials, use case registers, and risk-based impact assessments.",
     "type": "policy_introduced",
     "jurisdiction": "federal",
-    "relatedPolicyId": "dta-ai-policy-v2",
+    "relatedPolicyId": "policy-responsible-use-ai-government-v2",
     "sourceUrl": "https://www.digital.gov.au/ai/ai-in-government-policy"
   }
 ]

--- a/public/data/sample-timeline.json
+++ b/public/data/sample-timeline.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "1",
-    "date": "2019-11-01",
-    "title": "AI Ethics Framework Released",
-    "description": "Australia releases its voluntary AI Ethics Framework, establishing 8 core principles for responsible AI.",
+    "date": "2019-11-07",
+    "title": "AI Ethics Principles Published",
+    "description": "Australia publishes its voluntary AI Ethics Principles, establishing 8 principles for responsible AI.",
     "type": "policy_introduced",
     "jurisdiction": "federal",
     "relatedPolicyId": "australias-ai-ethics-framework",
-    "sourceUrl": "https://www.industry.gov.au/publications/australias-artificial-intelligence-ethics-framework"
+    "sourceUrl": "https://www.industry.gov.au/publications/australias-ai-ethics-principles"
   },
   {
     "id": "2",
@@ -19,9 +19,9 @@
   },
   {
     "id": "3",
-    "date": "2025-08-01",
-    "title": "NSW Artificial Intelligence Assessment Framework Published",
-    "description": "NSW publishes its current whole-of-government AI assessment framework for public-sector use cases.",
+    "date": "2024-07-01",
+    "title": "NSW AI Assessment Framework Made Mandatory",
+    "description": "NSW Circular DCS-2024-04 requires agencies using AI to apply the NSW AI Assessment Framework and AI Ethics Policy.",
     "type": "policy_introduced",
     "jurisdiction": "nsw",
     "relatedPolicyId": "nsw-artificial-intelligence-assessment-framework"
@@ -36,16 +36,16 @@
   },
   {
     "id": "5",
-    "date": "2024-09-01",
-    "title": "AG Issues Paper on AI Regulation",
-    "description": "Attorney-General's Department releases issues paper exploring AI regulatory options.",
+    "date": "2022-03-17",
+    "title": "ADM and AI Regulation Issues Paper Released",
+    "description": "The Digital Technology Taskforce launches consultation on automated decision-making and AI regulation.",
     "type": "announcement",
     "jurisdiction": "federal",
     "relatedPolicyId": "automated-decision-making-ai-regulation-issues-paper"
   },
   {
     "id": "6",
-    "date": "2025-02-01",
+    "date": "2024-09-01",
     "title": "Queensland AI Governance Policy Published",
     "description": "Queensland publishes its whole-of-government AI governance policy under QGEA.",
     "type": "policy_introduced",
@@ -54,7 +54,7 @@
   },
   {
     "id": "7",
-    "date": "2025-02-28",
+    "date": "2024-11-27",
     "title": "Victorian Generative AI Guideline Published",
     "description": "Victoria publishes its current administrative guideline for safe and responsible generative AI use in the public sector.",
     "type": "policy_introduced",
@@ -63,15 +63,16 @@
   },
   {
     "id": "8",
-    "date": "2024-01-15",
-    "title": "National AI Consultation Begins",
-    "description": "Federal government launches national consultation on mandatory AI guardrails.",
+    "date": "2024-09-05",
+    "title": "Mandatory Guardrails Proposals Paper Released",
+    "description": "The Australian Government releases its proposals paper on mandatory AI guardrails for high-risk settings.",
     "type": "announcement",
-    "jurisdiction": "federal"
+    "jurisdiction": "federal",
+    "relatedPolicyId": "safe-and-responsible-ai-australia-proposals-paper"
   },
   {
     "id": "9",
-    "date": "2025-03-12",
+    "date": "2023-09-28",
     "title": "Privacy Act Review Response Released",
     "description": "The Australian Government releases its response to the Privacy Act Review, including positions relevant to AI and automated decision-making.",
     "type": "policy_introduced",
@@ -80,11 +81,12 @@
   },
   {
     "id": "10",
-    "date": "2025-01-01",
-    "title": "AI Safety Framework Expected",
-    "description": "Federal government expected to release mandatory AI safety framework.",
-    "type": "milestone",
-    "jurisdiction": "federal"
+    "date": "2025-12-02",
+    "title": "National AI Plan Released",
+    "description": "The Australian Government publishes the National AI Plan setting out its economy-wide direction for AI.",
+    "type": "policy_introduced",
+    "jurisdiction": "federal",
+    "relatedPolicyId": "national-ai-plan-2025"
   },
   {
     "id": "11",

--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
 export const metadata = {
-  title: 'AI in Government Policy Framework | Policai',
+  title: 'Policy for the Responsible Use of AI in Government | Policai',
   description: 'Interactive visualization of Australia\'s Policy for the Responsible Use of AI in Government',
 };
 

--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -87,13 +87,23 @@ export default function FrameworkPage() {
         </p>
         <div className="mt-4 flex flex-wrap gap-4 text-xs text-muted-foreground">
           <div>
-            <span className="font-medium">Last Updated:</span>{' '}
+            <span className="font-medium">Effective:</span>{' '}
             {new Date(frameworkData.effectiveDate).toLocaleDateString('en-AU', {
               year: 'numeric',
               month: 'long',
               day: 'numeric',
             })}
           </div>
+          {frameworkData.lastUpdated && (
+            <div>
+              <span className="font-medium">Page Updated:</span>{' '}
+              {new Date(frameworkData.lastUpdated).toLocaleDateString('en-AU', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </div>
+          )}
           <div>
             <span className="font-medium">Version:</span> {frameworkData.version}
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ const plexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'Policai — Australian AI Policy Tracker',
+  title: 'Policai — Australian AI Policy / Government AI Tracker',
   description:
     'Search and browse Australian AI policy, regulation, and governance developments across federal and state jurisdictions.',
   keywords: [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ const plexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'Policai — Australian AI Policy / Government AI Tracker',
+  title: 'Policai — Australian AI Policy and Governance Tracker',
   description:
     'Search and browse Australian AI policy, regulation, and governance developments across federal and state jurisdictions.',
   keywords: [


### PR DESCRIPTION
## What

Refresh Policai's bundled policy dataset and related site framing so the app reflects a more current Australian AI policy set.

## Changes

- update  from 10 to 12 curated records
- replace stale / misnamed entries:
  - NSW AI Assurance Framework -> NSW Artificial Intelligence Assessment Framework
  - Victorian Public Sector AI Guidelines -> current Victorian generative AI guideline
  - Queensland AI Strategy -> QGEA Artificial Intelligence Governance Policy
- add missing major federal items:
  - AI Plan for the Australian Public Service 2025
  - National AI Plan
  - Voluntary AI Safety Standard
  - Government Response to the Privacy Act Review Report
  - Safe and Responsible AI in Australia — Proposals Paper
- tighten README and page metadata / framework copy to match current scope and naming

## Why

The live site appears to be serving the bundled sample dataset, and that dataset had stale or incomplete policy coverage. This PR gets the shipped fallback data much closer to current reality.

## Important follow-up

Production writes appear broken (/ to  return 500), which suggests the deployed app is not successfully using a writable live store right now. This PR fixes the bundled dataset, but the Supabase/live-write path still needs a separate pass.
