### PR TITLE
Redesign the network page and add core test coverage

### DIFF
--- a/content/blog/dta-ai-poc-to-scale-guidance.mdx
+++ b/content/blog/dta-ai-poc-to-scale-guidance.mdx
@@ -1,0 +1,39 @@
+---
+title: "DTA Releases Guidance on Scaling AI from Proof of Concept to Production"
+date: "2026-04-12"
+description: "The Digital Transformation Agency has published new guidance to help Australian Government agencies move AI projects beyond isolated experiments and into enterprise-scale operations."
+---
+
+The Digital Transformation Agency (DTA) has released [Guidance for AI proof of concept to scale](https://www.digital.gov.au/sites/default/files/documents/2026-03/AI%20PoC%20to%20Scale%20Guidance.pdf), a 34-page document aimed at helping Australian Government agencies bridge the gap between AI experimentation and real operational deployment.
+
+The core message is direct: benefits from AI come through enterprise integration, not through running disconnected experiments. The guidance is designed to complement the existing [Australian Government AI policy framework](https://www.digital.gov.au) and Technical Standard for Government's use of artificial intelligence, providing practical advice for agencies navigating the path from proof of concept (PoC) through pilot to production.
+
+## Why this matters
+
+Across both government and the private sector, most AI projects never make it past the experimental phase. The DTA's guidance acknowledges this openly, noting that even technically feasible PoCs risk becoming "shelfware" without clear ownership, strategic alignment, and a defined pathway to scale. Common failure modes include unclear success criteria, technology-led approaches disconnected from business needs, weak data governance, and a risk-avoidance culture that stalls progress before value can be demonstrated.
+
+This is a welcome intervention. Australian Government agencies have been running AI experiments for several years now, but the maturity gap between experimentation and sustained, scaled deployment has been a persistent theme in the policy landscape. Having formal guidance that names the problem directly — and provides structured advice for addressing it — is a meaningful step.
+
+## What the guidance covers
+
+The document is organised around several core areas.
+
+**Eight principles for scaling AI** form the foundation, covering strong data and capability foundations, enterprise-ready design, robust governance, cross-functional collaboration, strategic alignment with measurable outcomes, a culture of responsible innovation, AI literacy at all levels, and choosing the right technology for the right problem.
+
+**A three-stage transition model** defines the pathway from PoC to pilot to production. The DTA lays out how each stage differs across dimensions like users, data, infrastructure, governance, risk tolerance, and procurement. A PoC is expected to be short-lived and experimental, a pilot validates in a controlled real-world setting, and production means full enterprise integration with ongoing monitoring.
+
+**Twelve "dimension considerations"** provide a planning framework that spans business alignment, architecture, data, technology, people, governance, experimentation, delivery, scalability, sustainment, non-AI alternatives, and AI technique selection. For each dimension, the guidance describes the purpose, key activities, and how expectations change from PoC through to production. The inclusion of "non-AI considerations" is a particularly grounded addition — agencies are encouraged to assess whether a problem actually requires AI or could be addressed through simpler approaches like process redesign or rules-based automation.
+
+**A detailed challenges and mitigation table** maps common failure points to specific mitigations and accountable roles. These are practical and specific: requiring a problem statement and value hypothesis before funding a PoC, maintaining a technical debt register, running "security by design" reviews early, and including decommissioning in PoC closure checklists.
+
+**Six real-world scenarios** illustrate both success and failure patterns, covering co-design and transparency, clear expectations, cross-agency collaboration, gaps in user understanding, lack of business buy-in, and the challenges of integrating new AI models with legacy systems.
+
+The appendices include an AI readiness checklist for sponsors, managers and practitioners, guidance on AI evaluation, advice on informing procurement decisions, and a mapping of the guidance's dimensions to the Technical Standard.
+
+## Our take
+
+This is one of the more pragmatic pieces of AI guidance to come out of the Australian Government. Rather than focusing on high-level principles alone, it engages with the operational reality of why AI projects fail and what agencies can do differently. The emphasis on business alignment before technical work, the explicit encouragement to consider non-AI alternatives, and the accountability structures for common challenges all reflect lessons that many agencies have learned the hard way.
+
+The guidance also represents a maturing of the federal government's approach to AI governance. It sits alongside the AI in Government Policy, the Technical Standard, and the National Framework for AI Assurance as part of an increasingly coherent set of resources for agencies working with AI. For anyone tracking the Australian AI policy landscape — which is what Policai is here for — this is an important addition to the picture.
+
+You can read the full guidance on the [DTA website](https://www.digital.gov.au) or download the [PDF directly](https://www.digital.gov.au/sites/default/files/documents/2026-03/AI%20PoC%20to%20Scale%20Guidance.pdf).

--- a/docs/superpowers/specs/2026-04-12-network-page-redesign.md
+++ b/docs/superpowers/specs/2026-04-12-network-page-redesign.md
@@ -1,0 +1,131 @@
+# Network Page Redesign
+
+## Problem
+
+The current network page is a 995-line monolith using React Flow to display a rigid 3-column hierarchy (Jurisdiction → Agency → Policy). With 38+ policies and 50 agencies, it's unreadable, the layout doesn't reveal meaningful relationships, and the visual design is inconsistent with the rest of the app.
+
+## Design
+
+Replace the React Flow hierarchical layout with a D3.js force-directed graph. Policies cluster by jurisdiction, with cross-jurisdiction edges revealing shared themes and agencies. The page uses a floating toolbar for filtering, a slide-out sidebar for node details, and the app's existing design system throughout.
+
+### Layout
+
+Full-bleed force graph with two overlay layers:
+
+1. **Floating toolbar** (top) — search box, jurisdiction toggle pills, policy count stats
+2. **Slide-out sidebar** (right, on node click) — policy/agency details with connected nodes list
+
+The graph fills the page height (calc viewport minus header). No cards, stat grids, or sidebar chrome from the current design — the graph is the entire content area.
+
+### Force Graph
+
+Built with D3.js force simulation (already a project dependency — no React Flow needed).
+
+**Nodes:**
+- **Policy nodes**: circles sized by tag count (proxy for scope/importance), colored by jurisdiction using `--chart-1` through `--chart-5`
+- **Cluster labels**: jurisdiction name rendered as a text label at the centroid of each cluster, not as a node
+
+**Edges:**
+- **Intra-jurisdiction**: faint lines between policies sharing an agency or 2+ tags. Stroke color matches jurisdiction.
+- **Cross-jurisdiction**: dashed purple lines between policies sharing 3+ tags or referencing the same agency. These are the interesting connections.
+
+**Forces:**
+- Cluster force: policies attract toward their jurisdiction centroid
+- Repulsion: nodes repel to prevent overlap
+- Link force: connected nodes attract gently
+- Collision: prevents node overlap with padding
+
+**Interactions:**
+- Hover: node grows slightly, label appears (policy title), connected edges highlight
+- Click: opens slide-out sidebar with full details
+- Drag: reposition individual nodes
+- Zoom/pan: standard D3 zoom behavior
+- No minimap (the floating toolbar + search replaces the need)
+
+### Floating Toolbar
+
+Compact horizontal bar pinned to the top of the graph area:
+
+- **Search**: text input with magnifying glass icon, filters nodes by title match (fades non-matching nodes)
+- **Jurisdiction pills**: one per jurisdiction with data, colored using chart colors. Click to toggle visibility. Active pills are filled, inactive are outlined.
+- **Stats**: right-aligned, shows "{n} policies · {n} jurisdictions" in mono font
+
+Built with existing shadcn `Input` component and Tailwind classes. Uses `bg-card/90 backdrop-blur` for the glass effect over the graph.
+
+### Slide-out Sidebar
+
+320px panel that slides in from the right when a node is clicked. Shows:
+
+- **Header**: "POLICY DETAIL" label in mono uppercase, close button
+- **Badges**: status (using `--status-*` colors), type, jurisdiction
+- **Title**: policy title in semibold
+- **Date**: effective date in muted text
+- **Description**: 2-3 line description
+- **Connected nodes**: list of related policies/agencies with jurisdiction color dot. Clicking a connected node navigates to it in the graph.
+- **Tags**: tag pills in muted style
+- **Actions**: "View Full Policy →" link to `/policies/[id]`, "Source ↗" external link
+
+Uses shadcn `Badge`, `ScrollArea`, and `Button` components. Background uses `bg-card/95 backdrop-blur-xl` with `border-l border-border`.
+
+### Edge Computation
+
+Edges are computed client-side from the policy data:
+
+1. **Shared agency**: if two policies reference the same agency string (fuzzy matched), create an edge
+2. **Shared tags**: if two policies share 2+ tags, create an edge (3+ for cross-jurisdiction)
+3. **Dedup**: one edge per policy pair, weight = number of shared connections
+
+This replaces the current static hierarchy with data-driven relationships.
+
+### Styling
+
+All colors from CSS variables — works in both light and dark mode:
+- Node fills: `--chart-1` (federal), `--chart-2` (NSW), `--chart-3` (WA/QLD), `--chart-4` (ACT/VIC), `--chart-5` (other)
+- Status indicators on nodes: thin ring using `--status-active`, `--status-proposed`, etc.
+- Background: `--background` with subtle dot pattern using `--border` color
+- Fonts: IBM Plex Sans for labels, IBM Plex Mono for stats/counts
+- Transitions: 200ms ease for hover effects, 300ms for sidebar slide
+
+### Component Structure
+
+Break the 995-line monolith into focused components:
+
+```
+src/app/network/page.tsx              — page shell, data fetching, state
+src/components/network/
+  ForceGraph.tsx                      — D3 force simulation + SVG rendering
+  NetworkToolbar.tsx                  — search, jurisdiction pills, stats
+  NetworkSidebar.tsx                  — slide-out detail panel
+  use-force-simulation.ts            — custom hook for D3 force setup
+  compute-edges.ts                   — edge computation from policy data
+```
+
+### Data Flow
+
+1. Page fetches `/api/policies` and `/api/agencies` on mount (same as current)
+2. `compute-edges.ts` builds edge list from shared agencies/tags
+3. `use-force-simulation.ts` initializes D3 force simulation with nodes + edges
+4. `ForceGraph.tsx` renders SVG with D3-managed positions
+5. Toolbar filter state flows down — filtered-out nodes get `opacity: 0.1`
+6. Click events flow up — page sets `selectedNodeId`, sidebar renders
+
+### What Gets Removed
+
+- React Flow dependency usage on this page (keep the package for now since other pages may use it)
+- All inline node styling (replaced by CSS variables)
+- The stat cards grid above the graph
+- The legend card (jurisdiction colors are self-documenting via pills)
+- The "Controls" help card (standard zoom/pan, discoverable)
+- The node detail Dialog (replaced by sidebar)
+
+## Verification
+
+1. `npm run build` + `npm run lint` pass
+2. Graph renders with all policies from Supabase, clustered by jurisdiction
+3. Cross-jurisdiction edges visible between related policies
+4. Search filters nodes in real-time
+5. Jurisdiction pills toggle cluster visibility
+6. Click opens sidebar with correct policy details
+7. "View Full Policy" links to correct `/policies/[id]` page
+8. Works in both light and dark mode
+9. Responsive: on mobile, sidebar becomes a bottom sheet or full-screen overlay

--- a/docs/superpowers/specs/2026-04-12-network-page-redesign.md
+++ b/docs/superpowers/specs/2026-04-12-network-page-redesign.md
@@ -21,13 +21,14 @@ The graph fills the page height (calc viewport minus header). No cards, stat gri
 
 Built with D3.js force simulation (already a project dependency — no React Flow needed).
 
-**Nodes:**
+**Nodes (policy-only):**
 - **Policy nodes**: circles sized by tag count (proxy for scope/importance), colored by jurisdiction using `--chart-1` through `--chart-5`
 - **Cluster labels**: jurisdiction name rendered as a text label at the centroid of each cluster, not as a node
+- **No agency nodes**: agencies are not graph entities. They appear as metadata in the sidebar when a policy is selected (listed under "Agencies" as plain text). This avoids the 50-agency clutter problem and keeps the graph focused on policy-to-policy relationships.
 
-**Edges:**
-- **Intra-jurisdiction**: faint lines between policies sharing an agency or 2+ tags. Stroke color matches jurisdiction.
-- **Cross-jurisdiction**: dashed purple lines between policies sharing 3+ tags or referencing the same agency. These are the interesting connections.
+**Edges (tag-based only):**
+- **Intra-jurisdiction**: faint lines between policies sharing 2+ tags. Stroke color matches jurisdiction.
+- **Cross-jurisdiction**: dashed purple lines between policies sharing 3+ tags. These are the interesting connections.
 
 **Forces:**
 - Cluster force: policies attract toward their jurisdiction centroid
@@ -61,7 +62,8 @@ Built with existing shadcn `Input` component and Tailwind classes. Uses `bg-card
 - **Title**: policy title in semibold
 - **Date**: effective date in muted text
 - **Description**: 2-3 line description
-- **Connected nodes**: list of related policies/agencies with jurisdiction color dot. Clicking a connected node navigates to it in the graph.
+- **Connected policies**: list of policies linked by shared tags, with jurisdiction color dot. Clicking navigates to that node in the graph.
+- **Agencies**: plain text list of agency names from `policy.agencies` (non-navigable metadata, not graph entities)
 - **Tags**: tag pills in muted style
 - **Actions**: "View Full Policy →" link to `/policies/[id]`, "Source ↗" external link
 
@@ -69,13 +71,19 @@ Uses shadcn `Badge`, `ScrollArea`, and `Button` components. Background uses `bg-
 
 ### Edge Computation
 
-Edges are computed client-side from the policy data:
+Edges are computed **server-side** via a new API endpoint `GET /api/network` that returns pre-computed nodes and edges. This avoids unreliable client-side fuzzy matching.
 
-1. **Shared agency**: if two policies reference the same agency string (fuzzy matched), create an edge
-2. **Shared tags**: if two policies share 2+ tags, create an edge (3+ for cross-jurisdiction)
-3. **Dedup**: one edge per policy pair, weight = number of shared connections
+**Tag-based edges only (no agency string matching):**
 
-This replaces the current static hierarchy with data-driven relationships.
+The `Policy.agencies` field is free-text `string[]` with no canonical IDs — values like "Data and Digital Government Strategy Branch" don't resolve to agency records. Fuzzy matching would create false relationships and miss real ones. Instead, edges are derived solely from shared tags, which are structured and consistent:
+
+1. **Intra-jurisdiction**: two policies in the same jurisdiction sharing 2+ tags → edge
+2. **Cross-jurisdiction**: two policies in different jurisdictions sharing 3+ tags → edge
+3. **Dedup**: one edge per policy pair, weight = number of shared tags
+
+The `/api/network` endpoint returns `{ nodes: PolicyNode[], edges: Edge[] }` so the client receives a trusted, pre-computed graph. Agency names appear as metadata in the sidebar (non-navigable) but do not drive graph topology.
+
+**Future improvement:** When `Policy.agencies` is normalized to canonical agency IDs (foreign keys to the `agencies` table), agency-based edges can be added reliably.
 
 ### Styling
 
@@ -91,23 +99,33 @@ All colors from CSS variables — works in both light and dark mode:
 Break the 995-line monolith into focused components:
 
 ```
-src/app/network/page.tsx              — page shell, data fetching, state
+src/app/network/page.tsx              — page shell, data fetching, state management
+src/app/api/network/route.ts          — server-side edge computation, returns nodes + edges
 src/components/network/
   ForceGraph.tsx                      — D3 force simulation + SVG rendering
   NetworkToolbar.tsx                  — search, jurisdiction pills, stats
   NetworkSidebar.tsx                  — slide-out detail panel
   use-force-simulation.ts            — custom hook for D3 force setup
-  compute-edges.ts                   — edge computation from policy data
 ```
 
 ### Data Flow
 
-1. Page fetches `/api/policies` and `/api/agencies` on mount (same as current)
-2. `compute-edges.ts` builds edge list from shared agencies/tags
-3. `use-force-simulation.ts` initializes D3 force simulation with nodes + edges
-4. `ForceGraph.tsx` renders SVG with D3-managed positions
-5. Toolbar filter state flows down — filtered-out nodes get `opacity: 0.1`
-6. Click events flow up — page sets `selectedNodeId`, sidebar renders
+1. Page fetches `/api/network` on mount (single request, returns pre-computed nodes + edges)
+2. `use-force-simulation.ts` initializes D3 force simulation with the response data
+3. `ForceGraph.tsx` renders SVG with D3-managed positions
+4. Toolbar filter state flows down — filtered-out nodes get `opacity: 0.1`
+5. Click events flow up — page sets `selectedNodeId`, sidebar renders
+
+### Loading, Error, and Empty States
+
+The graph is the only content area, so degraded states must be explicit:
+
+- **Loading**: centered spinner with "Loading network..." text (same pattern as other pages)
+- **Error (fetch failure / 429)**: centered error message with "Failed to load network data" and a "Retry" button. No blank canvas.
+- **Empty (0 policies)**: centered illustration with "No policies found" message and link to the policies page
+- **Partial data**: if the API returns data but edge computation yields 0 edges, show the nodes without edges and a subtle note: "No cross-policy connections found yet"
+
+The page component manages `loading`, `error`, and `data` states explicitly — never renders the graph SVG until data is confirmed present.
 
 ### What Gets Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.4",
         "eslint": "^9",
         "eslint-config-next": "^16.2.2",
         "jsdom": "^29.0.1",
@@ -334,13 +335,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-      "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -393,9 +394,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-      "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -404,6 +405,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -4821,17 +4832,48 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.4",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -4840,13 +4882,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4867,9 +4909,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4880,13 +4922,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4894,14 +4936,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4910,9 +4952,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4920,13 +4962,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -5234,6 +5276,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7964,6 +8025,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -8594,6 +8662,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -9202,6 +9309,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-extensions": {
@@ -12606,19 +12754,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -12646,10 +12794,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -12671,6 +12821,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "scrape": "tsx scripts/run-scheduled-scrapers.ts",
     "pipeline": "tsx scripts/run-daily-pipeline.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
@@ -53,6 +54,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^9",
     "eslint-config-next": "^16.2.2",
     "jsdom": "^29.0.1",

--- a/src/app/api/agencies/route.test.ts
+++ b/src/app/api/agencies/route.test.ts
@@ -1,0 +1,57 @@
+/* @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildAgency } from '@/test/factories'
+
+const { getAgencies, getCommonwealthAgencies } = vi.hoisted(() => ({
+  getAgencies: vi.fn(),
+  getCommonwealthAgencies: vi.fn(),
+}))
+
+vi.mock('@/lib/data-service', () => ({
+  getAgencies,
+  getCommonwealthAgencies,
+}))
+
+import { GET } from './route'
+
+describe('/api/agencies', () => {
+  beforeEach(() => {
+    getAgencies.mockReset()
+    getCommonwealthAgencies.mockReset()
+  })
+
+  it('returns commonwealth agencies when requested explicitly', async () => {
+    const agencies = [buildAgency({ id: 'commonwealth-agency' })]
+    getCommonwealthAgencies.mockResolvedValue(agencies)
+
+    const response = await GET(new Request('https://example.com/api/agencies?commonwealth=true'))
+
+    expect(getCommonwealthAgencies).toHaveBeenCalledTimes(1)
+    expect(getAgencies).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual({
+      data: agencies,
+      total: 1,
+      success: true,
+    })
+  })
+
+  it('forwards level and jurisdiction filters to the data service', async () => {
+    const agencies = [buildAgency({ id: 'federal-agency' })]
+    getAgencies.mockResolvedValue(agencies)
+
+    const response = await GET(
+      new Request('https://example.com/api/agencies?level=federal&jurisdiction=federal'),
+    )
+
+    expect(getAgencies).toHaveBeenCalledWith({
+      level: 'federal',
+      jurisdiction: 'federal',
+    })
+    await expect(response.json()).resolves.toEqual({
+      data: agencies,
+      total: 1,
+      success: true,
+    })
+  })
+})

--- a/src/app/api/network/route.ts
+++ b/src/app/api/network/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { getPolicies } from '@/lib/data-service';
+
+export interface NetworkNode {
+  id: string;
+  title: string;
+  jurisdiction: string;
+  status: string;
+  type: string;
+  tags: string[];
+  agencies: string[];
+  effectiveDate: string;
+  sourceUrl: string;
+  description: string;
+}
+
+export interface NetworkEdge {
+  source: string;
+  target: string;
+  weight: number;
+  crossJurisdiction: boolean;
+}
+
+export async function GET() {
+  try {
+    const policies = await getPolicies();
+
+    // Build nodes
+    const nodes: NetworkNode[] = policies
+      .filter((p) => p.status !== 'trashed')
+      .map((p) => ({
+        id: p.id,
+        title: p.title,
+        jurisdiction: p.jurisdiction,
+        status: p.status,
+        type: p.type,
+        tags: p.tags,
+        agencies: p.agencies,
+        effectiveDate: typeof p.effectiveDate === 'string' ? p.effectiveDate : '',
+        sourceUrl: p.sourceUrl,
+        description: p.description,
+      }));
+
+    // Build edges from shared tags
+    const edges: NetworkEdge[] = [];
+    for (let i = 0; i < nodes.length; i++) {
+      for (let j = i + 1; j < nodes.length; j++) {
+        const a = nodes[i];
+        const b = nodes[j];
+
+        const sharedTags = a.tags.filter((t) => b.tags.includes(t));
+        const crossJurisdiction = a.jurisdiction !== b.jurisdiction;
+        const threshold = crossJurisdiction ? 3 : 2;
+
+        if (sharedTags.length >= threshold) {
+          edges.push({
+            source: a.id,
+            target: b.id,
+            weight: sharedTags.length,
+            crossJurisdiction,
+          });
+        }
+      }
+    }
+
+    return NextResponse.json({ nodes, edges, success: true });
+  } catch (error) {
+    console.error('[network] Failed to compute graph:', error);
+    return NextResponse.json(
+      { error: 'Failed to load network data', success: false },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/policies/[id]/route.test.ts
+++ b/src/app/api/policies/[id]/route.test.ts
@@ -1,0 +1,118 @@
+/* @vitest-environment node */
+
+import { NextResponse } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildPolicy } from '@/test/factories'
+
+const { getPolicyById, updatePolicy, deletePolicy, verifyAuth } = vi.hoisted(() => ({
+  getPolicyById: vi.fn(),
+  updatePolicy: vi.fn(),
+  deletePolicy: vi.fn(),
+  verifyAuth: vi.fn(),
+}))
+
+vi.mock('@/lib/data-service', () => ({
+  getPolicyById,
+  updatePolicy,
+  deletePolicy,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuth,
+  unauthorizedResponse: () =>
+    NextResponse.json(
+      { error: 'Unauthorized - Admin authentication required', success: false },
+      { status: 401 },
+    ),
+}))
+
+import { DELETE, GET, PATCH } from './route'
+
+describe('/api/policies/[id]', () => {
+  beforeEach(() => {
+    getPolicyById.mockReset()
+    updatePolicy.mockReset()
+    deletePolicy.mockReset()
+    verifyAuth.mockReset()
+  })
+
+  it('returns the requested policy when it exists', async () => {
+    const policy = buildPolicy({ id: 'policy-123' })
+    getPolicyById.mockResolvedValue(policy)
+
+    const response = await GET(new Request('https://example.com/api/policies/policy-123'), {
+      params: Promise.resolve({ id: 'policy-123' }),
+    })
+
+    expect(getPolicyById).toHaveBeenCalledWith('policy-123')
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      data: policy,
+      success: true,
+    })
+  })
+
+  it('returns 404 when the requested policy does not exist', async () => {
+    getPolicyById.mockResolvedValue(null)
+
+    const response = await GET(new Request('https://example.com/api/policies/missing'), {
+      params: Promise.resolve({ id: 'missing' }),
+    })
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Policy not found',
+      success: false,
+    })
+  })
+
+  it('requires auth before applying PATCH updates', async () => {
+    verifyAuth.mockResolvedValue(null)
+
+    const response = await PATCH(
+      new Request('https://example.com/api/policies/policy-123', {
+        method: 'PATCH',
+        body: JSON.stringify({ status: 'amended' }),
+      }),
+      {
+        params: Promise.resolve({ id: 'policy-123' }),
+      },
+    )
+
+    expect(response.status).toBe(401)
+    expect(updatePolicy).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when PATCH targets a missing policy', async () => {
+    verifyAuth.mockResolvedValue({ id: 'admin' })
+    updatePolicy.mockResolvedValue(null)
+
+    const response = await PATCH(
+      new Request('https://example.com/api/policies/missing', {
+        method: 'PATCH',
+        body: JSON.stringify({ status: 'amended' }),
+      }),
+      {
+        params: Promise.resolve({ id: 'missing' }),
+      },
+    )
+
+    expect(updatePolicy).toHaveBeenCalledWith('missing', { status: 'amended' })
+    expect(response.status).toBe(404)
+  })
+
+  it('deletes a policy when authorised', async () => {
+    verifyAuth.mockResolvedValue({ id: 'admin' })
+    deletePolicy.mockResolvedValue(true)
+
+    const response = await DELETE(new Request('https://example.com/api/policies/policy-123'), {
+      params: Promise.resolve({ id: 'policy-123' }),
+    })
+
+    expect(deletePolicy).toHaveBeenCalledWith('policy-123')
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+    })
+  })
+})

--- a/src/app/api/policies/route.test.ts
+++ b/src/app/api/policies/route.test.ts
@@ -1,0 +1,201 @@
+/* @vitest-environment node */
+
+import { NextResponse } from 'next/server'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildPolicy } from '@/test/factories'
+
+const {
+  summarizePolicy,
+  getPolicies,
+  createPolicy,
+  verifyAuth,
+  checkRateLimit,
+  MockDuplicatePolicyError,
+} = vi.hoisted(() => ({
+  summarizePolicy: vi.fn(),
+  getPolicies: vi.fn(),
+  createPolicy: vi.fn(),
+  verifyAuth: vi.fn(),
+  checkRateLimit: vi.fn(),
+  MockDuplicatePolicyError: class MockDuplicatePolicyError extends Error {
+    constructor(id: string) {
+      super(`Policy already exists: ${id}`)
+      this.name = 'DuplicatePolicyError'
+    }
+  },
+}))
+
+vi.mock('@/lib/claude', () => ({
+  summarizePolicy,
+}))
+
+vi.mock('@/lib/data-service', () => ({
+  DuplicatePolicyError: MockDuplicatePolicyError,
+  getPolicies,
+  createPolicy,
+}))
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuth,
+  unauthorizedResponse: () =>
+    NextResponse.json(
+      { error: 'Unauthorized - Admin authentication required', success: false },
+      { status: 401 },
+    ),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit,
+}))
+
+import { GET, POST } from './route'
+
+const originalOpenRouterKey = process.env.OPENROUTER_API_KEY
+
+describe('/api/policies', () => {
+  beforeEach(() => {
+    summarizePolicy.mockReset()
+    getPolicies.mockReset()
+    createPolicy.mockReset()
+    verifyAuth.mockReset()
+    checkRateLimit.mockReset()
+    delete process.env.OPENROUTER_API_KEY
+  })
+
+  afterEach(() => {
+    process.env.OPENROUTER_API_KEY = originalOpenRouterKey
+  })
+
+  it('returns filtered policies for GET requests', async () => {
+    const policies = [buildPolicy({ id: 'policy-a' }), buildPolicy({ id: 'policy-b', jurisdiction: 'nsw' })]
+    checkRateLimit.mockReturnValue(null)
+    getPolicies.mockResolvedValue(policies)
+
+    const response = await GET(
+      new Request(
+        'https://example.com/api/policies?jurisdiction=federal&type=framework&status=active&search=ethics',
+      ),
+    )
+
+    expect(getPolicies).toHaveBeenCalledWith({
+      jurisdiction: 'federal',
+      type: 'framework',
+      status: 'active',
+      search: 'ethics',
+    })
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      data: policies,
+      total: 2,
+      success: true,
+    })
+  })
+
+  it('short-circuits GET requests that exceed the rate limit', async () => {
+    checkRateLimit.mockReturnValue(
+      NextResponse.json({ error: 'Too many requests', success: false }, { status: 429 }),
+    )
+
+    const response = await GET(new Request('https://example.com/api/policies'))
+
+    expect(response.status).toBe(429)
+    expect(getPolicies).not.toHaveBeenCalled()
+  })
+
+  it('requires admin auth for POST requests', async () => {
+    verifyAuth.mockResolvedValue(null)
+
+    const response = await POST(
+      new Request('https://example.com/api/policies', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Unauthorised policy' }),
+      }),
+    )
+
+    expect(response.status).toBe(401)
+    expect(createPolicy).not.toHaveBeenCalled()
+  })
+
+  it('validates required POST fields', async () => {
+    verifyAuth.mockResolvedValue({ id: 'admin' })
+
+    const response = await POST(
+      new Request('https://example.com/api/policies', {
+        method: 'POST',
+        body: JSON.stringify({ title: 'Incomplete policy' }),
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Title, jurisdiction, type, and status are required',
+      success: false,
+    })
+  })
+
+  it('creates a policy and fills description from the generated summary when requested', async () => {
+    process.env.OPENROUTER_API_KEY = 'openrouter-key'
+    verifyAuth.mockResolvedValue({ id: 'admin' })
+    summarizePolicy.mockResolvedValue({
+      summary: 'Generated AI summary',
+    })
+    createPolicy.mockImplementation(async (policy) => policy)
+
+    const response = await POST(
+      new Request('https://example.com/api/policies', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: 'National AI Governance Standard',
+          jurisdiction: 'federal',
+          type: 'standard',
+          status: 'active',
+          content: 'The full policy body',
+          agencies: ['Department of Industry'],
+          tags: ['governance'],
+        }),
+      }),
+    )
+
+    expect(summarizePolicy).toHaveBeenCalledWith(
+      'National AI Governance Standard',
+      'The full policy body',
+    )
+    expect(createPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'national-ai-governance-standard',
+        title: 'National AI Governance Standard',
+        description: 'Generated AI summary',
+        aiSummary: 'Generated AI summary',
+        jurisdiction: 'federal',
+        type: 'standard',
+        status: 'active',
+        agencies: ['Department of Industry'],
+        tags: ['governance'],
+      }),
+    )
+    expect(response.status).toBe(200)
+  })
+
+  it('maps duplicate policy errors to a 409 response', async () => {
+    verifyAuth.mockResolvedValue({ id: 'admin' })
+    createPolicy.mockRejectedValue(new MockDuplicatePolicyError('duplicate-policy'))
+
+    const response = await POST(
+      new Request('https://example.com/api/policies', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: 'Duplicate policy',
+          jurisdiction: 'federal',
+          type: 'framework',
+          status: 'active',
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: 'A policy with this title already exists',
+      success: false,
+    })
+  })
+})

--- a/src/app/api/status/route.test.ts
+++ b/src/app/api/status/route.test.ts
@@ -1,0 +1,77 @@
+/* @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildScraperRunLog } from '@/test/factories'
+
+const { getLatestPipelineRun, getRecentScraperRuns } = vi.hoisted(() => ({
+  getLatestPipelineRun: vi.fn(),
+  getRecentScraperRuns: vi.fn(),
+}))
+
+vi.mock('@/lib/agents/pipeline-storage', () => ({
+  getLatestPipelineRun,
+}))
+
+vi.mock('@/lib/data-service', () => ({
+  getRecentScraperRuns,
+}))
+
+import { GET } from './route'
+
+describe('/api/status', () => {
+  beforeEach(() => {
+    getLatestPipelineRun.mockReset()
+    getRecentScraperRuns.mockReset()
+  })
+
+  it('returns null run summaries when there is no pipeline or scraper history', async () => {
+    getLatestPipelineRun.mockResolvedValue(null)
+    getRecentScraperRuns.mockResolvedValue([])
+
+    const response = await GET()
+
+    await expect(response.json()).resolves.toEqual({
+      lastPipelineRun: null,
+      lastScrapeRun: null,
+      success: true,
+    })
+  })
+
+  it('returns condensed status information for the latest pipeline and scraper runs', async () => {
+    getLatestPipelineRun.mockResolvedValue({
+      id: 'pipeline-1',
+      stage: 'verification_complete',
+      startedAt: '2025-02-01T00:00:00.000Z',
+      completedAt: '2025-02-01T00:10:00.000Z',
+      findingsCount: 8,
+      implementedCount: 3,
+      rejectedCount: 1,
+    })
+    getRecentScraperRuns.mockResolvedValue([
+      buildScraperRunLog({
+        timestamp: '2025-02-02T00:00:00.000Z',
+        sourceName: 'Federal Register',
+        policiesCreated: 2,
+      }),
+    ])
+
+    const response = await GET()
+
+    await expect(response.json()).resolves.toEqual({
+      lastPipelineRun: {
+        id: 'pipeline-1',
+        stage: 'verification_complete',
+        startedAt: '2025-02-01T00:00:00.000Z',
+        completedAt: '2025-02-01T00:10:00.000Z',
+        findingsCount: 8,
+        implementedCount: 3,
+      },
+      lastScrapeRun: {
+        timestamp: '2025-02-02T00:00:00.000Z',
+        sourceName: 'Federal Register',
+        policiesCreated: 2,
+      },
+      success: true,
+    })
+  })
+})

--- a/src/app/api/timeline/route.test.ts
+++ b/src/app/api/timeline/route.test.ts
@@ -1,0 +1,34 @@
+/* @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildTimelineEvent } from '@/test/factories'
+
+const { getTimelineEvents } = vi.hoisted(() => ({
+  getTimelineEvents: vi.fn(),
+}))
+
+vi.mock('@/lib/data-service', () => ({
+  getTimelineEvents,
+}))
+
+import { GET } from './route'
+
+describe('/api/timeline', () => {
+  beforeEach(() => {
+    getTimelineEvents.mockReset()
+  })
+
+  it('returns timeline events and forwards the jurisdiction filter', async () => {
+    const events = [buildTimelineEvent({ id: 'timeline-a' })]
+    getTimelineEvents.mockResolvedValue(events)
+
+    const response = await GET(new Request('https://example.com/api/timeline?jurisdiction=federal'))
+
+    expect(getTimelineEvents).toHaveBeenCalledWith({ jurisdiction: 'federal' })
+    await expect(response.json()).resolves.toEqual({
+      data: events,
+      total: 1,
+      success: true,
+    })
+  })
+})

--- a/src/app/network/page.tsx
+++ b/src/app/network/page.tsx
@@ -1,994 +1,164 @@
 'use client';
 
-import { useState, useCallback, useMemo, useEffect } from 'react';
-import {
-  ReactFlow,
-  type Node,
-  type Edge,
-  Controls,
-  Background,
-  MiniMap,
-  useNodesState,
-  useEdgesState,
-  MarkerType,
-  Position,
-  BackgroundVariant,
-} from '@xyflow/react';
-import '@xyflow/react/dist/style.css';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import Link from 'next/link';
+import { Network, AlertCircle, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import {
-  Filter,
-  FileText,
-  Building2,
-  Map,
-  ExternalLink,
-  Info,
-  Search,
-  X,
-  Network,
-  GitBranch,
-  BarChart3,
-} from 'lucide-react';
-import {
-  JURISDICTION_NAMES,
-  POLICY_TYPE_NAMES,
-  POLICY_STATUS_NAMES,
-  type Jurisdiction,
-  type PolicyType,
-  type PolicyStatus,
-  type Policy,
-  type Agency,
-} from '@/types';
-
-type NodeType = 'policy' | 'agency' | 'jurisdiction';
-
-interface NodeData extends Record<string, unknown> {
-  label: string;
-  type: NodeType;
-  status?: string;
-  policyType?: string;
-  originalData: Policy | Agency | { jurisdiction: Jurisdiction };
-}
-
-// Improved layout algorithm with hierarchical positioning grouped by jurisdiction
-function generateGraphData(
-  filterJurisdiction: string,
-  filterStatus: string,
-  filterType: string,
-  searchQuery: string,
-  policiesData: Policy[],
-  agenciesData: Agency[],
-) {
-  const nodes: Node<NodeData>[] = [];
-  const edges: Edge[] = [];
-
-  // Filter policies
-  const filteredPolicies = policiesData.filter((p) => {
-    const matchesJurisdiction = filterJurisdiction === 'all' || p.jurisdiction === filterJurisdiction;
-    const matchesStatus = filterStatus === 'all' || p.status === filterStatus;
-    const matchesType = filterType === 'all' || p.type === filterType;
-    const matchesSearch =
-      searchQuery === '' ||
-      p.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      p.description.toLowerCase().includes(searchQuery.toLowerCase());
-    return matchesJurisdiction && matchesStatus && matchesType && matchesSearch;
-  });
-
-  // Get unique agencies from filtered policies
-  const policyAgencyIds = new Set<string>();
-  filteredPolicies.forEach((p) => {
-    p.agencies.forEach((agencyId) => policyAgencyIds.add(agencyId.toLowerCase()));
-  });
-
-  // Filter agencies - match by id or acronym
-  const filteredAgencies = agenciesData.filter((a) => {
-    const matchesJurisdiction = filterJurisdiction === 'all' || a.jurisdiction === filterJurisdiction;
-    const isReferencedByPolicy =
-      policyAgencyIds.has(a.id.toLowerCase()) ||
-      policyAgencyIds.has(a.acronym.toLowerCase()) ||
-      policyAgencyIds.has(a.name.toLowerCase());
-    return matchesJurisdiction && (isReferencedByPolicy || filterJurisdiction !== 'all');
-  });
-
-  // Get relevant jurisdictions
-  const relevantJurisdictions =
-    filterJurisdiction === 'all'
-      ? [...new Set([...filteredPolicies.map((p) => p.jurisdiction), ...filteredAgencies.map((a) => a.jurisdiction)])]
-      : [filterJurisdiction];
-
-  // Group agencies and policies by jurisdiction for better layout
-  const agenciesByJurisdiction: Record<string, typeof filteredAgencies> = {};
-  const policiesByJurisdiction: Record<string, typeof filteredPolicies> = {};
-
-  relevantJurisdictions.forEach((j) => {
-    agenciesByJurisdiction[j] = filteredAgencies.filter((a) => a.jurisdiction === j);
-    policiesByJurisdiction[j] = filteredPolicies.filter((p) => p.jurisdiction === j);
-  });
-
-  // Layout constants
-  const nodeHeight = 50;
-  const nodeGap = 25;
-  const jurisdictionGap = 60;
-  const columnGap = 250;
-
-  const styles = {
-    jurisdictionBg: 'var(--network-jurisdiction-bg)',
-    jurisdictionBorder: 'var(--network-jurisdiction-border)',
-    agencyBg: 'var(--network-agency-bg)',
-    agencyForeground: 'var(--network-agency-foreground)',
-    agencyBorder: 'var(--network-agency-border)',
-    activeBg: 'var(--network-active-bg)',
-    activeBorder: 'var(--network-active-border)',
-    proposedBg: 'var(--network-proposed-bg)',
-    proposedBorder: 'var(--network-proposed-border)',
-    amendedBg: 'var(--network-amended-bg)',
-    amendedBorder: 'var(--network-amended-border)',
-    defaultBg: 'var(--network-default-bg)',
-    defaultBorder: 'var(--network-default-border)',
-    edge: 'var(--network-edge)',
-  };
-
-  // Get policy status colors
-  const getStatusColors = (status: string) => {
-    switch (status) {
-      case 'active':
-        return { bg: styles.activeBg, border: styles.activeBorder };
-      case 'proposed':
-        return { bg: styles.proposedBg, border: styles.proposedBorder };
-      case 'amended':
-        return { bg: styles.amendedBg, border: styles.amendedBorder };
-      default:
-        return { bg: styles.defaultBg, border: styles.defaultBorder };
-    }
-  };
-
-  let currentY = 50;
-
-  // Position nodes grouped by jurisdiction
-  relevantJurisdictions.forEach((jurisdiction) => {
-    const agencies = agenciesByJurisdiction[jurisdiction] || [];
-    const policies = policiesByJurisdiction[jurisdiction] || [];
-
-    // Calculate the height needed for this jurisdiction group
-    const agencyHeight = Math.max(agencies.length, 1) * (nodeHeight + nodeGap);
-    const policyHeight = Math.max(policies.length, 1) * (nodeHeight + nodeGap);
-    const groupHeight = Math.max(agencyHeight, policyHeight, nodeHeight + nodeGap);
-
-    // Center the jurisdiction node vertically in its group
-    const jurisdictionY = currentY + groupHeight / 2 - nodeHeight / 2;
-
-    // Add jurisdiction node
-    nodes.push({
-      id: `jurisdiction-${jurisdiction}`,
-      type: 'default',
-      position: { x: 50, y: jurisdictionY },
-      data: {
-        label: JURISDICTION_NAMES[jurisdiction as Jurisdiction] || jurisdiction,
-        type: 'jurisdiction',
-        originalData: { jurisdiction: jurisdiction as Jurisdiction },
-      },
-      style: {
-        background: styles.jurisdictionBg,
-        color: 'white',
-        border: `2px solid ${styles.jurisdictionBorder}`,
-        borderRadius: '12px',
-        padding: '12px 20px',
-        fontWeight: 600,
-        fontSize: '13px',
-        width: 160,
-        boxShadow: `0 4px 12px color-mix(in srgb, ${styles.jurisdictionBorder} 35%, transparent)`,
-      },
-      sourcePosition: Position.Right,
-      targetPosition: Position.Left,
-    });
-
-    // Add agency nodes for this jurisdiction
-    agencies.forEach((agency, index) => {
-      const agencyY = currentY + index * (nodeHeight + nodeGap);
-      nodes.push({
-        id: `agency-${agency.id}`,
-        type: 'default',
-        position: { x: 50 + columnGap, y: agencyY },
-        data: {
-          label: agency.acronym || agency.name.substring(0, 15),
-          type: 'agency',
-          originalData: agency,
-        },
-        style: {
-          background: styles.agencyBg,
-          color: styles.agencyForeground,
-          border: `2px solid ${styles.agencyBorder}`,
-          borderRadius: '10px',
-          padding: '10px 16px',
-          fontWeight: 500,
-          fontSize: '12px',
-          width: 130,
-          boxShadow: `0 4px 12px color-mix(in srgb, ${styles.agencyBorder} 28%, transparent)`,
-        },
-        sourcePosition: Position.Right,
-        targetPosition: Position.Left,
-      });
-
-      // Connect agency to jurisdiction
-      edges.push({
-        id: `edge-${agency.id}-${agency.jurisdiction}`,
-        source: `jurisdiction-${agency.jurisdiction}`,
-        target: `agency-${agency.id}`,
-        type: 'smoothstep',
-        animated: false,
-        style: { stroke: styles.edge, strokeWidth: 1.5 },
-        markerEnd: { type: MarkerType.ArrowClosed, color: styles.edge, width: 12, height: 12 },
-      });
-    });
-
-    // Add policy nodes for this jurisdiction
-    policies.forEach((policy, index) => {
-      const policyY = currentY + index * (nodeHeight + nodeGap);
-      const colors = getStatusColors(policy.status);
-
-      nodes.push({
-        id: `policy-${policy.id}`,
-        type: 'default',
-        position: { x: 50 + columnGap * 2, y: policyY },
-        data: {
-          label: policy.title.length > 30 ? policy.title.substring(0, 30) + '...' : policy.title,
-          type: 'policy',
-          status: policy.status,
-          policyType: policy.type,
-          originalData: policy,
-        },
-        style: {
-          background: colors.bg,
-          color: 'white',
-          border: `2px solid ${colors.border}`,
-          borderRadius: '10px',
-          padding: '10px 14px',
-          width: 220,
-          fontSize: '11px',
-          fontWeight: 500,
-          boxShadow: `0 4px 12px ${colors.border}40`,
-        },
-        sourcePosition: Position.Right,
-        targetPosition: Position.Left,
-      });
-
-      // Connect policy to its agencies within this jurisdiction
-      policy.agencies.forEach((agencyRef) => {
-        const agency = filteredAgencies.find(
-          (a) =>
-            a.id.toLowerCase() === agencyRef.toLowerCase() ||
-            a.acronym.toLowerCase() === agencyRef.toLowerCase() ||
-            a.name.toLowerCase() === agencyRef.toLowerCase()
-        );
-
-        if (agency) {
-          edges.push({
-            id: `edge-policy-${policy.id}-${agency.id}`,
-            source: `agency-${agency.id}`,
-            target: `policy-${policy.id}`,
-            type: 'smoothstep',
-            animated: policy.status === 'active',
-            style: {
-              stroke: policy.status === 'active' ? styles.activeBorder : styles.edge,
-              strokeWidth: policy.status === 'active' ? 2 : 1.5,
-            },
-            markerEnd: {
-              type: MarkerType.ArrowClosed,
-              color: policy.status === 'active' ? styles.activeBorder : styles.edge,
-              width: 12,
-              height: 12,
-            },
-          });
-        }
-      });
-    });
-
-    // Move to next jurisdiction group
-    currentY += groupHeight + jurisdictionGap;
-  });
-
-  return { nodes, edges };
-}
-
-// Statistics calculation
-function calculateStats(
-  filterJurisdiction: string,
-  filterStatus: string,
-  filterType: string,
-  searchQuery: string,
-  policiesData: Policy[],
-) {
-  const filteredPolicies = policiesData.filter((p) => {
-    const matchesJurisdiction = filterJurisdiction === 'all' || p.jurisdiction === filterJurisdiction;
-    const matchesStatus = filterStatus === 'all' || p.status === filterStatus;
-    const matchesType = filterType === 'all' || p.type === filterType;
-    const matchesSearch =
-      searchQuery === '' ||
-      p.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      p.description.toLowerCase().includes(searchQuery.toLowerCase());
-    return matchesJurisdiction && matchesStatus && matchesType && matchesSearch;
-  });
-
-  const activePolicies = filteredPolicies.filter((p) => p.status === 'active').length;
-  const proposedPolicies = filteredPolicies.filter((p) => p.status === 'proposed').length;
-  const jurisdictions = new Set(filteredPolicies.map((p) => p.jurisdiction)).size;
-
-  return {
-    totalPolicies: filteredPolicies.length,
-    activePolicies,
-    proposedPolicies,
-    jurisdictions,
-  };
-}
+import { ForceGraph } from '@/components/network/ForceGraph';
+import { NetworkToolbar } from '@/components/network/NetworkToolbar';
+import { NetworkSidebar } from '@/components/network/NetworkSidebar';
+import { JURISDICTION_COLORS, resolveColor } from '@/components/network/jurisdiction-colors';
+import { JURISDICTION_NAMES, type Jurisdiction } from '@/types';
+import type { NetworkNode, NetworkEdge } from '@/app/api/network/route';
 
 export default function NetworkPage() {
-  const [policiesData, setPoliciesData] = useState<Policy[]>([]);
-  const [agenciesData, setAgenciesData] = useState<Agency[]>([]);
-  const [dataLoading, setDataLoading] = useState(true);
-  const [filterJurisdiction, setFilterJurisdiction] = useState<string>('all');
-  const [filterStatus, setFilterStatus] = useState<string>('all');
-  const [filterType, setFilterType] = useState<string>('all');
-  const [searchQuery, setSearchQuery] = useState<string>('');
-  const [selectedNode, setSelectedNode] = useState<Node<NodeData> | null>(null);
-  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [nodes, setNodes] = useState<NetworkNode[]>([]);
+  const [edges, setEdges] = useState<NetworkEdge[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeJurisdictions, setActiveJurisdictions] = useState<Set<string>>(new Set());
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
-  useEffect(() => {
-    Promise.all([
-      fetch('/api/policies').then((r) => r.json()),
-      fetch('/api/agencies').then((r) => r.json()),
-    ])
-      .then(([policiesJson, agenciesJson]) => {
-        setPoliciesData(policiesJson.data ?? []);
-        setAgenciesData(agenciesJson.data ?? []);
-      })
-      .catch((err) => console.error('Failed to load network data:', err))
-      .finally(() => setDataLoading(false));
-  }, []);
-
-  // Generate graph data based on filters
-  const { nodes: graphNodes, edges: graphEdges } = useMemo(
-    () => generateGraphData(filterJurisdiction, filterStatus, filterType, searchQuery, policiesData, agenciesData),
-    [filterJurisdiction, filterStatus, filterType, searchQuery, policiesData, agenciesData]
-  );
-
-  // Calculate statistics
-  const stats = useMemo(
-    () => calculateStats(filterJurisdiction, filterStatus, filterType, searchQuery, policiesData),
-    [filterJurisdiction, filterStatus, filterType, searchQuery, policiesData]
-  );
-
-  const [nodes, setNodes, onNodesChange] = useNodesState(graphNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(graphEdges);
-
-  // Update nodes and edges when filters change
-  useEffect(() => {
-    setNodes(graphNodes);
-    setEdges(graphEdges);
-  }, [graphNodes, graphEdges, setNodes, setEdges]);
-
-  const onNodeClick = useCallback((_: React.MouseEvent, node: Node<NodeData>) => {
-    setSelectedNode(node);
-  }, []);
-
-  const onNodeMouseEnter = useCallback((_: React.MouseEvent, node: Node<NodeData>) => {
-    setHoveredNode(node.id);
-  }, []);
-
-  const onNodeMouseLeave = useCallback(() => {
-    setHoveredNode(null);
-  }, []);
-
-  const clearFilters = () => {
-    setFilterJurisdiction('all');
-    setFilterStatus('all');
-    setFilterType('all');
-    setSearchQuery('');
-  };
-
-  const hasActiveFilters =
-    filterJurisdiction !== 'all' || filterStatus !== 'all' || filterType !== 'all' || searchQuery !== '';
-
-  // Highlight connected edges on hover - subtle effect
-  const highlightedEdges = useMemo(() => {
-    if (!hoveredNode) return edges;
-    return edges.map((edge) => {
-      const isConnected = edge.source === hoveredNode || edge.target === hoveredNode;
-      return {
-        ...edge,
-        style: {
-          ...edge.style,
-          strokeWidth: isConnected ? 3 : edge.style?.strokeWidth,
-          opacity: isConnected ? 1 : 0.6,
-        },
-      };
-    });
-  }, [edges, hoveredNode]);
-
-  // Highlight connected nodes on hover - subtle effect without aggressive fading
-  const highlightedNodes = useMemo(() => {
-    if (!hoveredNode) return nodes;
-    const connectedNodeIds = new Set<string>();
-    connectedNodeIds.add(hoveredNode);
-    edges.forEach((edge) => {
-      if (edge.source === hoveredNode) connectedNodeIds.add(edge.target);
-      if (edge.target === hoveredNode) connectedNodeIds.add(edge.source);
-    });
-
-    return nodes.map((node) => {
-      const isConnected = connectedNodeIds.has(node.id);
-      const isHovered = node.id === hoveredNode;
-      return {
-        ...node,
-        style: {
-          ...node.style,
-          opacity: isConnected ? 1 : 0.75,
-          filter: isHovered ? 'brightness(1.1)' : undefined,
-          boxShadow: isHovered
-            ? '0 0 20px rgba(99, 102, 241, 0.5), 0 4px 12px rgba(0,0,0,0.3)'
-            : node.style?.boxShadow,
-        },
-      };
-    });
-  }, [nodes, edges, hoveredNode]);
-
-  // MiniMap node color function
-  const nodeColor = (node: Node<NodeData>) => {
-    switch (node.data.type) {
-      case 'jurisdiction':
-        return 'var(--network-jurisdiction-border)';
-      case 'agency':
-        return 'var(--network-agency-border)';
-      case 'policy':
-        return node.data.status === 'active'
-          ? 'var(--network-active-border)'
-          : node.data.status === 'proposed'
-            ? 'var(--network-proposed-border)'
-            : node.data.status === 'amended'
-              ? 'var(--network-amended-border)'
-              : 'var(--network-default-border)';
-      default:
-        return 'var(--network-default-border)';
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/network');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error || 'Failed to load');
+      setNodes(json.nodes);
+      setEdges(json.edges);
+      // Initialize all jurisdictions as active
+      const jurisdictions = new Set<string>(json.nodes.map((n: NetworkNode) => n.jurisdiction));
+      setActiveJurisdictions(jurisdictions);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load network data');
+    } finally {
+      setLoading(false);
     }
-  };
+  }, []);
 
-  if (dataLoading) {
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  // Jurisdiction info for toolbar
+  const jurisdictionInfo = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const node of nodes) {
+      counts[node.jurisdiction] = (counts[node.jurisdiction] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([key, count]) => ({
+        key,
+        label: JURISDICTION_NAMES[key as Jurisdiction] || key,
+        color: resolveColor(JURISDICTION_COLORS[key] || 'var(--chart-1)'),
+        count,
+      }));
+  }, [nodes]);
+
+  const toggleJurisdiction = useCallback((key: string) => {
+    setActiveJurisdictions((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  // Selected policy and its connections
+  const selectedPolicy = useMemo(
+    () => nodes.find((n) => n.id === selectedNodeId) ?? null,
+    [nodes, selectedNodeId],
+  );
+
+  const connectedPolicies = useMemo(() => {
+    if (!selectedNodeId) return [];
+    const connected: { id: string; title: string; jurisdiction: string }[] = [];
+    for (const edge of edges) {
+      if (edge.source === selectedNodeId) {
+        const target = nodes.find((n) => n.id === edge.target);
+        if (target) connected.push({ id: target.id, title: target.title, jurisdiction: target.jurisdiction });
+      } else if (edge.target === selectedNodeId) {
+        const source = nodes.find((n) => n.id === edge.source);
+        if (source) connected.push({ id: source.id, title: source.title, jurisdiction: source.jurisdiction });
+      }
+    }
+    return connected;
+  }, [selectedNodeId, edges, nodes]);
+
+  // Loading state
+  if (loading) {
     return (
-      <div className="container mx-auto max-w-7xl px-4 py-8 md:py-10">
-        <div className="flex items-center justify-center min-h-[60vh]">
-          <div className="animate-pulse text-muted-foreground">Loading network data...</div>
-        </div>
+      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)] gap-3">
+        <div className="animate-spin rounded-full h-8 w-8 border-2 border-muted-foreground border-t-foreground" />
+        <p className="text-sm text-muted-foreground">Loading network...</p>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)] gap-4">
+        <AlertCircle className="h-12 w-12 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">Failed to load network data</p>
+        <p className="text-xs text-muted-foreground/60">{error}</p>
+        <Button variant="outline" size="sm" onClick={fetchData}>
+          <RefreshCw className="h-3 w-3 mr-2" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (nodes.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)] gap-4">
+        <Network className="h-12 w-12 text-muted-foreground/30" />
+        <p className="text-sm text-muted-foreground">No policies found</p>
+        <Link href="/" className="text-xs text-primary hover:underline">
+          Browse policies →
+        </Link>
       </div>
     );
   }
 
   return (
-    <div className="container mx-auto max-w-7xl px-4 py-8 md:py-10">
-      {/* Header */}
-      <div className="mb-8 space-y-2">
-        <div className="flex items-center gap-3">
-          <div className="rounded-xl bg-primary/10 p-3">
-            <Network className="h-6 w-6 text-primary" />
-          </div>
-          <h1 className="text-3xl font-bold tracking-tight">Relationship Network</h1>
+    <div className="relative w-full h-[calc(100vh-4rem)] overflow-hidden">
+      <NetworkToolbar
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        jurisdictions={jurisdictionInfo}
+        activeJurisdictions={activeJurisdictions}
+        onToggleJurisdiction={toggleJurisdiction}
+        totalPolicies={nodes.length}
+      />
+
+      <ForceGraph
+        nodes={nodes}
+        edges={edges}
+        searchQuery={searchQuery}
+        activeJurisdictions={activeJurisdictions}
+        selectedNodeId={selectedNodeId}
+        onNodeClick={setSelectedNodeId}
+      />
+
+      <NetworkSidebar
+        policy={selectedPolicy}
+        connectedPolicies={connectedPolicies}
+        onClose={() => setSelectedNodeId(null)}
+        onNavigateToNode={setSelectedNodeId}
+      />
+
+      {/* Partial data note */}
+      {edges.length === 0 && nodes.length > 0 && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-card/90 backdrop-blur border border-border rounded-lg px-4 py-2 text-xs text-muted-foreground">
+          No cross-policy connections found yet — policies may not share enough tags
         </div>
-        <p className="max-w-3xl text-muted-foreground">
-          Visualise connections between AI policies, government agencies, and jurisdictions across Australia
-        </p>
-      </div>
-
-      {/* Statistics Cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <Card className="border-indigo-500/15 bg-indigo-500/5 shadow-sm dark:border-indigo-400/20 dark:bg-indigo-400/10">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-indigo-500/20">
-                <Map className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold tabular-nums">{stats.jurisdictions}</div>
-                <p className="text-xs text-muted-foreground">Jurisdictions</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="border-green-500/15 bg-green-500/5 shadow-sm dark:border-green-400/20 dark:bg-green-400/10">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-green-500/20">
-                <FileText className="h-4 w-4 text-green-600 dark:text-green-400" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold tabular-nums">{stats.activePolicies}</div>
-                <p className="text-xs text-muted-foreground">Active Policies</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="border-amber-500/15 bg-amber-500/5 shadow-sm dark:border-amber-400/20 dark:bg-amber-400/10">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-amber-500/20">
-                <GitBranch className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold tabular-nums">{stats.proposedPolicies}</div>
-                <p className="text-xs text-muted-foreground">Proposed</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="border-purple-500/15 bg-purple-500/5 shadow-sm dark:border-purple-400/20 dark:bg-purple-400/10">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-purple-500/20">
-                <BarChart3 className="h-4 w-4 text-purple-600 dark:text-purple-400" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold tabular-nums">{stats.totalPolicies}</div>
-                <p className="text-xs text-muted-foreground">Total Policies</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div className="grid lg:grid-cols-4 gap-6">
-        {/* Sidebar: Filters & Legend */}
-        <div className="space-y-4 lg:col-span-1 lg:sticky lg:top-24 lg:self-start">
-          {/* Search */}
-          <Card className="shadow-sm">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Search className="h-4 w-4" />
-                Search
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="relative">
-                <Input
-                  placeholder="Search policies..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pr-8"
-                />
-                {searchQuery && (
-                  <button
-                    onClick={() => setSearchQuery('')}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Filters */}
-          <Card className="shadow-sm">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Filter className="h-4 w-4" />
-                Filters
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div>
-                <label className="text-xs font-medium mb-1.5 block text-muted-foreground">Jurisdiction</label>
-                <Select value={filterJurisdiction} onValueChange={setFilterJurisdiction}>
-                  <SelectTrigger className="h-9">
-                    <SelectValue placeholder="All Jurisdictions" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Jurisdictions</SelectItem>
-                    {Object.entries(JURISDICTION_NAMES).map(([key, name]) => (
-                      <SelectItem key={key} value={key}>
-                        {name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <label className="text-xs font-medium mb-1.5 block text-muted-foreground">Status</label>
-                <Select value={filterStatus} onValueChange={setFilterStatus}>
-                  <SelectTrigger className="h-9">
-                    <SelectValue placeholder="All Statuses" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Statuses</SelectItem>
-                    {Object.entries(POLICY_STATUS_NAMES).map(([key, name]) => (
-                      <SelectItem key={key} value={key}>
-                        {name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <label className="text-xs font-medium mb-1.5 block text-muted-foreground">Type</label>
-                <Select value={filterType} onValueChange={setFilterType}>
-                  <SelectTrigger className="h-9">
-                    <SelectValue placeholder="All Types" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Types</SelectItem>
-                    {Object.entries(POLICY_TYPE_NAMES).map(([key, name]) => (
-                      <SelectItem key={key} value={key}>
-                        {name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {hasActiveFilters && (
-                <Button variant="outline" size="sm" onClick={clearFilters} className="w-full">
-                  <X className="h-3 w-3 mr-1" />
-                  Clear Filters
-                </Button>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Legend */}
-          <Card className="shadow-sm">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Info className="h-4 w-4" />
-                Legend
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2.5">
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-jurisdiction-bg)' }}
-                />
-                <span className="text-xs">Jurisdiction</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-agency-bg)' }}
-                />
-                <span className="text-xs">Agency</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-active-bg)' }}
-                />
-                <span className="text-xs">Active Policy</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-proposed-bg)' }}
-                />
-                <span className="text-xs">Proposed Policy</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-amended-bg)' }}
-                />
-                <span className="text-xs">Amended Policy</span>
-              </div>
-              <div className="mt-3 pt-3 border-t">
-                <div className="flex items-center gap-2 mb-1.5">
-                  <div className="h-0.5 w-8 bg-green-500 rounded animate-pulse" />
-                  <span className="text-xs">Active Connection</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="h-0.5 w-8 bg-slate-400 rounded" />
-                  <span className="text-xs">Connection</span>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* How to Use */}
-          <Card className="shadow-sm">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm">Controls</CardTitle>
-            </CardHeader>
-            <CardContent className="text-xs text-muted-foreground space-y-1.5">
-              <p>• Drag to pan the view</p>
-              <p>• Scroll to zoom in/out</p>
-              <p>• Click nodes for details</p>
-              <p>• Hover to highlight connections</p>
-              <p>• Drag nodes to rearrange</p>
-              <p>• Use minimap for navigation</p>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Network Graph */}
-        <div className="lg:col-span-3">
-          <Card className="h-[440px] overflow-hidden shadow-sm lg:h-[700px]">
-            <CardContent className="p-0 h-full">
-              {highlightedNodes.length === 0 ? (
-                <div className="flex flex-col items-center justify-center h-full text-center p-8">
-                  <Network className="h-16 w-16 text-muted-foreground/30 mb-4" />
-                  <h3 className="text-lg font-medium mb-2">No Results Found</h3>
-                  <p className="text-sm text-muted-foreground mb-4">
-                    Try adjusting your filters or search query to see the network graph.
-                  </p>
-                  <Button variant="outline" size="sm" onClick={clearFilters}>
-                    Clear All Filters
-                  </Button>
-                </div>
-              ) : (
-                <ReactFlow
-                  nodes={highlightedNodes}
-                  edges={highlightedEdges}
-                  onNodesChange={onNodesChange}
-                  onEdgesChange={onEdgesChange}
-                  onNodeClick={onNodeClick}
-                  onNodeMouseEnter={onNodeMouseEnter}
-                  onNodeMouseLeave={onNodeMouseLeave}
-                  fitView
-                  fitViewOptions={{ padding: 0.2 }}
-                  attributionPosition="bottom-left"
-                  minZoom={0.3}
-                  maxZoom={2}
-                  defaultEdgeOptions={{
-                    type: 'smoothstep',
-                  }}
-                >
-                  <Controls showInteractive={false} />
-                  <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="var(--border)" />
-                  <MiniMap
-                    nodeColor={nodeColor}
-                    maskColor="var(--network-minimap-mask)"
-                    className="bg-background/80 backdrop-blur-sm border border-border rounded-lg"
-                    position="bottom-right"
-                  />
-                </ReactFlow>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-
-      {/* Node Detail Dialog */}
-      <Dialog open={!!selectedNode} onOpenChange={() => setSelectedNode(null)}>
-        <DialogContent className="max-w-lg">
-          {selectedNode?.data.type === 'policy' && (
-            <>
-              <DialogHeader>
-                <div className="flex items-center gap-2">
-                  <div className="p-2 rounded-lg bg-primary/10">
-                    <FileText className="h-5 w-5 text-primary" />
-                  </div>
-                  <div>
-                    <DialogTitle className="text-lg">Policy Details</DialogTitle>
-                    <DialogDescription className="text-xs">View policy information</DialogDescription>
-                  </div>
-                </div>
-              </DialogHeader>
-              <ScrollArea className="max-h-[400px] mt-4">
-                <div className="space-y-4">
-                  <h3 className="font-semibold">
-                    {(selectedNode.data.originalData as Policy).title}
-                  </h3>
-                  <div className="flex flex-wrap gap-2">
-                    <Badge
-                      variant={
-                        (selectedNode.data.originalData as Policy).status === 'active'
-                          ? 'default'
-                          : 'secondary'
-                      }
-                      className={
-                        (selectedNode.data.originalData as Policy).status === 'active'
-                          ? 'bg-[var(--status-active)] hover:opacity-90 text-background'
-                          : ''
-                      }
-                    >
-                      {
-                        POLICY_STATUS_NAMES[
-                          (selectedNode.data.originalData as Policy).status as PolicyStatus
-                        ]
-                      }
-                    </Badge>
-                    <Badge variant="outline">
-                      {
-                        POLICY_TYPE_NAMES[
-                          (selectedNode.data.originalData as Policy).type as PolicyType
-                        ]
-                      }
-                    </Badge>
-                    <Badge variant="secondary">
-                      {
-                        JURISDICTION_NAMES[
-                          (selectedNode.data.originalData as Policy).jurisdiction as Jurisdiction
-                        ]
-                      }
-                    </Badge>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {(selectedNode.data.originalData as Policy).description}
-                  </p>
-                  {(selectedNode.data.originalData as Policy).aiSummary && (
-                    <div className="p-4 bg-muted rounded-lg">
-                      <h4 className="text-sm font-medium mb-2">AI Summary</h4>
-                      <p className="text-sm text-muted-foreground">
-                        {(selectedNode.data.originalData as Policy).aiSummary}
-                      </p>
-                    </div>
-                  )}
-                  <div className="flex flex-wrap gap-2">
-                    {(selectedNode.data.originalData as Policy).tags?.map((tag) => (
-                      <Badge key={tag} variant="outline" className="text-xs">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                  {(selectedNode.data.originalData as Policy).sourceUrl && (
-                    <a
-                      href={(selectedNode.data.originalData as Policy).sourceUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-                    >
-                      <ExternalLink className="h-4 w-4" />
-                      View Source
-                    </a>
-                  )}
-                </div>
-              </ScrollArea>
-            </>
-          )}
-
-          {selectedNode?.data.type === 'agency' && (
-            <>
-              <DialogHeader>
-                <div className="flex items-center gap-2">
-                  <div className="p-2 rounded-lg bg-amber-500/10 dark:bg-amber-400/15">
-                    <Building2 className="h-5 w-5 text-amber-600 dark:text-amber-400" />
-                  </div>
-                  <div>
-                    <DialogTitle className="text-lg">Agency Details</DialogTitle>
-                    <DialogDescription className="text-xs">View agency information</DialogDescription>
-                  </div>
-                </div>
-              </DialogHeader>
-              <div className="space-y-4 mt-4">
-                <h3 className="font-semibold">
-                  {(selectedNode.data.originalData as Agency).name}
-                </h3>
-                <div className="flex flex-wrap gap-2">
-                  <Badge variant="default">
-                    {(selectedNode.data.originalData as Agency).acronym}
-                  </Badge>
-                  <Badge variant="outline">
-                    {(selectedNode.data.originalData as Agency).level}
-                  </Badge>
-                  <Badge variant="secondary">
-                    {
-                      JURISDICTION_NAMES[
-                        (selectedNode.data.originalData as Agency).jurisdiction as Jurisdiction
-                      ]
-                    }
-                  </Badge>
-                </div>
-                {(selectedNode.data.originalData as Agency).aiTransparencyStatement && (
-                  <div className="p-4 bg-muted rounded-lg">
-                    <h4 className="text-sm font-medium mb-2">AI Transparency Statement</h4>
-                    <p className="text-sm text-muted-foreground">
-                      {(selectedNode.data.originalData as Agency).aiTransparencyStatement}
-                    </p>
-                  </div>
-                )}
-                {(selectedNode.data.originalData as Agency).aiUsageDisclosure && (
-                  <div className="p-4 bg-blue-500/10 dark:bg-blue-400/10 rounded-lg border border-blue-500/20 dark:border-blue-400/20">
-                    <h4 className="text-sm font-medium mb-2">AI Usage Disclosure</h4>
-                    <p className="text-sm text-muted-foreground">
-                      {(selectedNode.data.originalData as Agency).aiUsageDisclosure}
-                    </p>
-                  </div>
-                )}
-                <a
-                  href={(selectedNode.data.originalData as Agency).website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-                >
-                  <ExternalLink className="h-4 w-4" />
-                  Visit Website
-                </a>
-              </div>
-            </>
-          )}
-
-          {selectedNode?.data.type === 'jurisdiction' && (
-            <>
-              <DialogHeader>
-                <div className="flex items-center gap-2">
-                  <div className="p-2 rounded-lg bg-indigo-500/10 dark:bg-indigo-400/15">
-                    <Map className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
-                  </div>
-                  <div>
-                    <DialogTitle className="text-lg">Jurisdiction</DialogTitle>
-                    <DialogDescription className="text-xs">
-                      {
-                        JURISDICTION_NAMES[
-                          (selectedNode.data.originalData as { jurisdiction: Jurisdiction }).jurisdiction
-                        ]
-                      }
-                    </DialogDescription>
-                  </div>
-                </div>
-              </DialogHeader>
-              <div className="space-y-4 mt-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <Card className="bg-gradient-to-br from-green-500/10 to-green-500/5 border-green-500/20 dark:from-green-400/15 dark:to-green-400/5 dark:border-green-400/20">
-                    <CardContent className="pt-4 pb-3">
-                      <div className="text-2xl font-bold">
-                        {
-                          policiesData.filter(
-                            (p) =>
-                              p.jurisdiction ===
-                              (selectedNode.data.originalData as { jurisdiction: Jurisdiction }).jurisdiction
-                          ).length
-                        }
-                      </div>
-                      <p className="text-xs text-muted-foreground">Policies</p>
-                    </CardContent>
-                  </Card>
-                  <Card className="bg-gradient-to-br from-amber-500/10 to-amber-500/5 border-amber-500/20 dark:from-amber-400/15 dark:to-amber-400/5 dark:border-amber-400/20">
-                    <CardContent className="pt-4 pb-3">
-                      <div className="text-2xl font-bold">
-                        {
-                          agenciesData.filter(
-                            (a) =>
-                              a.jurisdiction ===
-                              (selectedNode.data.originalData as { jurisdiction: Jurisdiction }).jurisdiction
-                          ).length
-                        }
-                      </div>
-                      <p className="text-xs text-muted-foreground">Agencies</p>
-                    </CardContent>
-                  </Card>
-                </div>
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  onClick={() => {
-                    setFilterJurisdiction(
-                      (selectedNode.data.originalData as { jurisdiction: Jurisdiction }).jurisdiction
-                    );
-                    setSelectedNode(null);
-                  }}
-                >
-                  <Filter className="h-4 w-4 mr-2" />
-                  Filter by this Jurisdiction
-                </Button>
-              </div>
-            </>
-          )}
-        </DialogContent>
-      </Dialog>
+      )}
     </div>
   );
 }

--- a/src/components/auth/ProtectedRoute.test.tsx
+++ b/src/components/auth/ProtectedRoute.test.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { push, useAuth } = vi.hoisted(() => ({
+  push: vi.fn(),
+  useAuth: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push,
+  }),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth,
+}))
+
+import { ProtectedRoute } from './ProtectedRoute'
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    push.mockReset()
+    useAuth.mockReset()
+  })
+
+  it('shows a loading state while auth is resolving', () => {
+    useAuth.mockReturnValue({
+      user: null,
+      isLoading: true,
+    })
+
+    render(
+      <ProtectedRoute>
+        <div>Secret content</div>
+      </ProtectedRoute>,
+    )
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(screen.queryByText('Secret content')).not.toBeInTheDocument()
+  })
+
+  it('redirects unauthenticated users to the admin login page', async () => {
+    useAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+    })
+
+    const { container } = render(
+      <ProtectedRoute>
+        <div>Secret content</div>
+      </ProtectedRoute>,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith('/admin/login')
+    })
+  })
+
+  it('renders children for authenticated users', () => {
+    useAuth.mockReturnValue({
+      user: { id: 'user-1' },
+      isLoading: false,
+    })
+
+    render(
+      <ProtectedRoute>
+        <div>Secret content</div>
+      </ProtectedRoute>,
+    )
+
+    expect(screen.getByText('Secret content')).toBeInTheDocument()
+    expect(push).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/network/ForceGraph.tsx
+++ b/src/components/network/ForceGraph.tsx
@@ -1,0 +1,297 @@
+'use client';
+
+import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import { zoom as d3Zoom, type ZoomBehavior } from 'd3-zoom';
+import { select } from 'd3-selection';
+import { drag as d3Drag } from 'd3-drag';
+import type { NetworkNode, NetworkEdge } from '@/app/api/network/route';
+import { useForceSimulation, type SimNode } from './use-force-simulation';
+import { JURISDICTION_COLORS, resolveColor } from './jurisdiction-colors';
+import { JURISDICTION_NAMES, type Jurisdiction } from '@/types';
+
+interface ForceGraphProps {
+  nodes: NetworkNode[];
+  edges: NetworkEdge[];
+  searchQuery: string;
+  activeJurisdictions: Set<string>;
+  selectedNodeId: string | null;
+  onNodeClick: (id: string) => void;
+}
+
+const STATUS_RING_COLORS: Record<string, string> = {
+  active: 'var(--status-active)',
+  proposed: 'var(--status-proposed)',
+  amended: 'var(--status-amended)',
+  repealed: 'var(--status-repealed)',
+};
+
+export function ForceGraph({
+  nodes,
+  edges,
+  searchQuery,
+  activeJurisdictions,
+  selectedNodeId,
+  onNodeClick,
+}: ForceGraphProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const gRef = useRef<SVGGElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
+  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [transform, setTransform] = useState({ x: 0, y: 0, k: 1 });
+
+  // Measure container
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      if (width > 0 && height > 0) setDimensions({ width, height });
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const { simNodes, simEdges, simulation } = useForceSimulation(
+    nodes,
+    edges,
+    dimensions.width,
+    dimensions.height,
+  );
+
+  // Compute cluster centroids for labels
+  const clusterLabels = useMemo(() => {
+    const groups: Record<string, { xs: number[]; ys: number[] }> = {};
+    for (const node of simNodes) {
+      if (!groups[node.jurisdiction]) groups[node.jurisdiction] = { xs: [], ys: [] };
+      groups[node.jurisdiction].xs.push(node.x);
+      groups[node.jurisdiction].ys.push(node.y);
+    }
+    return Object.entries(groups).map(([jurisdiction, { xs, ys }]) => ({
+      jurisdiction,
+      label: JURISDICTION_NAMES[jurisdiction as Jurisdiction] || jurisdiction,
+      x: xs.reduce((a, b) => a + b, 0) / xs.length,
+      y: ys.reduce((a, b) => a + b, 0) / ys.length - 30,
+    }));
+  }, [simNodes]);
+
+  // Zoom behavior
+  useEffect(() => {
+    if (!svgRef.current) return;
+    const svg = select(svgRef.current);
+    const zoomBehavior: ZoomBehavior<SVGSVGElement, unknown> = d3Zoom<SVGSVGElement, unknown>()
+      .scaleExtent([0.3, 3])
+      .on('zoom', (event) => {
+        setTransform({ x: event.transform.x, y: event.transform.y, k: event.transform.k });
+      });
+    svg.call(zoomBehavior);
+    return () => { svg.on('.zoom', null); };
+  }, []);
+
+  // Drag behavior
+  const handleDragStart = useCallback(
+    (nodeId: string) => {
+      const sim = simulation.current;
+      if (sim) sim.alphaTarget(0.3).restart();
+      const node = sim?.nodes().find((n) => (n as SimNode).id === nodeId) as SimNode | undefined;
+      if (node) node.fx = node.x;
+      if (node) node.fy = node.y;
+    },
+    [simulation],
+  );
+
+  const handleDrag = useCallback(
+    (nodeId: string, dx: number, dy: number) => {
+      const sim = simulation.current;
+      const node = sim?.nodes().find((n) => (n as SimNode).id === nodeId) as SimNode | undefined;
+      if (node) {
+        node.fx = (node.fx ?? node.x) + dx / transform.k;
+        node.fy = (node.fy ?? node.y) + dy / transform.k;
+      }
+    },
+    [simulation, transform.k],
+  );
+
+  const handleDragEnd = useCallback(
+    (nodeId: string) => {
+      const sim = simulation.current;
+      if (sim) sim.alphaTarget(0);
+      const node = sim?.nodes().find((n) => (n as SimNode).id === nodeId) as SimNode | undefined;
+      if (node) { node.fx = null; node.fy = null; }
+    },
+    [simulation],
+  );
+
+  // Node visibility
+  const isNodeVisible = useCallback(
+    (node: SimNode) => {
+      if (!activeJurisdictions.has(node.jurisdiction)) return false;
+      if (searchQuery && !node.title.toLowerCase().includes(searchQuery.toLowerCase())) return false;
+      return true;
+    },
+    [activeJurisdictions, searchQuery],
+  );
+
+  // Connected node highlighting
+  const connectedIds = useMemo(() => {
+    if (!hoveredNode) return new Set<string>();
+    const ids = new Set<string>();
+    ids.add(hoveredNode);
+    for (const edge of simEdges) {
+      const src = typeof edge.source === 'object' ? (edge.source as SimNode).id : String(edge.source);
+      const tgt = typeof edge.target === 'object' ? (edge.target as SimNode).id : String(edge.target);
+      if (src === hoveredNode) ids.add(tgt);
+      if (tgt === hoveredNode) ids.add(src);
+    }
+    return ids;
+  }, [hoveredNode, simEdges]);
+
+  return (
+    <div ref={containerRef} className="w-full h-full relative">
+      <svg
+        ref={svgRef}
+        width={dimensions.width}
+        height={dimensions.height}
+        className="cursor-grab active:cursor-grabbing"
+      >
+        {/* Background pattern */}
+        <defs>
+          <pattern id="network-dots" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+            <circle cx="10" cy="10" r="0.8" className="fill-border" />
+          </pattern>
+        </defs>
+        <rect width={dimensions.width} height={dimensions.height} fill="url(#network-dots)" />
+
+        <g ref={gRef} transform={`translate(${transform.x},${transform.y}) scale(${transform.k})`}>
+          {/* Edges */}
+          {simEdges.map((edge, i) => {
+            const src = edge.source as SimNode;
+            const tgt = edge.target as SimNode;
+            if (!isNodeVisible(src) || !isNodeVisible(tgt)) return null;
+
+            const isHighlighted = hoveredNode && (connectedIds.has(src.id) && connectedIds.has(tgt.id));
+            const jurisdictionColor = resolveColor(JURISDICTION_COLORS[src.jurisdiction] || 'var(--chart-1)');
+
+            return (
+              <line
+                key={`edge-${i}`}
+                x1={src.x}
+                y1={src.y}
+                x2={tgt.x}
+                y2={tgt.y}
+                stroke={edge.crossJurisdiction ? '#a855f7' : jurisdictionColor}
+                strokeWidth={isHighlighted ? 2.5 : 1}
+                strokeDasharray={edge.crossJurisdiction ? '6,3' : undefined}
+                opacity={hoveredNode ? (isHighlighted ? 0.8 : 0.15) : 0.3}
+                className="transition-opacity duration-200"
+              />
+            );
+          })}
+
+          {/* Cluster labels */}
+          {clusterLabels
+            .filter((cl) => activeJurisdictions.has(cl.jurisdiction))
+            .map((cl) => (
+              <text
+                key={`label-${cl.jurisdiction}`}
+                x={cl.x}
+                y={cl.y}
+                textAnchor="middle"
+                className="fill-muted-foreground font-sans text-[11px] font-medium pointer-events-none select-none"
+                opacity={0.5}
+              >
+                {cl.label}
+              </text>
+            ))}
+
+          {/* Nodes */}
+          {simNodes.map((node) => {
+            const visible = isNodeVisible(node);
+            const isHovered = hoveredNode === node.id;
+            const isSelected = selectedNodeId === node.id;
+            const isConnected = connectedIds.has(node.id);
+            const jurisdictionColor = resolveColor(JURISDICTION_COLORS[node.jurisdiction] || 'var(--chart-1)');
+            const statusColor = resolveColor(STATUS_RING_COLORS[node.status] || 'var(--status-repealed)');
+
+            const nodeOpacity = !visible
+              ? 0.08
+              : hoveredNode
+                ? isConnected
+                  ? 1
+                  : 0.25
+                : 1;
+
+            return (
+              <g
+                key={node.id}
+                transform={`translate(${node.x},${node.y})`}
+                opacity={nodeOpacity}
+                className="transition-opacity duration-200 cursor-pointer"
+                onMouseEnter={() => setHoveredNode(node.id)}
+                onMouseLeave={() => setHoveredNode(null)}
+                onClick={() => onNodeClick(node.id)}
+                onMouseDown={(e) => {
+                  const startX = e.clientX;
+                  const startY = e.clientY;
+                  let dragged = false;
+                  handleDragStart(node.id);
+
+                  const onMove = (ev: MouseEvent) => {
+                    const dx = ev.clientX - startX;
+                    const dy = ev.clientY - startY;
+                    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) dragged = true;
+                    handleDrag(node.id, ev.movementX, ev.movementY);
+                  };
+                  const onUp = () => {
+                    handleDragEnd(node.id);
+                    window.removeEventListener('mousemove', onMove);
+                    window.removeEventListener('mouseup', onUp);
+                    if (!dragged) onNodeClick(node.id);
+                  };
+                  window.addEventListener('mousemove', onMove);
+                  window.addEventListener('mouseup', onUp);
+                  e.stopPropagation();
+                }}
+              >
+                {/* Status ring */}
+                <circle
+                  r={node.radius + 2}
+                  fill="none"
+                  stroke={statusColor}
+                  strokeWidth={isSelected ? 2.5 : 1.5}
+                  opacity={isHovered || isSelected ? 1 : 0.6}
+                />
+                {/* Node circle */}
+                <circle
+                  r={isHovered ? node.radius * 1.2 : node.radius}
+                  fill={jurisdictionColor}
+                  className="transition-all duration-150"
+                />
+                {/* Hover label */}
+                {isHovered && (
+                  <>
+                    <rect
+                      x={-node.title.length * 3.2}
+                      y={-node.radius - 26}
+                      width={node.title.length * 6.4}
+                      height={18}
+                      rx={4}
+                      className="fill-card stroke-border"
+                      strokeWidth={0.5}
+                    />
+                    <text
+                      y={-node.radius - 14}
+                      textAnchor="middle"
+                      className="fill-foreground font-sans text-[10px] pointer-events-none select-none"
+                    >
+                      {node.title.length > 40 ? node.title.slice(0, 37) + '...' : node.title}
+                    </text>
+                  </>
+                )}
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/network/NetworkSidebar.tsx
+++ b/src/components/network/NetworkSidebar.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { X, ExternalLink, ArrowRight } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { JURISDICTION_NAMES, POLICY_TYPE_NAMES, POLICY_STATUS_NAMES, type Jurisdiction, type PolicyType, type PolicyStatus } from '@/types';
+import type { NetworkNode } from '@/app/api/network/route';
+import { JURISDICTION_COLORS, resolveColor } from './jurisdiction-colors';
+
+interface ConnectedPolicy {
+  id: string;
+  title: string;
+  jurisdiction: string;
+}
+
+interface NetworkSidebarProps {
+  policy: NetworkNode | null;
+  connectedPolicies: ConnectedPolicy[];
+  onClose: () => void;
+  onNavigateToNode: (id: string) => void;
+}
+
+export function NetworkSidebar({
+  policy,
+  connectedPolicies,
+  onClose,
+  onNavigateToNode,
+}: NetworkSidebarProps) {
+  return (
+    <div
+      className={`absolute top-0 right-0 bottom-0 w-80 bg-card/95 backdrop-blur-xl border-l border-border transition-transform duration-300 z-20 ${
+        policy ? 'translate-x-0' : 'translate-x-full'
+      }`}
+    >
+      {policy && (
+        <ScrollArea className="h-full">
+          <div className="p-5 space-y-4">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground font-semibold">
+                Policy Detail
+              </span>
+              <button
+                onClick={onClose}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            {/* Badges */}
+            <div className="flex flex-wrap gap-1.5">
+              <Badge
+                variant="default"
+                className="text-[10px]"
+                style={{
+                  backgroundColor: `var(--status-${policy.status}-bg)`,
+                  color: `var(--status-${policy.status})`,
+                  border: 'none',
+                }}
+              >
+                {POLICY_STATUS_NAMES[policy.status as PolicyStatus] || policy.status}
+              </Badge>
+              <Badge variant="outline" className="text-[10px]">
+                {POLICY_TYPE_NAMES[policy.type as PolicyType] || policy.type}
+              </Badge>
+              <Badge variant="secondary" className="text-[10px]">
+                {JURISDICTION_NAMES[policy.jurisdiction as Jurisdiction] || policy.jurisdiction}
+              </Badge>
+            </div>
+
+            {/* Title */}
+            <h3 className="text-base font-semibold leading-snug">{policy.title}</h3>
+
+            {/* Date */}
+            {policy.effectiveDate && (
+              <p className="text-[11px] text-muted-foreground">
+                Effective: {new Date(policy.effectiveDate).toLocaleDateString('en-AU', {
+                  day: 'numeric',
+                  month: 'short',
+                  year: 'numeric',
+                })}
+              </p>
+            )}
+
+            {/* Description */}
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {policy.description.length > 250
+                ? policy.description.slice(0, 247) + '...'
+                : policy.description}
+            </p>
+
+            {/* Connected policies */}
+            {connectedPolicies.length > 0 && (
+              <div>
+                <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground font-semibold block mb-2">
+                  Connected Policies
+                </span>
+                <div className="space-y-1">
+                  {connectedPolicies.map((cp) => (
+                    <button
+                      key={cp.id}
+                      onClick={() => onNavigateToNode(cp.id)}
+                      className="flex items-center gap-2 w-full px-2.5 py-2 rounded-lg bg-muted/50 hover:bg-muted text-left transition-colors group"
+                    >
+                      <div
+                        className="w-2 h-2 rounded-full flex-shrink-0"
+                        style={{ backgroundColor: resolveColor(JURISDICTION_COLORS[cp.jurisdiction] || 'var(--chart-1)') }}
+                      />
+                      <span className="text-xs text-foreground truncate flex-1">
+                        {cp.title}
+                      </span>
+                      <ArrowRight className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Agencies */}
+            {policy.agencies.length > 0 && (
+              <div>
+                <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground font-semibold block mb-2">
+                  Agencies
+                </span>
+                <div className="space-y-1">
+                  {policy.agencies.map((agency) => (
+                    <p key={agency} className="text-xs text-muted-foreground">
+                      {agency}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Tags */}
+            {policy.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {policy.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="bg-muted text-muted-foreground px-2 py-0.5 rounded text-[10px]"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex gap-2 pt-2">
+              <a
+                href={`/policies/${policy.id}`}
+                className="flex-1 flex items-center justify-center gap-1 px-3 py-2 bg-muted hover:bg-accent border border-border rounded-lg text-xs font-medium transition-colors"
+              >
+                View Full Policy
+                <ArrowRight className="h-3 w-3" />
+              </a>
+              {policy.sourceUrl && (
+                <a
+                  href={policy.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 px-3 py-2 bg-muted/50 hover:bg-muted border border-border rounded-lg text-xs text-muted-foreground transition-colors"
+                >
+                  Source
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              )}
+            </div>
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  );
+}

--- a/src/components/network/NetworkToolbar.tsx
+++ b/src/components/network/NetworkToolbar.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { Search, X } from 'lucide-react';
+import { JURISDICTION_NAMES, type Jurisdiction } from '@/types';
+import { JURISDICTION_COLORS } from './jurisdiction-colors';
+
+interface JurisdictionInfo {
+  key: string;
+  label: string;
+  color: string;
+  count: number;
+}
+
+interface NetworkToolbarProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  jurisdictions: JurisdictionInfo[];
+  activeJurisdictions: Set<string>;
+  onToggleJurisdiction: (key: string) => void;
+  totalPolicies: number;
+}
+
+export function NetworkToolbar({
+  searchQuery,
+  onSearchChange,
+  jurisdictions,
+  activeJurisdictions,
+  onToggleJurisdiction,
+  totalPolicies,
+}: NetworkToolbarProps) {
+  return (
+    <div className="absolute top-4 left-4 right-4 z-10 flex items-center gap-3 bg-card/90 backdrop-blur-lg border border-border rounded-xl px-4 py-2.5 shadow-sm">
+      {/* Search */}
+      <div className="relative flex-shrink-0 w-48">
+        <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+        <input
+          type="text"
+          placeholder="Search policies..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-full bg-muted/50 border border-border rounded-lg pl-7 pr-7 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/60"
+        />
+        {searchQuery && (
+          <button
+            onClick={() => onSearchChange('')}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="w-px h-6 bg-border" />
+
+      {/* Jurisdiction pills */}
+      <div className="flex gap-1.5 flex-wrap flex-1 min-w-0">
+        {jurisdictions.map((j) => {
+          const active = activeJurisdictions.has(j.key);
+          return (
+            <button
+              key={j.key}
+              onClick={() => onToggleJurisdiction(j.key)}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium transition-all"
+              style={
+                active
+                  ? { background: j.color, color: 'white' }
+                  : { background: 'transparent', color: 'var(--muted-foreground)', border: '1px solid var(--border)' }
+              }
+            >
+              {j.label}
+              <span className="opacity-70">{j.count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Stats */}
+      <div className="flex-shrink-0 font-mono text-[11px] text-muted-foreground whitespace-nowrap">
+        <strong className="text-foreground">{totalPolicies}</strong> policies
+      </div>
+    </div>
+  );
+}

--- a/src/components/network/jurisdiction-colors.ts
+++ b/src/components/network/jurisdiction-colors.ts
@@ -1,0 +1,20 @@
+export const JURISDICTION_COLORS: Record<string, string> = {
+  federal: 'var(--chart-1)',
+  nsw: 'var(--chart-2)',
+  wa: 'var(--chart-3)',
+  qld: 'var(--chart-3)',
+  act: 'var(--chart-4)',
+  vic: 'var(--chart-4)',
+  sa: 'var(--chart-5)',
+  tas: 'var(--chart-5)',
+  nt: 'var(--chart-5)',
+};
+
+/** Resolve CSS variable to a concrete color for D3 (which can't use CSS vars in SVG). */
+export function resolveColor(cssVar: string): string {
+  if (typeof window === 'undefined') return '#888';
+  const resolved = getComputedStyle(document.documentElement)
+    .getPropertyValue(cssVar.replace('var(', '').replace(')', ''))
+    .trim();
+  return resolved || '#888';
+}

--- a/src/components/network/use-force-simulation.ts
+++ b/src/components/network/use-force-simulation.ts
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import {
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCollide,
+  forceX,
+  forceY,
+  type Simulation,
+  type SimulationNodeDatum,
+  type SimulationLinkDatum,
+} from 'd3-force';
+import type { NetworkNode, NetworkEdge } from '@/app/api/network/route';
+
+export interface SimNode extends SimulationNodeDatum, NetworkNode {
+  x: number;
+  y: number;
+  radius: number;
+}
+
+export interface SimEdge extends SimulationLinkDatum<SimNode> {
+  weight: number;
+  crossJurisdiction: boolean;
+}
+
+/** Compute cluster centroids for jurisdiction-based grouping. */
+function getJurisdictionCentroids(
+  jurisdictions: string[],
+  width: number,
+  height: number,
+): Record<string, { x: number; y: number }> {
+  const centroids: Record<string, { x: number; y: number }> = {};
+  const count = jurisdictions.length;
+  const cx = width / 2;
+  const cy = height / 2;
+  const radius = Math.min(width, height) * 0.3;
+
+  jurisdictions.forEach((j, i) => {
+    const angle = (2 * Math.PI * i) / count - Math.PI / 2;
+    centroids[j] = {
+      x: cx + radius * Math.cos(angle),
+      y: cy + radius * Math.sin(angle),
+    };
+  });
+
+  return centroids;
+}
+
+export function useForceSimulation(
+  nodes: NetworkNode[],
+  edges: NetworkEdge[],
+  width: number,
+  height: number,
+) {
+  const simRef = useRef<Simulation<SimNode, SimEdge> | null>(null);
+  const [simNodes, setSimNodes] = useState<SimNode[]>([]);
+  const [simEdges, setSimEdges] = useState<SimEdge[]>([]);
+  const tickRef = useRef(0);
+
+  const updatePositions = useCallback(() => {
+    if (!simRef.current) return;
+    const currentNodes = simRef.current.nodes() as SimNode[];
+    // Only update state every 3 ticks for performance
+    tickRef.current++;
+    if (tickRef.current % 3 === 0 || tickRef.current < 10) {
+      setSimNodes([...currentNodes]);
+      setSimEdges([...(simRef.current.force('link') as ReturnType<typeof forceLink<SimNode, SimEdge>>).links()]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (nodes.length === 0 || width === 0 || height === 0) return;
+
+    // Build jurisdiction centroids
+    const jurisdictions = [...new Set(nodes.map((n) => n.jurisdiction))];
+    const centroids = getJurisdictionCentroids(jurisdictions, width, height);
+
+    // Create simulation nodes with initial positions near their jurisdiction centroid
+    const simNodeData: SimNode[] = nodes.map((n) => {
+      const centroid = centroids[n.jurisdiction] || { x: width / 2, y: height / 2 };
+      return {
+        ...n,
+        x: centroid.x + (Math.random() - 0.5) * 80,
+        y: centroid.y + (Math.random() - 0.5) * 80,
+        radius: Math.max(5, Math.min(12, 4 + n.tags.length)),
+      };
+    });
+
+    // Create simulation edges (referencing node objects)
+    const nodeMap = new Map(simNodeData.map((n) => [n.id, n]));
+    const simEdgeData: SimEdge[] = edges
+      .filter((e) => nodeMap.has(e.source) && nodeMap.has(e.target))
+      .map((e) => ({
+        source: nodeMap.get(e.source)!,
+        target: nodeMap.get(e.target)!,
+        weight: e.weight,
+        crossJurisdiction: e.crossJurisdiction,
+      }));
+
+    // Stop previous simulation
+    if (simRef.current) simRef.current.stop();
+
+    tickRef.current = 0;
+
+    const simulation = forceSimulation<SimNode>(simNodeData)
+      .force(
+        'link',
+        forceLink<SimNode, SimEdge>(simEdgeData)
+          .id((d) => d.id)
+          .distance(60)
+          .strength((d) => 0.1 * d.weight),
+      )
+      .force('charge', forceManyBody<SimNode>().strength(-120))
+      .force('collide', forceCollide<SimNode>().radius((d) => d.radius + 4))
+      // Cluster force: attract toward jurisdiction centroid
+      .force(
+        'x',
+        forceX<SimNode>()
+          .x((d) => centroids[d.jurisdiction]?.x ?? width / 2)
+          .strength(0.15),
+      )
+      .force(
+        'y',
+        forceY<SimNode>()
+          .y((d) => centroids[d.jurisdiction]?.y ?? height / 2)
+          .strength(0.15),
+      )
+      .on('tick', updatePositions)
+      .alphaDecay(0.02);
+
+    simRef.current = simulation;
+
+    // Final positions after simulation settles
+    return () => {
+      simulation.stop();
+    };
+  }, [nodes, edges, width, height, updatePositions]);
+
+  return { simNodes, simEdges, simulation: simRef };
+}

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,132 @@
+/* @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createClient = vi.fn()
+const getUser = vi.fn()
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient,
+}))
+
+const originalEnv = {
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  supabaseAnonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+  adminPassword: process.env.ADMIN_PASSWORD,
+  nodeEnv: process.env.NODE_ENV,
+}
+
+async function loadAuthModule() {
+  vi.resetModules()
+  return import('./auth')
+}
+
+describe('auth helpers', () => {
+  beforeEach(() => {
+    createClient.mockReset()
+    getUser.mockReset()
+    createClient.mockReturnValue({
+      auth: {
+        getUser,
+      },
+    })
+
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    delete process.env.ADMIN_PASSWORD
+    process.env.NODE_ENV = 'test'
+  })
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = originalEnv.supabaseUrl
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalEnv.supabaseAnonKey
+    process.env.ADMIN_PASSWORD = originalEnv.adminPassword
+    process.env.NODE_ENV = originalEnv.nodeEnv
+  })
+
+  it('authenticates with Supabase when credentials and a session are present', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon-key'
+    getUser.mockResolvedValue({
+      data: { user: { id: 'supabase-user', email: 'user@example.com' } },
+      error: null,
+    })
+
+    const { verifyAuth } = await loadAuthModule()
+    const request = new Request('https://example.com/api/policies', {
+      headers: {
+        authorization: 'Bearer token',
+        cookie: 'sb-access-token=test',
+      },
+    })
+
+    await expect(verifyAuth(request)).resolves.toEqual({
+      id: 'supabase-user',
+      email: 'user@example.com',
+    })
+
+    expect(createClient).toHaveBeenCalledWith(
+      'https://example.supabase.co',
+      'anon-key',
+      expect.objectContaining({
+        global: {
+          headers: {
+            Authorization: 'Bearer token',
+            Cookie: 'sb-access-token=test',
+          },
+        },
+      }),
+    )
+  })
+
+  it('authenticates with the admin password header when configured', async () => {
+    process.env.ADMIN_PASSWORD = 'secret'
+    const { verifyAuth } = await loadAuthModule()
+
+    const request = new Request('https://example.com/api/policies', {
+      headers: {
+        'x-admin-password': 'secret',
+      },
+    })
+
+    await expect(verifyAuth(request)).resolves.toEqual({
+      id: 'admin',
+      email: 'admin@local',
+    })
+  })
+
+  it('denies access when the admin password is configured but incorrect', async () => {
+    process.env.ADMIN_PASSWORD = 'secret'
+    const { verifyAuth } = await loadAuthModule()
+
+    const request = new Request('https://example.com/api/policies', {
+      headers: {
+        'x-admin-password': 'wrong',
+      },
+    })
+
+    await expect(verifyAuth(request)).resolves.toBeNull()
+  })
+
+  it('grants local access in development when no auth backend is configured', async () => {
+    process.env.NODE_ENV = 'development'
+    const { verifyAuth } = await loadAuthModule()
+
+    await expect(verifyAuth(new Request('https://example.com/api/policies'))).resolves.toEqual({
+      id: 'local-admin',
+      email: 'admin@localhost',
+    })
+  })
+
+  it('returns an unauthorized response payload', async () => {
+    const { unauthorizedResponse } = await loadAuthModule()
+
+    const response = unauthorizedResponse()
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Unauthorized - Admin authentication required',
+      success: false,
+    })
+  })
+})

--- a/src/lib/data-service.test.ts
+++ b/src/lib/data-service.test.ts
@@ -1,0 +1,169 @@
+/* @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildAgency, buildPolicy, buildScraperRunLog, buildTimelineEvent } from '@/test/factories'
+
+const readJsonFile = vi.fn()
+const writeJsonFile = vi.fn()
+
+vi.mock('@/lib/file-store', () => ({
+  readJsonFile,
+  writeJsonFile,
+}))
+
+const originalEnv = {
+  supabaseUrl: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  supabaseAnonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+}
+
+async function loadDataServiceModule() {
+  vi.resetModules()
+  return import('./data-service')
+}
+
+describe('data-service JSON fallback', () => {
+  beforeEach(() => {
+    readJsonFile.mockReset()
+    writeJsonFile.mockReset()
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  })
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = originalEnv.supabaseUrl
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalEnv.supabaseAnonKey
+  })
+
+  it('filters and sorts policies from the JSON fallback', async () => {
+    const older = buildPolicy({
+      id: 'older-policy',
+      title: 'Older ethics policy',
+      effectiveDate: '2024-01-01',
+      tags: ['ethics'],
+    })
+    const newer = buildPolicy({
+      id: 'newer-policy',
+      title: 'Newer ethics policy',
+      effectiveDate: '2025-03-01',
+      tags: ['ethics', 'governance'],
+    })
+    const excluded = buildPolicy({
+      id: 'excluded-policy',
+      jurisdiction: 'nsw',
+      tags: ['other'],
+    })
+
+    readJsonFile.mockResolvedValue([older, newer, excluded])
+
+    const { getPolicies } = await loadDataServiceModule()
+    const result = await getPolicies({
+      jurisdiction: 'federal',
+      search: 'ethics',
+    })
+
+    expect(result.map((policy) => policy.id)).toEqual(['newer-policy', 'older-policy'])
+  })
+
+  it('throws a typed error when a duplicate policy is created', async () => {
+    const existing = buildPolicy()
+    readJsonFile.mockResolvedValue([existing])
+
+    const { createPolicy, DuplicatePolicyError } = await loadDataServiceModule()
+
+    await expect(createPolicy(existing)).rejects.toBeInstanceOf(DuplicatePolicyError)
+    expect(writeJsonFile).not.toHaveBeenCalled()
+  })
+
+  it('adds and removes trashed metadata when policy status changes', async () => {
+    const policy = buildPolicy()
+    readJsonFile.mockResolvedValue([policy])
+
+    const { updatePolicy } = await loadDataServiceModule()
+
+    const trashed = await updatePolicy(policy.id, { status: 'trashed' })
+    expect(trashed).toEqual(
+      expect.objectContaining({
+        status: 'trashed',
+        trashedAt: expect.any(String),
+      }),
+    )
+
+    const persistedAfterTrash = writeJsonFile.mock.calls[0]?.[1]?.[0]
+    expect(persistedAfterTrash).toEqual(expect.objectContaining({ status: 'trashed', trashedAt: expect.any(String) }))
+
+    readJsonFile.mockResolvedValue([
+      {
+        ...policy,
+        status: 'trashed',
+        trashedAt: '2025-01-02T00:00:00.000Z',
+      },
+    ])
+
+    const restored = await updatePolicy(policy.id, { status: 'active' })
+    expect(restored).toEqual(expect.objectContaining({ status: 'active' }))
+    expect(restored).not.toHaveProperty('trashedAt')
+  })
+
+  it('filters agencies and sorts them alphabetically', async () => {
+    readJsonFile.mockResolvedValue([
+      buildAgency({ id: 'a-2', name: 'Zeta Office' }),
+      buildAgency({ id: 'a-1', name: 'Alpha Office' }),
+      buildAgency({ id: 'a-3', level: 'state', jurisdiction: 'nsw', name: 'NSW Office' }),
+    ])
+
+    const { getAgencies } = await loadDataServiceModule()
+    const result = await getAgencies({ level: 'federal' })
+
+    expect(result.map((agency) => agency.name)).toEqual(['Alpha Office', 'Zeta Office'])
+  })
+
+  it('merges curated and generated timeline events without duplicating curated policy entries', async () => {
+    const coveredPolicy = buildPolicy({
+      id: 'covered-policy',
+      title: 'Covered policy',
+      effectiveDate: '2025-01-10',
+    })
+    const generatedPolicy = buildPolicy({
+      id: 'generated-policy',
+      title: 'Generated policy',
+      effectiveDate: '2025-01-20',
+      description: 'x'.repeat(240),
+    })
+    const manualEvent = buildTimelineEvent({
+      id: 'manual-event',
+      date: '2025-01-05',
+      relatedPolicyId: coveredPolicy.id,
+    })
+
+    readJsonFile
+      .mockResolvedValueOnce([coveredPolicy, generatedPolicy])
+      .mockResolvedValueOnce([manualEvent])
+
+    const { getTimelineEvents } = await loadDataServiceModule()
+    const result = await getTimelineEvents({ jurisdiction: 'federal' })
+
+    expect(result.map((event) => event.id)).toEqual(['manual-event', 'policy-timeline-generated-policy'])
+    expect(result[1]).toEqual(
+      expect.objectContaining({
+        title: 'Generated policy',
+        description: `${'x'.repeat(197)}...`,
+      }),
+    )
+  })
+
+  it('caps persisted scraper logs at the most recent 100 entries', async () => {
+    readJsonFile.mockResolvedValue(
+      Array.from({ length: 100 }, (_, index) =>
+        buildScraperRunLog({ id: `existing-${index}`, timestamp: `2025-02-${String(index + 1).padStart(2, '0')}T00:00:00.000Z` }),
+      ),
+    )
+
+    const { logScraperRun } = await loadDataServiceModule()
+    await logScraperRun(buildScraperRunLog({ id: 'latest-run' }))
+
+    const persistedRuns = writeJsonFile.mock.calls[0]?.[1]
+    expect(persistedRuns).toHaveLength(100)
+    expect(persistedRuns[0]).toEqual(expect.objectContaining({ id: 'latest-run' }))
+    expect(persistedRuns.at(-1)).toEqual(expect.objectContaining({ id: 'existing-98' }))
+  })
+})

--- a/src/lib/file-store.test.ts
+++ b/src/lib/file-store.test.ts
@@ -1,0 +1,50 @@
+/* @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readFile, writeFile } = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}))
+
+vi.mock('fs', () => ({
+  promises: {
+    readFile,
+    writeFile,
+  },
+}))
+
+import { readJsonFile, writeJsonFile } from './file-store'
+
+describe('file-store', () => {
+  beforeEach(() => {
+    readFile.mockReset()
+    writeFile.mockReset()
+  })
+
+  describe('readJsonFile', () => {
+    it('parses valid JSON content', async () => {
+      readFile.mockResolvedValue('{"ok":true}')
+
+      await expect(readJsonFile('/tmp/test.json', { ok: false })).resolves.toEqual({ ok: true })
+      expect(readFile).toHaveBeenCalledWith('/tmp/test.json', 'utf-8')
+    })
+
+    it('returns the fallback when the file is missing or invalid', async () => {
+      const fallback = { ok: false }
+      readFile.mockRejectedValueOnce(new Error('missing'))
+      await expect(readJsonFile('/tmp/missing.json', fallback)).resolves.toEqual(fallback)
+
+      readFile.mockResolvedValueOnce('not-json')
+      await expect(readJsonFile('/tmp/invalid.json', fallback)).resolves.toEqual(fallback)
+    })
+  })
+
+  describe('writeJsonFile', () => {
+    it('writes pretty-printed JSON', async () => {
+      await writeJsonFile('/tmp/out.json', { ok: true })
+
+      expect(writeFile).toHaveBeenCalledWith('/tmp/out.json', '{\n  "ok": true\n}', 'utf-8')
+    })
+  })
+})

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -1,0 +1,66 @@
+/* @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function loadRateLimitModule() {
+  vi.resetModules()
+  return import('./rate-limit')
+}
+
+describe('checkRateLimit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('allows requests while the limit has not been reached', async () => {
+    const { checkRateLimit } = await loadRateLimitModule()
+    const request = new Request('https://example.com/api/policies', {
+      headers: {
+        'x-forwarded-for': '203.0.113.1',
+      },
+    })
+
+    expect(checkRateLimit(request, { limit: 2, windowSeconds: 10 })).toBeNull()
+    expect(checkRateLimit(request, { limit: 2, windowSeconds: 10 })).toBeNull()
+  })
+
+  it('returns a 429 response with a retry header when the limit is exceeded', async () => {
+    const { checkRateLimit } = await loadRateLimitModule()
+    const request = new Request('https://example.com/api/policies', {
+      headers: {
+        'x-real-ip': '203.0.113.2',
+      },
+    })
+
+    checkRateLimit(request, { limit: 1, windowSeconds: 10 })
+    const response = checkRateLimit(request, { limit: 1, windowSeconds: 10 })
+
+    expect(response?.status).toBe(429)
+    expect(response?.headers.get('Retry-After')).toBe('10')
+    await expect(response?.json()).resolves.toEqual({
+      error: 'Too many requests',
+      success: false,
+    })
+  })
+
+  it('resets the counter after the window expires', async () => {
+    const { checkRateLimit } = await loadRateLimitModule()
+    const request = new Request('https://example.com/api/policies', {
+      headers: {
+        'x-forwarded-for': '203.0.113.3',
+      },
+    })
+
+    checkRateLimit(request, { limit: 1, windowSeconds: 5 })
+    expect(checkRateLimit(request, { limit: 1, windowSeconds: 5 })?.status).toBe(429)
+
+    vi.advanceTimersByTime(5_001)
+
+    expect(checkRateLimit(request, { limit: 1, windowSeconds: 5 })).toBeNull()
+  })
+})

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { cn, cleanHtmlContent, extractJsonFromResponse } from './utils'
+import {
+  cleanHtmlContent,
+  cn,
+  extractJsonFromResponse,
+  findSimilarTitle,
+  normalizeUrl,
+  titleSimilarity,
+} from './utils'
 
 describe('cn', () => {
   it('merges class names', () => {
@@ -57,5 +64,46 @@ describe('extractJsonFromResponse', () => {
   it('returns fallback for empty string', () => {
     const fallback = { empty: true }
     expect(extractJsonFromResponse('', fallback)).toEqual(fallback)
+  })
+})
+
+describe('titleSimilarity', () => {
+  it('scores identical keyword sets as a full match', () => {
+    expect(titleSimilarity('National AI Ethics Framework', 'AI ethics framework national')).toBe(1)
+  })
+
+  it('ignores stop words and punctuation', () => {
+    expect(titleSimilarity('The AI Governance Plan', 'AI governance plan')).toBe(1)
+  })
+
+  it('returns zero when there is no overlap', () => {
+    expect(titleSimilarity('Procurement rules', 'Machine learning principles')).toBe(0)
+  })
+})
+
+describe('normalizeUrl', () => {
+  it('strips fragments, trailing slashes, and tracking params', () => {
+    expect(
+      normalizeUrl('https://www.example.gov.au/policy/?utm_source=newsletter&ref=feed#summary'),
+    ).toBe('https://www.example.gov.au/policy')
+  })
+
+  it('falls back to trimming trailing slashes for invalid URLs', () => {
+    expect(normalizeUrl('not-a-real-url///')).toBe('not-a-real-url')
+  })
+})
+
+describe('findSimilarTitle', () => {
+  it('returns the first fuzzy match at or above the threshold', () => {
+    expect(
+      findSimilarTitle('National AI Ethics Framework', [
+        'Cyber Security Principles',
+        'Australia National AI Ethics Framework',
+      ]),
+    ).toBe('Australia National AI Ethics Framework')
+  })
+
+  it('returns null when titles are below the threshold', () => {
+    expect(findSimilarTitle('AI Safety Standard', ['Procurement Policy'], 0.8)).toBeNull()
   })
 })

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,0 +1,61 @@
+import type { Agency, Policy, ScraperRunLog, TimelineEvent } from '@/types'
+
+export function buildPolicy(overrides: Partial<Policy> = {}): Policy {
+  return {
+    id: 'policy-1',
+    title: 'National AI Ethics Framework',
+    description: 'A framework for safe and responsible AI use across government.',
+    jurisdiction: 'federal',
+    type: 'framework',
+    status: 'active',
+    effectiveDate: '2025-01-01',
+    agencies: ['Department of Industry'],
+    sourceUrl: 'https://example.gov.au/policies/national-ai-ethics-framework',
+    content: 'Detailed policy content',
+    aiSummary: 'Responsible AI guardrails for government use.',
+    tags: ['ai', 'ethics'],
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+export function buildAgency(overrides: Partial<Agency> = {}): Agency {
+  return {
+    id: 'agency-1',
+    name: 'Department of Industry',
+    acronym: 'DISR',
+    level: 'federal',
+    jurisdiction: 'federal',
+    website: 'https://example.gov.au/industry',
+    hasPublishedStatement: true,
+    ...overrides,
+  }
+}
+
+export function buildTimelineEvent(overrides: Partial<TimelineEvent> = {}): TimelineEvent {
+  return {
+    id: 'timeline-1',
+    date: '2025-02-01',
+    title: 'Manual timeline event',
+    description: 'A curated timeline milestone.',
+    type: 'announcement',
+    jurisdiction: 'federal',
+    sourceUrl: 'https://example.gov.au/timeline/manual-event',
+    ...overrides,
+  }
+}
+
+export function buildScraperRunLog(overrides: Partial<ScraperRunLog> = {}): ScraperRunLog {
+  return {
+    id: 'run-1',
+    timestamp: '2025-02-01T00:00:00.000Z',
+    sourceId: 'source-1',
+    sourceName: 'Department feed',
+    linksFound: 3,
+    policiesCreated: 1,
+    errors: [],
+    durationMs: 1200,
+    ...overrides,
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,9 +5,25 @@ import path from 'path'
 export default defineConfig({
   plugins: [react()],
   test: {
+    clearMocks: true,
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: [
+        'src/lib/{auth,data-service,file-store,rate-limit,utils}.ts',
+        'src/app/api/{agencies,status,timeline}/route.ts',
+        'src/app/api/policies/**/*.ts',
+        'src/components/auth/**/*.tsx',
+      ],
+      exclude: [
+        'src/test/**',
+        'src/**/*.test.{ts,tsx}',
+        'src/**/*.spec.{ts,tsx}',
+      ],
+    },
   },
   resolve: {
     alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom/vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach } from 'vitest'
+
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
## Summary
- redesign `/network` around a D3 force-directed graph with dedicated toolbar, sidebar, simulation hook, and jurisdiction colour helpers
- include the network-page design/spec work and supporting API updates already on this branch
- add a shared Vitest harness plus focused tests for core library logic, auth/rate limiting, policy and support API routes, and protected-route UI behavior

## Testing
- npm test
- npm run test:coverage
