### PR TITLE
feat: make scraper system fully autonomous

### DIFF
--- a/src/app/api/admin/pipeline/route.ts
+++ b/src/app/api/admin/pipeline/route.ts
@@ -11,19 +11,11 @@ import {
   approvePipelineRun,
   rejectPipelineRun,
 } from '@/lib/agents/pipeline';
-import fs from 'fs/promises';
-import path from 'path';
-
-const POLICIES_FILE = path.join(process.cwd(), 'public', 'data', 'sample-policies.json');
+import { getPolicies } from '@/lib/data-service';
 
 async function getExistingPolicyTitles(): Promise<string[]> {
-  try {
-    const data = await fs.readFile(POLICIES_FILE, 'utf-8');
-    const policies = JSON.parse(data);
-    return policies.map((p: { title: string }) => p.title);
-  } catch {
-    return [];
-  }
+  const policies = await getPolicies();
+  return policies.map((p) => p.title);
 }
 
 /**

--- a/src/app/api/admin/run-scraper/route.ts
+++ b/src/app/api/admin/run-scraper/route.ts
@@ -1,44 +1,9 @@
 import { NextResponse } from 'next/server';
-import { analyseContentRelevance } from '@/lib/claude';
+import { analyseContentRelevance, type ContentAnalysis } from '@/lib/claude';
 import { verifyAuth, unauthorizedResponse } from '@/lib/auth';
 import * as cheerio from 'cheerio';
 import { cleanHtmlContent } from '@/lib/utils';
-
-// Data source URLs mapping
-const DATA_SOURCES = {
-  'source-1': {
-    name: 'DTA AI Policy',
-    url: 'https://www.dta.gov.au/our-projects/artificial-intelligence',
-  },
-  'source-2': {
-    name: 'DISER AI Strategy',
-    url: 'https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence',
-  },
-  'source-3': {
-    name: 'CSIRO Data61',
-    url: 'https://www.csiro.au/en/research/technology-space/ai',
-  },
-  'source-4': {
-    name: 'AHRC AI Ethics',
-    url: 'https://humanrights.gov.au/our-work/technology-and-human-rights',
-  },
-  'source-5': {
-    name: 'OAIC AI Guidance',
-    url: 'https://www.oaic.gov.au/privacy/guidance-and-advice/artificial-intelligence-and-privacy',
-  },
-  'source-6': {
-    name: 'NSW Digital AI',
-    url: 'https://www.digital.nsw.gov.au/policy/artificial-intelligence',
-  },
-  'source-7': {
-    name: 'Victorian AI Strategy',
-    url: 'https://www.vic.gov.au/artificial-intelligence-strategy',
-  },
-  'source-8': {
-    name: 'ACCC Digital Platforms',
-    url: 'https://www.accc.gov.au/focus-areas/digital-platforms-and-services',
-  },
-} as const;
+import { DATA_SOURCES_MAP } from '@/lib/data-sources';
 
 interface ScrapedLink {
   url: string;
@@ -138,7 +103,7 @@ async function fetchContent(url: string): Promise<string> {
 /**
  * Create a policy from analyzed content
  */
-async function createPolicy(title: string, url: string, analysis: any, content: string) {
+async function createPolicy(title: string, url: string, analysis: ContentAnalysis, content: string) {
   const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3002'}/api/policies`, {
     method: 'POST',
     headers: {
@@ -169,7 +134,7 @@ async function createPolicy(title: string, url: string, analysis: any, content: 
 /**
  * Add content to pending review queue
  */
-async function addToPendingReview(title: string, url: string, analysis: any) {
+async function addToPendingReview(title: string, url: string, analysis: ContentAnalysis) {
   const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3002'}/api/admin/pending`, {
     method: 'POST',
     headers: {
@@ -218,7 +183,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const source = DATA_SOURCES[sourceId as keyof typeof DATA_SOURCES];
+    const source = DATA_SOURCES_MAP[sourceId];
     if (!source) {
       return NextResponse.json(
         { error: 'Invalid sourceId', success: false },

--- a/src/app/api/cron/pipeline/route.ts
+++ b/src/app/api/cron/pipeline/route.ts
@@ -1,0 +1,74 @@
+/**
+ * Vercel Cron endpoint — runs the full AI research pipeline.
+ *
+ * Triggered weekly (see vercel.json). Runs the research agent, verifier agent,
+ * and auto-approves high-confidence findings for implementation.
+ *
+ * Protected by CRON_SECRET so only Vercel infrastructure can invoke it.
+ */
+
+import { NextResponse } from 'next/server';
+import { startPipelineRun } from '@/lib/agents/pipeline';
+import { getPolicies } from '@/lib/data-service';
+
+export const maxDuration = 300;
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (!cronSecret) {
+    console.error('[cron/pipeline] CRON_SECRET is not configured');
+    return NextResponse.json(
+      { error: 'CRON_SECRET not configured', success: false },
+      { status: 500 },
+    );
+  }
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      { error: 'ANTHROPIC_API_KEY not configured', success: false },
+      { status: 500 },
+    );
+  }
+
+  console.log(`[cron/pipeline] Starting pipeline at ${new Date().toISOString()}`);
+
+  try {
+    const policies = await getPolicies();
+    const existingTitles = policies.map((p) => p.title);
+
+    const run = await startPipelineRun(existingTitles, {
+      autoApprove: true,
+      autoApproveThreshold: 0.8,
+    });
+
+    console.log(`[cron/pipeline] Completed. Stage: ${run.stage}, Implemented: ${run.implementedCount}`);
+
+    return NextResponse.json({
+      success: true,
+      timestamp: new Date().toISOString(),
+      run: {
+        id: run.id,
+        stage: run.stage,
+        findingsCount: run.findingsCount,
+        verifiedCount: run.verifiedCount,
+        implementedCount: run.implementedCount,
+        rejectedCount: run.rejectedCount,
+      },
+    });
+  } catch (error) {
+    console.error('[cron/pipeline] Failed:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Pipeline failed',
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/cron/scrape/route.ts
+++ b/src/app/api/cron/scrape/route.ts
@@ -4,18 +4,22 @@
  * Triggered by Vercel Cron Jobs on schedule (see vercel.json).
  * Protected by CRON_SECRET so only Vercel infrastructure can invoke it.
  *
- * The scraper logic runs inline — no HTTP calls to localhost required.
+ * Fan-out strategy:
+ * - Without ?source= param: dispatches one request per enabled source
+ *   using waitUntil() so the fan-out doesn't block the response.
+ * - With ?source=<sourceId>: scrapes only that single source, keeping
+ *   each invocation well under the 300s timeout.
  */
 
 import { NextResponse } from 'next/server';
+import { after } from 'next/server';
 import * as cheerio from 'cheerio';
 import { analyseContentRelevance, summarizePolicy } from '@/lib/claude';
 import { cleanHtmlContent } from '@/lib/utils';
 import { DATA_SOURCES, type DataSource } from '@/lib/data-sources';
-import { createPolicy, policyExists } from '@/lib/data-service';
+import { createPolicy, policyExists, logScraperRun } from '@/lib/data-service';
 import type { Policy } from '@/types';
 
-// Allow long-running (Vercel Cron timeout is 60s on Hobby, 300s on Pro)
 export const maxDuration = 300;
 
 // ---------------------------------------------------------------------------
@@ -89,7 +93,7 @@ async function fetchContent(url: string): Promise<string> {
   return cleanHtmlContent(await response.text());
 }
 
-/** Build and persist a new policy from analysed content. */
+/** Build and persist a new policy from analysed content via data-service. */
 async function processHighConfidenceLink(
   title: string,
   url: string,
@@ -113,7 +117,6 @@ async function processHighConfidenceLink(
     return false;
   }
 
-  // Optionally generate a richer AI summary
   let aiSummary = analysis.summary || '';
   if (process.env.ANTHROPIC_API_KEY) {
     try {
@@ -153,6 +156,7 @@ async function processHighConfidenceLink(
 // ---------------------------------------------------------------------------
 
 async function scrapeSource(source: DataSource) {
+  const startTime = Date.now();
   console.log(`[cron] Scraping: ${source.name} (${source.url})`);
 
   const links = await scrapeLinks(source.url);
@@ -160,6 +164,7 @@ async function scrapeSource(source: DataSource) {
 
   let created = 0;
   let skipped = 0;
+  const errors: string[] = [];
 
   for (const link of links) {
     try {
@@ -182,20 +187,35 @@ async function scrapeSource(source: DataSource) {
       // Rate limit between pages
       await new Promise((r) => setTimeout(r, 2000));
     } catch (err) {
-      console.error(`[cron] Error processing ${link.url}:`, err);
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      console.error(`[cron] Error processing ${link.url}:`, msg);
+      errors.push(`${link.url}: ${msg}`);
       skipped++;
     }
   }
 
-  return { source: source.name, linksFound: links.length, created, skipped };
+  const durationMs = Date.now() - startTime;
+
+  // Log the run for monitoring
+  await logScraperRun({
+    id: `cron-${source.id}-${Date.now()}`,
+    timestamp: new Date().toISOString(),
+    sourceId: source.id,
+    sourceName: source.name,
+    linksFound: links.length,
+    policiesCreated: created,
+    errors,
+    durationMs,
+  });
+
+  return { source: source.name, linksFound: links.length, created, skipped, errors };
 }
 
 // ---------------------------------------------------------------------------
-// Route handler
+// Auth helper
 // ---------------------------------------------------------------------------
 
-export async function GET(request: Request) {
-  // Verify the request is from Vercel Cron
+function verifyCronAuth(request: Request): NextResponse | null {
   const authHeader = request.headers.get('authorization');
   const cronSecret = process.env.CRON_SECRET;
 
@@ -218,38 +238,62 @@ export async function GET(request: Request) {
     );
   }
 
-  console.log(`[cron] Starting scheduled scrape at ${new Date().toISOString()}`);
+  return null;
+}
 
-  const results = [];
-  const enabledSources = DATA_SOURCES.filter((s) => s.enabled);
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
 
-  for (const source of enabledSources) {
-    try {
-      const result = await scrapeSource(source);
-      results.push(result);
-    } catch (err) {
-      console.error(`[cron] Failed to scrape ${source.name}:`, err);
-      results.push({
-        source: source.name,
-        linksFound: 0,
-        created: 0,
-        skipped: 0,
-        error: err instanceof Error ? err.message : 'Unknown error',
-      });
+export async function GET(request: Request) {
+  const authError = verifyCronAuth(request);
+  if (authError) return authError;
+
+  const url = new URL(request.url);
+  const sourceId = url.searchParams.get('source');
+
+  // Single source mode — scrape just one source
+  if (sourceId) {
+    const source = DATA_SOURCES.find((s) => s.id === sourceId && s.enabled);
+    if (!source) {
+      return NextResponse.json(
+        { error: `Source not found or disabled: ${sourceId}`, success: false },
+        { status: 404 },
+      );
     }
 
-    // Rate limit between sources
-    await new Promise((r) => setTimeout(r, 5000));
+    const result = await scrapeSource(source);
+    return NextResponse.json({ success: true, result });
   }
 
-  const totalCreated = results.reduce((sum, r) => sum + r.created, 0);
-  console.log(`[cron] Completed. Created ${totalCreated} new policies from ${enabledSources.length} sources.`);
+  // Fan-out mode — dispatch one request per enabled source
+  console.log(`[cron] Starting fan-out scrape at ${new Date().toISOString()}`);
+  const enabledSources = DATA_SOURCES.filter((s) => s.enabled);
+
+  const cronSecret = process.env.CRON_SECRET!;
+
+  after(async () => {
+    for (const source of enabledSources) {
+      try {
+        const sourceUrl = new URL(url.pathname, url.origin);
+        sourceUrl.searchParams.set('source', source.id);
+
+        await fetch(sourceUrl.toString(), {
+          headers: { Authorization: `Bearer ${cronSecret}` },
+        });
+      } catch (err) {
+        console.error(`[cron] Failed to dispatch ${source.name}:`, err);
+      }
+
+      // Stagger dispatches by 2s to avoid thundering herd
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  });
 
   return NextResponse.json({
     success: true,
+    dispatched: true,
+    sources: enabledSources.map((s) => s.id),
     timestamp: new Date().toISOString(),
-    sourcesScanned: enabledSources.length,
-    totalCreated,
-    results,
   });
 }

--- a/src/lib/agents/implementation-agent.ts
+++ b/src/lib/agents/implementation-agent.ts
@@ -1,25 +1,18 @@
 import Anthropic from '@anthropic-ai/sdk';
-import path from 'path';
 import type { ResearchFinding, VerificationResult, Policy } from '@/types';
 import { updateFindingStatus } from './pipeline-storage';
 import { extractJsonFromResponse } from '@/lib/utils';
-import { readJsonFile, writeJsonFile } from '@/lib/file-store';
+import {
+  getPolicies,
+  createPolicy as createPolicyInDb,
+  updatePolicy as updatePolicyInDb,
+} from '@/lib/data-service';
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY || '',
 });
 
 const MODEL = 'claude-sonnet-4-20250514';
-
-const POLICIES_FILE = path.join(process.cwd(), 'public', 'data', 'sample-policies.json');
-
-async function loadPolicies(): Promise<Policy[]> {
-  return readJsonFile<Policy[]>(POLICIES_FILE, []);
-}
-
-async function savePolicies(policies: Policy[]) {
-  return writeJsonFile(POLICIES_FILE, policies);
-}
 
 /**
  * Generate a proper policy entry from a verified finding using Claude
@@ -137,7 +130,7 @@ export async function runImplementationAgent(
   let updatedCount = 0;
   let skippedCount = 0;
 
-  const policies = await loadPolicies();
+  const policies = await getPolicies();
   const verificationMap = new Map(verifications.map(v => [v.findingId, v]));
 
   // Only implement verified findings
@@ -166,18 +159,15 @@ export async function runImplementationAgent(
       );
 
       if (existingPolicy && !finding.isNewPolicy) {
-        // Update existing policy
+        // Update existing policy via data-service
         const policyData = await generatePolicyEntry(finding, verification);
-        const idx = policies.findIndex(p => p.id === existingPolicy.id);
 
-        policies[idx] = {
-          ...existingPolicy,
+        await updatePolicyInDb(existingPolicy.id, {
           description: policyData.description,
           aiSummary: policyData.aiSummary,
           tags: [...new Set([...existingPolicy.tags, ...policyData.tags])],
           agencies: [...new Set([...existingPolicy.agencies, ...policyData.agencies])],
-          updatedAt: new Date().toISOString(),
-        };
+        });
 
         await updateFindingStatus(finding.id, 'implemented');
         results.push({
@@ -187,7 +177,7 @@ export async function runImplementationAgent(
         });
         updatedCount++;
       } else {
-        // Create new policy
+        // Create new policy via data-service
         const policyData = await generatePolicyEntry(finding, verification);
         const policyId = generatePolicyId(policyData.title);
 
@@ -210,7 +200,7 @@ export async function runImplementationAgent(
           updatedAt: new Date().toISOString(),
         };
 
-        policies.push(newPolicy);
+        await createPolicyInDb(newPolicy);
         await updateFindingStatus(finding.id, 'implemented');
         results.push({
           findingId: finding.id,
@@ -235,9 +225,6 @@ export async function runImplementationAgent(
       skippedCount++;
     }
   }
-
-  // Save updated policies
-  await savePolicies(policies);
 
   console.log(`[Implementation Agent] Complete. Created: ${createdCount}, Updated: ${updatedCount}, Skipped: ${skippedCount}`);
 

--- a/src/lib/agents/pipeline.ts
+++ b/src/lib/agents/pipeline.ts
@@ -18,6 +18,13 @@ function generateRunId(): string {
   return `run-${date}-${rand}`;
 }
 
+export interface PipelineOptions {
+  /** Skip HITL for high-confidence findings and auto-implement them. */
+  autoApprove?: boolean;
+  /** Verification confidence threshold for auto-approve (default 0.8). */
+  autoApproveThreshold?: number;
+}
+
 /**
  * Start a new pipeline run - executes the Research Agent and Verifier Agent,
  * then pauses for HITL review before implementation.
@@ -27,12 +34,13 @@ function generateRunId(): string {
  * 2. research_complete -> Findings stored
  * 3. verification    -> Verifier Agent checks findings
  * 4. verification_complete -> HITL checkpoint #1 (post-verification)
- * 5. hitl_review     -> Waiting for human approval
+ * 5. hitl_review     -> Waiting for human approval (skipped if autoApprove)
  * 6. implementation  -> Implementation Agent applies changes
  * 7. complete        -> Done
  */
 export async function startPipelineRun(
-  existingPolicyTitles: string[]
+  existingPolicyTitles: string[],
+  options?: PipelineOptions,
 ): Promise<PipelineRun> {
   const runId = generateRunId();
   const run: PipelineRun = {
@@ -74,8 +82,47 @@ export async function startPipelineRun(
     run.rejectedCount = verifierResult.rejectedCount;
     await updateStage(run, 'verification_complete');
 
-    // Stage 3: HITL checkpoint - pause for human review
-    // The pipeline stops here. An admin must call approvePipelineRun() to continue.
+    // Stage 3: HITL checkpoint or auto-approve
+    const autoApprove = options?.autoApprove ?? false;
+    const threshold = options?.autoApproveThreshold ?? 0.8;
+
+    if (autoApprove) {
+      // Auto-approve verified findings above the confidence threshold
+      const allFindings = await getFindings(runId);
+      const allVerifications = await getVerifications(runId);
+      const verificationMap = new Map(allVerifications.map(v => [v.findingId, v]));
+
+      const highConfFindings = allFindings.filter(f => {
+        if (f.status !== 'verified') return false;
+        const v = verificationMap.get(f.id);
+        return v && v.confidenceScore >= threshold;
+      });
+
+      if (highConfFindings.length > 0) {
+        console.log(`[Pipeline] Auto-approving ${highConfFindings.length} high-confidence findings (threshold: ${threshold})`);
+
+        run.hitlApprovedAt = new Date().toISOString();
+        run.hitlApprovedBy = 'auto';
+        run.hitlNotes = `Auto-approved ${highConfFindings.length} findings with confidence >= ${threshold}`;
+
+        await updateStage(run, 'implementation');
+        const implResult = await runImplementationAgent(highConfFindings, allVerifications);
+        run.implementedCount = implResult.createdCount + implResult.updatedCount;
+
+        run.completedAt = new Date().toISOString();
+        await updateStage(run, 'complete');
+
+        console.log(`[Pipeline] Run ${runId} auto-completed. Implemented: ${run.implementedCount}`);
+      } else {
+        run.completedAt = new Date().toISOString();
+        await updateStage(run, 'complete');
+        console.log(`[Pipeline] Run ${runId} completed. No findings met auto-approve threshold.`);
+      }
+
+      return run;
+    }
+
+    // Manual mode: pause for human review
     await updateStage(run, 'hitl_review');
 
     console.log(`[Pipeline] Run ${runId} paused at HITL review.`);

--- a/src/lib/agents/research-agent.ts
+++ b/src/lib/agents/research-agent.ts
@@ -3,6 +3,7 @@ import * as cheerio from 'cheerio';
 import type { ResearchFinding, PolicyType, Jurisdiction } from '@/types';
 import { saveFindings } from './pipeline-storage';
 import { cleanHtmlContent, extractJsonFromResponse } from '@/lib/utils';
+import { DATA_SOURCES } from '@/lib/data-sources';
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY || '',
@@ -10,49 +11,7 @@ const anthropic = new Anthropic({
 
 const MODEL = 'claude-sonnet-4-20250514';
 
-// Australian government AI policy sources
-const RESEARCH_SOURCES = [
-  {
-    id: 'dta',
-    name: 'DTA AI Policy',
-    url: 'https://www.dta.gov.au/our-projects/artificial-intelligence',
-  },
-  {
-    id: 'diser',
-    name: 'DISER AI Strategy',
-    url: 'https://www.industry.gov.au/science-technology-and-innovation/technology/artificial-intelligence',
-  },
-  {
-    id: 'csiro',
-    name: 'CSIRO Data61',
-    url: 'https://www.csiro.au/en/research/technology-space/ai',
-  },
-  {
-    id: 'ahrc',
-    name: 'AHRC AI Ethics',
-    url: 'https://humanrights.gov.au/our-work/technology-and-human-rights',
-  },
-  {
-    id: 'oaic',
-    name: 'OAIC AI Guidance',
-    url: 'https://www.oaic.gov.au/privacy/guidance-and-advice/artificial-intelligence-and-privacy',
-  },
-  {
-    id: 'nsw',
-    name: 'NSW Digital AI',
-    url: 'https://www.digital.nsw.gov.au/policy/artificial-intelligence',
-  },
-  {
-    id: 'vic',
-    name: 'Victorian AI Strategy',
-    url: 'https://www.vic.gov.au/artificial-intelligence-strategy',
-  },
-  {
-    id: 'accc',
-    name: 'ACCC Digital Platforms',
-    url: 'https://www.accc.gov.au/focus-areas/digital-platforms-and-services',
-  },
-];
+const RESEARCH_SOURCES = DATA_SOURCES.filter((s) => s.enabled);
 
 interface ScrapedPage {
   url: string;

--- a/src/lib/data-service.ts
+++ b/src/lib/data-service.ts
@@ -11,7 +11,7 @@
 
 import path from 'path';
 import { readJsonFile, writeJsonFile } from '@/lib/file-store';
-import type { Policy, Agency, TimelineEvent } from '@/types';
+import type { Policy, Agency, TimelineEvent, ScraperRunLog } from '@/types';
 
 // ---------------------------------------------------------------------------
 // Supabase availability
@@ -295,4 +295,48 @@ export async function getTimelineEvents(filters?: {
     events = events.filter((e) => e.jurisdiction === filters.jurisdiction);
   }
   return events.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}
+
+// ---------------------------------------------------------------------------
+// Scraper run logging
+// ---------------------------------------------------------------------------
+
+const SCRAPER_RUNS_FILE = path.join(process.cwd(), 'public', 'data', 'scraper-runs.json');
+
+export async function logScraperRun(run: ScraperRunLog): Promise<void> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      const { error } = await supabase.from('scraper_runs').insert(run);
+      if (!error) return;
+      console.warn('[data-service] Supabase logScraperRun failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase logScraperRun exception, falling back to JSON:', err);
+    }
+  }
+
+  const runs = await readJsonFile<ScraperRunLog[]>(SCRAPER_RUNS_FILE, []);
+  runs.unshift(run);
+  // Keep only the last 100 runs in JSON to prevent unbounded growth
+  await writeJsonFile(SCRAPER_RUNS_FILE, runs.slice(0, 100));
+}
+
+export async function getRecentScraperRuns(limit = 20): Promise<ScraperRunLog[]> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      const { data, error } = await supabase
+        .from('scraper_runs')
+        .select('*')
+        .order('timestamp', { ascending: false })
+        .limit(limit);
+      if (!error && data) return data as ScraperRunLog[];
+      console.warn('[data-service] Supabase getRecentScraperRuns failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase getRecentScraperRuns exception, falling back to JSON:', err);
+    }
+  }
+
+  const runs = await readJsonFile<ScraperRunLog[]>(SCRAPER_RUNS_FILE, []);
+  return runs.slice(0, limit);
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -222,6 +222,17 @@ export interface VerificationResult {
   suggestedCorrections: string[];
 }
 
+export interface ScraperRunLog {
+  id: string;
+  timestamp: string;
+  sourceId: string;
+  sourceName: string;
+  linksFound: number;
+  policiesCreated: number;
+  errors: string[];
+  durationMs: number;
+}
+
 export interface PipelineRun {
   id: string;
   startedAt: string;

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/scrape",
       "schedule": "0 2 * * *"
+    },
+    {
+      "path": "/api/cron/pipeline",
+      "schedule": "0 4 * * 0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Per-source fan-out**: Cron scraper now dispatches each source as a separate invocation via `after()`, keeping each well under the 300s Vercel timeout
- **Autonomous pipeline**: New weekly cron (`/api/cron/pipeline`, Sunday 4AM) runs the full research → verification → implementation pipeline with auto-approve for high-confidence findings (>= 0.8)
- **Durable writes**: Implementation agent now uses `data-service.ts` (Supabase-first, JSON fallback) instead of direct JSON file writes that don't persist on Vercel
- **Monitoring**: Scraper run logging (`logScraperRun` / `getRecentScraperRuns`) tracks cron health
- **Source consolidation**: Admin scraper route and research agent now import from `data-sources.ts` instead of hardcoding their own source lists

## Environment setup

`CRON_SECRET` has been added to production env vars. Both cron jobs will register on the next production deploy.

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] `npm run lint` passes with 0 errors (verified locally)
- [ ] Verify cron jobs appear in Vercel dashboard after deploy
- [ ] Test single-source scrape: `curl -H "Authorization: Bearer $CRON_SECRET" "https://<url>/api/cron/scrape?source=source-1"`
- [ ] Test fan-out dispatch: `curl -H "Authorization: Bearer $CRON_SECRET" "https://<url>/api/cron/scrape"`
- [ ] Test pipeline cron: `curl -H "Authorization: Bearer $CRON_SECRET" "https://<url>/api/cron/pipeline"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)