### PR TITLE
Add a dismissible site disclaimer banner

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
+import { SiteDisclaimerBanner } from '@/components/layout/SiteDisclaimerBanner';
 
 const navItems = [
   { href: '/', label: 'Policies' },
@@ -51,6 +52,7 @@ export function Header() {
 
   return (
     <header className="sticky top-0 z-50 w-full border-b-2 border-foreground bg-background">
+      <SiteDisclaimerBanner />
       <div className="container mx-auto flex h-12 items-center px-4">
         <Link href="/" className="font-sans text-lg font-bold tracking-wide uppercase">
           Policai

--- a/src/components/layout/SiteDisclaimerBanner.tsx
+++ b/src/components/layout/SiteDisclaimerBanner.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+const DISMISS_KEY = 'policai-dismissed-site-disclaimer';
+const GITHUB_URL = 'https://github.com/l0cka/policai';
+
+export function SiteDisclaimerBanner() {
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false;
+    }
+
+    return window.localStorage.getItem(DISMISS_KEY) === 'true';
+  });
+
+  const handleDismiss = () => {
+    window.localStorage.setItem(DISMISS_KEY, 'true');
+    setDismissed(true);
+  };
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <div className="border-b border-foreground/20 bg-muted/60">
+      <div className="container mx-auto flex items-start gap-3 px-4 py-3 sm:items-center">
+        <p className="flex-1 text-sm leading-6 text-foreground/85">
+          Policai is a work in progress and is not regularly maintained. It is open source, and
+          contributions are encouraged via{' '}
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium underline underline-offset-4 transition-colors hover:text-foreground"
+          >
+            GitHub
+          </a>
+          .
+        </p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={handleDismiss}
+          className="mt-0.5 shrink-0 text-muted-foreground hover:text-foreground sm:mt-0"
+          aria-label="Dismiss site disclaimer"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/SiteDisclaimerBanner.tsx
+++ b/src/components/layout/SiteDisclaimerBanner.tsx
@@ -1,24 +1,45 @@
 'use client';
 
-import { useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import { X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const DISMISS_KEY = 'policai-dismissed-site-disclaimer';
 const GITHUB_URL = 'https://github.com/l0cka/policai';
+const DISMISS_EVENT = 'policai-disclaimer-dismissed';
+
+function subscribe(onStoreChange: () => void) {
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === DISMISS_KEY) {
+      onStoreChange();
+    }
+  };
+
+  const handleDismiss = () => onStoreChange();
+
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener(DISMISS_EVENT, handleDismiss);
+
+  return () => {
+    window.removeEventListener('storage', handleStorage);
+    window.removeEventListener(DISMISS_EVENT, handleDismiss);
+  };
+}
+
+function getDismissedSnapshot() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.localStorage.getItem(DISMISS_KEY) === 'true';
+}
 
 export function SiteDisclaimerBanner() {
-  const [dismissed, setDismissed] = useState(() => {
-    if (typeof window === 'undefined') {
-      return false;
-    }
-
-    return window.localStorage.getItem(DISMISS_KEY) === 'true';
-  });
+  const dismissed = useSyncExternalStore(subscribe, getDismissedSnapshot, () => false);
 
   const handleDismiss = () => {
     window.localStorage.setItem(DISMISS_KEY, 'true');
-    setDismissed(true);
+    window.dispatchEvent(new Event(DISMISS_EVENT));
   };
 
   if (dismissed) {


### PR DESCRIPTION
## Summary
- add a site-wide disclaimer banner above the header navigation
- explain that the project is a work in progress, not regularly maintained, and open to GitHub contributions
- persist dismissal state in `localStorage` so the banner stays hidden after being closed

## Testing
- `npx eslint src/components/layout/Header.tsx src/components/layout/SiteDisclaimerBanner.tsx`