### PR TITLE
Fix P0: add auth to unprotected API endpoints

### DIFF
--- a/src/app/api/claude/analyze/route.ts
+++ b/src/app/api/claude/analyze/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server';
 import { analyseContentRelevance } from '@/lib/claude';
+import { verifyAuth, unauthorizedResponse } from '@/lib/auth';
 
 export async function POST(request: Request) {
+  const user = await verifyAuth(request);
+  if (!user) return unauthorizedResponse();
+
   try {
     const body = await request.json();
     const { content, sourceUrl } = body;

--- a/src/app/api/policies/[id]/route.ts
+++ b/src/app/api/policies/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getPolicyById, updatePolicy, deletePolicy } from '@/lib/data-service';
+import { verifyAuth, unauthorizedResponse } from '@/lib/auth';
 
 // GET - Retrieve a single policy by ID
 export async function GET(
@@ -35,6 +36,9 @@ export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const user = await verifyAuth(request);
+  if (!user) return unauthorizedResponse();
+
   try {
     const { id } = await params;
     const body = await request.json();
@@ -66,6 +70,9 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const user = await verifyAuth(request);
+  if (!user) return unauthorizedResponse();
+
   try {
     const { id } = await params;
     const deleted = await deletePolicy(id);

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { summarizePolicy } from '@/lib/claude';
 import { DuplicatePolicyError, getPolicies, createPolicy } from '@/lib/data-service';
+import { verifyAuth, unauthorizedResponse } from '@/lib/auth';
 import type { Policy } from '@/types';
 
 export async function GET(request: Request) {
@@ -20,6 +21,9 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
+  const user = await verifyAuth(request);
+  if (!user) return unauthorizedResponse();
+
   try {
     const body = await request.json();
     const { title, description, jurisdiction, type, status, effectiveDate, sourceUrl, content, aiSummary, tags, agencies, generateSummary } = body;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -53,8 +53,9 @@ export async function verifyAuth(request: Request) {
     return null;
   }
 
-  // Strategy 3: No auth backend configured — allow access (dev/local mode)
-  if (!supabaseUrl && !supabaseAnonKey) {
+  // Strategy 3: No auth backend configured — allow access in development only
+  if (!supabaseUrl && !supabaseAnonKey && process.env.NODE_ENV === 'development') {
+    console.warn('[auth] No auth backend configured — granting dev-mode access');
     return { id: 'local-admin', email: 'admin@localhost' };
   }
 


### PR DESCRIPTION
## Summary

Fixes four P0 security issues where API endpoints were accessible without authentication.

- **#14** Dev-mode auth bypass grants admin access in production when no auth is configured
- **#12** Policy CRUD API (POST, PATCH, DELETE) has no authentication
- **#13 / #36** `/api/claude/analyze` endpoint is unauthenticated

## Changes

- Gate dev-mode auth fallback behind `NODE_ENV === 'development'` in `src/lib/auth.ts`
- Add `verifyAuth` to `POST /api/policies` (GET remains public for browsing)
- Add `verifyAuth` to `PATCH /api/policies/[id]` and `DELETE /api/policies/[id]` (GET remains public)
- Add `verifyAuth` to `POST /api/claude/analyze`

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Unauthenticated POST/PATCH/DELETE to `/api/policies` returns 401
- [ ] Unauthenticated POST to `/api/claude/analyze` returns 401
- [ ] GET `/api/policies` still works without auth
- [ ] Admin dashboard still works with `ADMIN_PASSWORD` or Supabase auth
- [ ] Local dev (`NODE_ENV=development`) still allows access without credentials

Closes #14, #12, #13, #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)