### PR TITLE
Fix Vercel cron scraping and refresh the network experience

### DIFF
--- a/content/blog/dta-ai-poc-to-scale-guidance.mdx
+++ b/content/blog/dta-ai-poc-to-scale-guidance.mdx
@@ -1,0 +1,39 @@
+---
+title: "DTA Releases Guidance on Scaling AI from Proof of Concept to Production"
+date: "2026-04-12"
+description: "The Digital Transformation Agency has published new guidance to help Australian Government agencies move AI projects beyond isolated experiments and into enterprise-scale operations."
+---
+
+The Digital Transformation Agency (DTA) has released [Guidance for AI proof of concept to scale](https://www.digital.gov.au/sites/default/files/documents/2026-03/AI%20PoC%20to%20Scale%20Guidance.pdf), a 34-page document aimed at helping Australian Government agencies bridge the gap between AI experimentation and real operational deployment.
+
+The core message is direct: benefits from AI come through enterprise integration, not through running disconnected experiments. The guidance is designed to complement the existing [Australian Government AI policy framework](https://www.digital.gov.au) and Technical Standard for Government's use of artificial intelligence, providing practical advice for agencies navigating the path from proof of concept (PoC) through pilot to production.
+
+## Why this matters
+
+Across both government and the private sector, most AI projects never make it past the experimental phase. The DTA's guidance acknowledges this openly, noting that even technically feasible PoCs risk becoming "shelfware" without clear ownership, strategic alignment, and a defined pathway to scale. Common failure modes include unclear success criteria, technology-led approaches disconnected from business needs, weak data governance, and a risk-avoidance culture that stalls progress before value can be demonstrated.
+
+This is a welcome intervention. Australian Government agencies have been running AI experiments for several years now, but the maturity gap between experimentation and sustained, scaled deployment has been a persistent theme in the policy landscape. Having formal guidance that names the problem directly — and provides structured advice for addressing it — is a meaningful step.
+
+## What the guidance covers
+
+The document is organised around several core areas.
+
+**Eight principles for scaling AI** form the foundation, covering strong data and capability foundations, enterprise-ready design, robust governance, cross-functional collaboration, strategic alignment with measurable outcomes, a culture of responsible innovation, AI literacy at all levels, and choosing the right technology for the right problem.
+
+**A three-stage transition model** defines the pathway from PoC to pilot to production. The DTA lays out how each stage differs across dimensions like users, data, infrastructure, governance, risk tolerance, and procurement. A PoC is expected to be short-lived and experimental, a pilot validates in a controlled real-world setting, and production means full enterprise integration with ongoing monitoring.
+
+**Twelve "dimension considerations"** provide a planning framework that spans business alignment, architecture, data, technology, people, governance, experimentation, delivery, scalability, sustainment, non-AI alternatives, and AI technique selection. For each dimension, the guidance describes the purpose, key activities, and how expectations change from PoC through to production. The inclusion of "non-AI considerations" is a particularly grounded addition — agencies are encouraged to assess whether a problem actually requires AI or could be addressed through simpler approaches like process redesign or rules-based automation.
+
+**A detailed challenges and mitigation table** maps common failure points to specific mitigations and accountable roles. These are practical and specific: requiring a problem statement and value hypothesis before funding a PoC, maintaining a technical debt register, running "security by design" reviews early, and including decommissioning in PoC closure checklists.
+
+**Six real-world scenarios** illustrate both success and failure patterns, covering co-design and transparency, clear expectations, cross-agency collaboration, gaps in user understanding, lack of business buy-in, and the challenges of integrating new AI models with legacy systems.
+
+The appendices include an AI readiness checklist for sponsors, managers and practitioners, guidance on AI evaluation, advice on informing procurement decisions, and a mapping of the guidance's dimensions to the Technical Standard.
+
+## Our take
+
+This is one of the more pragmatic pieces of AI guidance to come out of the Australian Government. Rather than focusing on high-level principles alone, it engages with the operational reality of why AI projects fail and what agencies can do differently. The emphasis on business alignment before technical work, the explicit encouragement to consider non-AI alternatives, and the accountability structures for common challenges all reflect lessons that many agencies have learned the hard way.
+
+The guidance also represents a maturing of the federal government's approach to AI governance. It sits alongside the AI in Government Policy, the Technical Standard, and the National Framework for AI Assurance as part of an increasingly coherent set of resources for agencies working with AI. For anyone tracking the Australian AI policy landscape — which is what Policai is here for — this is an important addition to the picture.
+
+You can read the full guidance on the [DTA website](https://www.digital.gov.au) or download the [PDF directly](https://www.digital.gov.au/sites/default/files/documents/2026-03/AI%20PoC%20to%20Scale%20Guidance.pdf).

--- a/docs/superpowers/specs/2026-04-12-network-page-redesign.md
+++ b/docs/superpowers/specs/2026-04-12-network-page-redesign.md
@@ -1,0 +1,131 @@
+# Network Page Redesign
+
+## Problem
+
+The current network page is a 995-line monolith using React Flow to display a rigid 3-column hierarchy (Jurisdiction → Agency → Policy). With 38+ policies and 50 agencies, it's unreadable, the layout doesn't reveal meaningful relationships, and the visual design is inconsistent with the rest of the app.
+
+## Design
+
+Replace the React Flow hierarchical layout with a D3.js force-directed graph. Policies cluster by jurisdiction, with cross-jurisdiction edges revealing shared themes and agencies. The page uses a floating toolbar for filtering, a slide-out sidebar for node details, and the app's existing design system throughout.
+
+### Layout
+
+Full-bleed force graph with two overlay layers:
+
+1. **Floating toolbar** (top) — search box, jurisdiction toggle pills, policy count stats
+2. **Slide-out sidebar** (right, on node click) — policy/agency details with connected nodes list
+
+The graph fills the page height (calc viewport minus header). No cards, stat grids, or sidebar chrome from the current design — the graph is the entire content area.
+
+### Force Graph
+
+Built with D3.js force simulation (already a project dependency — no React Flow needed).
+
+**Nodes:**
+- **Policy nodes**: circles sized by tag count (proxy for scope/importance), colored by jurisdiction using `--chart-1` through `--chart-5`
+- **Cluster labels**: jurisdiction name rendered as a text label at the centroid of each cluster, not as a node
+
+**Edges:**
+- **Intra-jurisdiction**: faint lines between policies sharing an agency or 2+ tags. Stroke color matches jurisdiction.
+- **Cross-jurisdiction**: dashed purple lines between policies sharing 3+ tags or referencing the same agency. These are the interesting connections.
+
+**Forces:**
+- Cluster force: policies attract toward their jurisdiction centroid
+- Repulsion: nodes repel to prevent overlap
+- Link force: connected nodes attract gently
+- Collision: prevents node overlap with padding
+
+**Interactions:**
+- Hover: node grows slightly, label appears (policy title), connected edges highlight
+- Click: opens slide-out sidebar with full details
+- Drag: reposition individual nodes
+- Zoom/pan: standard D3 zoom behavior
+- No minimap (the floating toolbar + search replaces the need)
+
+### Floating Toolbar
+
+Compact horizontal bar pinned to the top of the graph area:
+
+- **Search**: text input with magnifying glass icon, filters nodes by title match (fades non-matching nodes)
+- **Jurisdiction pills**: one per jurisdiction with data, colored using chart colors. Click to toggle visibility. Active pills are filled, inactive are outlined.
+- **Stats**: right-aligned, shows "{n} policies · {n} jurisdictions" in mono font
+
+Built with existing shadcn `Input` component and Tailwind classes. Uses `bg-card/90 backdrop-blur` for the glass effect over the graph.
+
+### Slide-out Sidebar
+
+320px panel that slides in from the right when a node is clicked. Shows:
+
+- **Header**: "POLICY DETAIL" label in mono uppercase, close button
+- **Badges**: status (using `--status-*` colors), type, jurisdiction
+- **Title**: policy title in semibold
+- **Date**: effective date in muted text
+- **Description**: 2-3 line description
+- **Connected nodes**: list of related policies/agencies with jurisdiction color dot. Clicking a connected node navigates to it in the graph.
+- **Tags**: tag pills in muted style
+- **Actions**: "View Full Policy →" link to `/policies/[id]`, "Source ↗" external link
+
+Uses shadcn `Badge`, `ScrollArea`, and `Button` components. Background uses `bg-card/95 backdrop-blur-xl` with `border-l border-border`.
+
+### Edge Computation
+
+Edges are computed client-side from the policy data:
+
+1. **Shared agency**: if two policies reference the same agency string (fuzzy matched), create an edge
+2. **Shared tags**: if two policies share 2+ tags, create an edge (3+ for cross-jurisdiction)
+3. **Dedup**: one edge per policy pair, weight = number of shared connections
+
+This replaces the current static hierarchy with data-driven relationships.
+
+### Styling
+
+All colors from CSS variables — works in both light and dark mode:
+- Node fills: `--chart-1` (federal), `--chart-2` (NSW), `--chart-3` (WA/QLD), `--chart-4` (ACT/VIC), `--chart-5` (other)
+- Status indicators on nodes: thin ring using `--status-active`, `--status-proposed`, etc.
+- Background: `--background` with subtle dot pattern using `--border` color
+- Fonts: IBM Plex Sans for labels, IBM Plex Mono for stats/counts
+- Transitions: 200ms ease for hover effects, 300ms for sidebar slide
+
+### Component Structure
+
+Break the 995-line monolith into focused components:
+
+```
+src/app/network/page.tsx              — page shell, data fetching, state
+src/components/network/
+  ForceGraph.tsx                      — D3 force simulation + SVG rendering
+  NetworkToolbar.tsx                  — search, jurisdiction pills, stats
+  NetworkSidebar.tsx                  — slide-out detail panel
+  use-force-simulation.ts            — custom hook for D3 force setup
+  compute-edges.ts                   — edge computation from policy data
+```
+
+### Data Flow
+
+1. Page fetches `/api/policies` and `/api/agencies` on mount (same as current)
+2. `compute-edges.ts` builds edge list from shared agencies/tags
+3. `use-force-simulation.ts` initializes D3 force simulation with nodes + edges
+4. `ForceGraph.tsx` renders SVG with D3-managed positions
+5. Toolbar filter state flows down — filtered-out nodes get `opacity: 0.1`
+6. Click events flow up — page sets `selectedNodeId`, sidebar renders
+
+### What Gets Removed
+
+- React Flow dependency usage on this page (keep the package for now since other pages may use it)
+- All inline node styling (replaced by CSS variables)
+- The stat cards grid above the graph
+- The legend card (jurisdiction colors are self-documenting via pills)
+- The "Controls" help card (standard zoom/pan, discoverable)
+- The node detail Dialog (replaced by sidebar)
+
+## Verification
+
+1. `npm run build` + `npm run lint` pass
+2. Graph renders with all policies from Supabase, clustered by jurisdiction
+3. Cross-jurisdiction edges visible between related policies
+4. Search filters nodes in real-time
+5. Jurisdiction pills toggle cluster visibility
+6. Click opens sidebar with correct policy details
+7. "View Full Policy" links to correct `/policies/[id]` page
+8. Works in both light and dark mode
+9. Responsive: on mobile, sidebar becomes a bottom sheet or full-screen overlay

--- a/docs/superpowers/specs/2026-04-12-network-page-redesign.md
+++ b/docs/superpowers/specs/2026-04-12-network-page-redesign.md
@@ -21,13 +21,14 @@ The graph fills the page height (calc viewport minus header). No cards, stat gri
 
 Built with D3.js force simulation (already a project dependency — no React Flow needed).
 
-**Nodes:**
+**Nodes (policy-only):**
 - **Policy nodes**: circles sized by tag count (proxy for scope/importance), colored by jurisdiction using `--chart-1` through `--chart-5`
 - **Cluster labels**: jurisdiction name rendered as a text label at the centroid of each cluster, not as a node
+- **No agency nodes**: agencies are not graph entities. They appear as metadata in the sidebar when a policy is selected (listed under "Agencies" as plain text). This avoids the 50-agency clutter problem and keeps the graph focused on policy-to-policy relationships.
 
-**Edges:**
-- **Intra-jurisdiction**: faint lines between policies sharing an agency or 2+ tags. Stroke color matches jurisdiction.
-- **Cross-jurisdiction**: dashed purple lines between policies sharing 3+ tags or referencing the same agency. These are the interesting connections.
+**Edges (tag-based only):**
+- **Intra-jurisdiction**: faint lines between policies sharing 2+ tags. Stroke color matches jurisdiction.
+- **Cross-jurisdiction**: dashed purple lines between policies sharing 3+ tags. These are the interesting connections.
 
 **Forces:**
 - Cluster force: policies attract toward their jurisdiction centroid
@@ -61,7 +62,8 @@ Built with existing shadcn `Input` component and Tailwind classes. Uses `bg-card
 - **Title**: policy title in semibold
 - **Date**: effective date in muted text
 - **Description**: 2-3 line description
-- **Connected nodes**: list of related policies/agencies with jurisdiction color dot. Clicking a connected node navigates to it in the graph.
+- **Connected policies**: list of policies linked by shared tags, with jurisdiction color dot. Clicking navigates to that node in the graph.
+- **Agencies**: plain text list of agency names from `policy.agencies` (non-navigable metadata, not graph entities)
 - **Tags**: tag pills in muted style
 - **Actions**: "View Full Policy →" link to `/policies/[id]`, "Source ↗" external link
 
@@ -69,13 +71,19 @@ Uses shadcn `Badge`, `ScrollArea`, and `Button` components. Background uses `bg-
 
 ### Edge Computation
 
-Edges are computed client-side from the policy data:
+Edges are computed **server-side** via a new API endpoint `GET /api/network` that returns pre-computed nodes and edges. This avoids unreliable client-side fuzzy matching.
 
-1. **Shared agency**: if two policies reference the same agency string (fuzzy matched), create an edge
-2. **Shared tags**: if two policies share 2+ tags, create an edge (3+ for cross-jurisdiction)
-3. **Dedup**: one edge per policy pair, weight = number of shared connections
+**Tag-based edges only (no agency string matching):**
 
-This replaces the current static hierarchy with data-driven relationships.
+The `Policy.agencies` field is free-text `string[]` with no canonical IDs — values like "Data and Digital Government Strategy Branch" don't resolve to agency records. Fuzzy matching would create false relationships and miss real ones. Instead, edges are derived solely from shared tags, which are structured and consistent:
+
+1. **Intra-jurisdiction**: two policies in the same jurisdiction sharing 2+ tags → edge
+2. **Cross-jurisdiction**: two policies in different jurisdictions sharing 3+ tags → edge
+3. **Dedup**: one edge per policy pair, weight = number of shared tags
+
+The `/api/network` endpoint returns `{ nodes: PolicyNode[], edges: Edge[] }` so the client receives a trusted, pre-computed graph. Agency names appear as metadata in the sidebar (non-navigable) but do not drive graph topology.
+
+**Future improvement:** When `Policy.agencies` is normalized to canonical agency IDs (foreign keys to the `agencies` table), agency-based edges can be added reliably.
 
 ### Styling
 
@@ -91,23 +99,33 @@ All colors from CSS variables — works in both light and dark mode:
 Break the 995-line monolith into focused components:
 
 ```
-src/app/network/page.tsx              — page shell, data fetching, state
+src/app/network/page.tsx              — page shell, data fetching, state management
+src/app/api/network/route.ts          — server-side edge computation, returns nodes + edges
 src/components/network/
   ForceGraph.tsx                      — D3 force simulation + SVG rendering
   NetworkToolbar.tsx                  — search, jurisdiction pills, stats
   NetworkSidebar.tsx                  — slide-out detail panel
   use-force-simulation.ts            — custom hook for D3 force setup
-  compute-edges.ts                   — edge computation from policy data
 ```
 
 ### Data Flow
 
-1. Page fetches `/api/policies` and `/api/agencies` on mount (same as current)
-2. `compute-edges.ts` builds edge list from shared agencies/tags
-3. `use-force-simulation.ts` initializes D3 force simulation with nodes + edges
-4. `ForceGraph.tsx` renders SVG with D3-managed positions
-5. Toolbar filter state flows down — filtered-out nodes get `opacity: 0.1`
-6. Click events flow up — page sets `selectedNodeId`, sidebar renders
+1. Page fetches `/api/network` on mount (single request, returns pre-computed nodes + edges)
+2. `use-force-simulation.ts` initializes D3 force simulation with the response data
+3. `ForceGraph.tsx` renders SVG with D3-managed positions
+4. Toolbar filter state flows down — filtered-out nodes get `opacity: 0.1`
+5. Click events flow up — page sets `selectedNodeId`, sidebar renders
+
+### Loading, Error, and Empty States
+
+The graph is the only content area, so degraded states must be explicit:
+
+- **Loading**: centered spinner with "Loading network..." text (same pattern as other pages)
+- **Error (fetch failure / 429)**: centered error message with "Failed to load network data" and a "Retry" button. No blank canvas.
+- **Empty (0 policies)**: centered illustration with "No policies found" message and link to the policies page
+- **Partial data**: if the API returns data but edge computation yields 0 edges, show the nodes without edges and a subtle note: "No cross-policy connections found yet"
+
+The page component manages `loading`, `error`, and `data` states explicitly — never renders the graph SVG until data is confirmed present.
 
 ### What Gets Removed
 

--- a/src/app/api/admin/run-scraper/route.ts
+++ b/src/app/api/admin/run-scraper/route.ts
@@ -6,6 +6,12 @@ import * as cheerio from 'cheerio';
 import { cleanHtmlContent } from '@/lib/utils';
 import { DATA_SOURCES_MAP } from '@/lib/data-sources';
 import {
+  cleanScrapedLinkTitle,
+  isRelevantScrapedCandidate,
+  shouldCreatePolicyFromAnalysis,
+  shouldQueuePolicyForReview,
+} from '@/lib/scraper-filter';
+import {
   createPolicy as createPolicyInDb,
   DuplicatePolicyError,
 } from '@/lib/data-service';
@@ -40,7 +46,7 @@ async function scrapeLinks(sourceUrl: string): Promise<ScrapedLink[]> {
     // Find all links on the page
     $('a').each((_, element) => {
       const href = $(element).attr('href');
-      const text = $(element).text().trim();
+      const text = cleanScrapedLinkTitle($(element).text().trim());
 
       if (!href || !text) return;
 
@@ -54,29 +60,18 @@ async function scrapeLinks(sourceUrl: string): Promise<ScrapedLink[]> {
       }
 
       // Filter for likely policy/document links
-      const isLikelyPolicy =
-        href.includes('pdf') ||
-        href.includes('policy') ||
-        href.includes('guidance') ||
-        href.includes('framework') ||
-        href.includes('strategy') ||
-        href.includes('standard') ||
-        href.includes('regulation') ||
-        text.toLowerCase().includes('policy') ||
-        text.toLowerCase().includes('framework') ||
-        text.toLowerCase().includes('guidance') ||
-        text.toLowerCase().includes('standard');
+      const candidate = {
+        url: absoluteUrl,
+        title: text,
+        text: $(element).parent().text().trim().slice(0, 500),
+      };
 
-      if (isLikelyPolicy) {
-        links.push({
-          url: absoluteUrl,
-          title: text,
-          text: $(element).parent().text().trim().slice(0, 500),
-        });
+      if (isRelevantScrapedCandidate(candidate)) {
+        links.push(candidate);
       }
     });
 
-    return links.slice(0, 10); // Limit to 10 links per source
+    return Array.from(new Map(links.map((link) => [link.url, link])).values()).slice(0, 10);
   } catch (error) {
     console.error(`Error scraping ${sourceUrl}:`, error);
     return [];
@@ -229,7 +224,7 @@ export async function POST(request: Request) {
         itemsProcessed++;
 
         // Decision logic based on relevance score
-        if (analysis.relevanceScore >= 0.8 && analysis.isRelevant) {
+        if (shouldCreatePolicyFromAnalysis(link, analysis)) {
           // High confidence - auto-create policy
           try {
             await createPolicy(link.title, link.url, analysis, content);
@@ -241,7 +236,7 @@ export async function POST(request: Request) {
             await addToPendingReview(link.title, link.url, analysis);
             itemsPending++;
           }
-        } else if (analysis.relevanceScore >= 0.5 && analysis.isRelevant) {
+        } else if (shouldQueuePolicyForReview(link, analysis)) {
           // Medium confidence - add to pending review
           await addToPendingReview(link.title, link.url, analysis);
           itemsPending++;

--- a/src/app/api/cron/agencies/route.ts
+++ b/src/app/api/cron/agencies/route.ts
@@ -13,6 +13,7 @@ import { getAgencies } from '@/lib/data-service';
 import { isSupabaseConfigured } from '@/lib/data-service';
 
 export const maxDuration = 300;
+export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');

--- a/src/app/api/cron/pipeline/route.ts
+++ b/src/app/api/cron/pipeline/route.ts
@@ -12,6 +12,7 @@ import { startPipelineRun } from '@/lib/agents/pipeline';
 import { getPolicies } from '@/lib/data-service';
 
 export const maxDuration = 300;
+export const dynamic = 'force-dynamic';
 
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');

--- a/src/app/api/cron/scrape/route.ts
+++ b/src/app/api/cron/scrape/route.ts
@@ -17,10 +17,22 @@ import * as cheerio from 'cheerio';
 import { analyseContentRelevance, summarizePolicy } from '@/lib/claude';
 import { cleanHtmlContent } from '@/lib/utils';
 import { DATA_SOURCES, type DataSource } from '@/lib/data-sources';
-import { createPolicy, policyExists, logScraperRun } from '@/lib/data-service';
+import {
+  createPolicy,
+  DuplicatePolicyError,
+  policyExists,
+  policyExistsBySourceUrl,
+  logScraperRun,
+} from '@/lib/data-service';
+import {
+  cleanScrapedLinkTitle,
+  isRelevantScrapedCandidate,
+  shouldCreatePolicyFromAnalysis,
+} from '@/lib/scraper-filter';
 import type { Policy } from '@/types';
 
 export const maxDuration = 300;
+export const dynamic = 'force-dynamic';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -45,7 +57,7 @@ async function scrapeLinks(sourceUrl: string): Promise<ScrapedLink[]> {
 
     $('a').each((_, element) => {
       const href = $(element).attr('href');
-      const text = $(element).text().trim();
+      const text = cleanScrapedLinkTitle($(element).text().trim());
       if (!href || !text) return;
 
       let absoluteUrl = href;
@@ -56,29 +68,18 @@ async function scrapeLinks(sourceUrl: string): Promise<ScrapedLink[]> {
         return;
       }
 
-      const isLikelyPolicy =
-        href.includes('pdf') ||
-        href.includes('policy') ||
-        href.includes('guidance') ||
-        href.includes('framework') ||
-        href.includes('strategy') ||
-        href.includes('standard') ||
-        href.includes('regulation') ||
-        text.toLowerCase().includes('policy') ||
-        text.toLowerCase().includes('framework') ||
-        text.toLowerCase().includes('guidance') ||
-        text.toLowerCase().includes('standard');
+      const candidate = {
+        url: absoluteUrl,
+        title: text,
+        text: $(element).parent().text().trim().slice(0, 500),
+      };
 
-      if (isLikelyPolicy) {
-        links.push({
-          url: absoluteUrl,
-          title: text,
-          text: $(element).parent().text().trim().slice(0, 500),
-        });
+      if (isRelevantScrapedCandidate(candidate)) {
+        links.push(candidate);
       }
     });
 
-    return links.slice(0, 10);
+    return Array.from(new Map(links.map((link) => [link.url, link])).values()).slice(0, 10);
   } catch (error) {
     console.error(`[cron] Error scraping ${sourceUrl}:`, error);
     return [];
@@ -112,7 +113,7 @@ async function processHighConfidenceLink(
     .replace(/(^-|-$)/g, '')
     .slice(0, 50);
 
-  if (await policyExists(id)) {
+  if (await policyExists(id) || await policyExistsBySourceUrl(url)) {
     console.log(`[cron] Policy already exists: ${id}`);
     return false;
   }
@@ -147,8 +148,16 @@ async function processHighConfidenceLink(
     updatedAt: now,
   };
 
-  await createPolicy(newPolicy);
-  return true;
+  try {
+    await createPolicy(newPolicy);
+    return true;
+  } catch (error) {
+    if (error instanceof DuplicatePolicyError) {
+      console.log(`[cron] Policy already exists: ${id}`);
+      return false;
+    }
+    throw error;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -171,7 +180,7 @@ async function scrapeSource(source: DataSource) {
       const content = await fetchContent(link.url);
       const analysis = await analyseContentRelevance(content, link.url);
 
-      if (analysis.relevanceScore >= 0.8 && analysis.isRelevant) {
+      if (shouldCreatePolicyFromAnalysis(link, analysis)) {
         const wasCreated = await processHighConfidenceLink(
           link.title,
           link.url,

--- a/src/app/api/network/route.ts
+++ b/src/app/api/network/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { getPolicies } from '@/lib/data-service';
+
+export interface NetworkNode {
+  id: string;
+  title: string;
+  jurisdiction: string;
+  status: string;
+  type: string;
+  tags: string[];
+  agencies: string[];
+  effectiveDate: string;
+  sourceUrl: string;
+  description: string;
+}
+
+export interface NetworkEdge {
+  source: string;
+  target: string;
+  weight: number;
+  crossJurisdiction: boolean;
+}
+
+export async function GET() {
+  try {
+    const policies = await getPolicies();
+
+    // Build nodes
+    const nodes: NetworkNode[] = policies
+      .filter((p) => p.status !== 'trashed')
+      .map((p) => ({
+        id: p.id,
+        title: p.title,
+        jurisdiction: p.jurisdiction,
+        status: p.status,
+        type: p.type,
+        tags: p.tags,
+        agencies: p.agencies,
+        effectiveDate: typeof p.effectiveDate === 'string' ? p.effectiveDate : '',
+        sourceUrl: p.sourceUrl,
+        description: p.description,
+      }));
+
+    // Build edges from shared tags
+    const edges: NetworkEdge[] = [];
+    for (let i = 0; i < nodes.length; i++) {
+      for (let j = i + 1; j < nodes.length; j++) {
+        const a = nodes[i];
+        const b = nodes[j];
+
+        const sharedTags = a.tags.filter((t) => b.tags.includes(t));
+        const crossJurisdiction = a.jurisdiction !== b.jurisdiction;
+        const threshold = crossJurisdiction ? 3 : 2;
+
+        if (sharedTags.length >= threshold) {
+          edges.push({
+            source: a.id,
+            target: b.id,
+            weight: sharedTags.length,
+            crossJurisdiction,
+          });
+        }
+      }
+    }
+
+    return NextResponse.json({ nodes, edges, success: true });
+  } catch (error) {
+    console.error('[network] Failed to compute graph:', error);
+    return NextResponse.json(
+      { error: 'Failed to load network data', success: false },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/network/page.tsx
+++ b/src/app/network/page.tsx
@@ -1,994 +1,164 @@
 'use client';
 
-import { useState, useCallback, useMemo, useEffect } from 'react';
-import {
-  ReactFlow,
-  type Node,
-  type Edge,
-  Controls,
-  Background,
-  MiniMap,
-  useNodesState,
-  useEdgesState,
-  MarkerType,
-  Position,
-  BackgroundVariant,
-} from '@xyflow/react';
-import '@xyflow/react/dist/style.css';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import Link from 'next/link';
+import { Network, AlertCircle, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import {
-  Filter,
-  FileText,
-  Building2,
-  Map,
-  ExternalLink,
-  Info,
-  Search,
-  X,
-  Network,
-  GitBranch,
-  BarChart3,
-} from 'lucide-react';
-import {
-  JURISDICTION_NAMES,
-  POLICY_TYPE_NAMES,
-  POLICY_STATUS_NAMES,
-  type Jurisdiction,
-  type PolicyType,
-  type PolicyStatus,
-  type Policy,
-  type Agency,
-} from '@/types';
-
-type NodeType = 'policy' | 'agency' | 'jurisdiction';
-
-interface NodeData extends Record<string, unknown> {
-  label: string;
-  type: NodeType;
-  status?: string;
-  policyType?: string;
-  originalData: Policy | Agency | { jurisdiction: Jurisdiction };
-}
-
-// Improved layout algorithm with hierarchical positioning grouped by jurisdiction
-function generateGraphData(
-  filterJurisdiction: string,
-  filterStatus: string,
-  filterType: string,
-  searchQuery: string,
-  policiesData: Policy[],
-  agenciesData: Agency[],
-) {
-  const nodes: Node<NodeData>[] = [];
-  const edges: Edge[] = [];
-
-  // Filter policies
-  const filteredPolicies = policiesData.filter((p) => {
-    const matchesJurisdiction = filterJurisdiction === 'all' || p.jurisdiction === filterJurisdiction;
-    const matchesStatus = filterStatus === 'all' || p.status === filterStatus;
-    const matchesType = filterType === 'all' || p.type === filterType;
-    const matchesSearch =
-      searchQuery === '' ||
-      p.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      p.description.toLowerCase().includes(searchQuery.toLowerCase());
-    return matchesJurisdiction && matchesStatus && matchesType && matchesSearch;
-  });
-
-  // Get unique agencies from filtered policies
-  const policyAgencyIds = new Set<string>();
-  filteredPolicies.forEach((p) => {
-    p.agencies.forEach((agencyId) => policyAgencyIds.add(agencyId.toLowerCase()));
-  });
-
-  // Filter agencies - match by id or acronym
-  const filteredAgencies = agenciesData.filter((a) => {
-    const matchesJurisdiction = filterJurisdiction === 'all' || a.jurisdiction === filterJurisdiction;
-    const isReferencedByPolicy =
-      policyAgencyIds.has(a.id.toLowerCase()) ||
-      policyAgencyIds.has(a.acronym.toLowerCase()) ||
-      policyAgencyIds.has(a.name.toLowerCase());
-    return matchesJurisdiction && (isReferencedByPolicy || filterJurisdiction !== 'all');
-  });
-
-  // Get relevant jurisdictions
-  const relevantJurisdictions =
-    filterJurisdiction === 'all'
-      ? [...new Set([...filteredPolicies.map((p) => p.jurisdiction), ...filteredAgencies.map((a) => a.jurisdiction)])]
-      : [filterJurisdiction];
-
-  // Group agencies and policies by jurisdiction for better layout
-  const agenciesByJurisdiction: Record<string, typeof filteredAgencies> = {};
-  const policiesByJurisdiction: Record<string, typeof filteredPolicies> = {};
-
-  relevantJurisdictions.forEach((j) => {
-    agenciesByJurisdiction[j] = filteredAgencies.filter((a) => a.jurisdiction === j);
-    policiesByJurisdiction[j] = filteredPolicies.filter((p) => p.jurisdiction === j);
-  });
-
-  // Layout constants
-  const nodeHeight = 50;
-  const nodeGap = 25;
-  const jurisdictionGap = 60;
-  const columnGap = 250;
-
-  const styles = {
-    jurisdictionBg: 'var(--network-jurisdiction-bg)',
-    jurisdictionBorder: 'var(--network-jurisdiction-border)',
-    agencyBg: 'var(--network-agency-bg)',
-    agencyForeground: 'var(--network-agency-foreground)',
-    agencyBorder: 'var(--network-agency-border)',
-    activeBg: 'var(--network-active-bg)',
-    activeBorder: 'var(--network-active-border)',
-    proposedBg: 'var(--network-proposed-bg)',
-    proposedBorder: 'var(--network-proposed-border)',
-    amendedBg: 'var(--network-amended-bg)',
-    amendedBorder: 'var(--network-amended-border)',
-    defaultBg: 'var(--network-default-bg)',
-    defaultBorder: 'var(--network-default-border)',
-    edge: 'var(--network-edge)',
-  };
-
-  // Get policy status colors
-  const getStatusColors = (status: string) => {
-    switch (status) {
-      case 'active':
-        return { bg: styles.activeBg, border: styles.activeBorder };
-      case 'proposed':
-        return { bg: styles.proposedBg, border: styles.proposedBorder };
-      case 'amended':
-        return { bg: styles.amendedBg, border: styles.amendedBorder };
-      default:
-        return { bg: styles.defaultBg, border: styles.defaultBorder };
-    }
-  };
-
-  let currentY = 50;
-
-  // Position nodes grouped by jurisdiction
-  relevantJurisdictions.forEach((jurisdiction) => {
-    const agencies = agenciesByJurisdiction[jurisdiction] || [];
-    const policies = policiesByJurisdiction[jurisdiction] || [];
-
-    // Calculate the height needed for this jurisdiction group
-    const agencyHeight = Math.max(agencies.length, 1) * (nodeHeight + nodeGap);
-    const policyHeight = Math.max(policies.length, 1) * (nodeHeight + nodeGap);
-    const groupHeight = Math.max(agencyHeight, policyHeight, nodeHeight + nodeGap);
-
-    // Center the jurisdiction node vertically in its group
-    const jurisdictionY = currentY + groupHeight / 2 - nodeHeight / 2;
-
-    // Add jurisdiction node
-    nodes.push({
-      id: `jurisdiction-${jurisdiction}`,
-      type: 'default',
-      position: { x: 50, y: jurisdictionY },
-      data: {
-        label: JURISDICTION_NAMES[jurisdiction as Jurisdiction] || jurisdiction,
-        type: 'jurisdiction',
-        originalData: { jurisdiction: jurisdiction as Jurisdiction },
-      },
-      style: {
-        background: styles.jurisdictionBg,
-        color: 'white',
-        border: `2px solid ${styles.jurisdictionBorder}`,
-        borderRadius: '12px',
-        padding: '12px 20px',
-        fontWeight: 600,
-        fontSize: '13px',
-        width: 160,
-        boxShadow: `0 4px 12px color-mix(in srgb, ${styles.jurisdictionBorder} 35%, transparent)`,
-      },
-      sourcePosition: Position.Right,
-      targetPosition: Position.Left,
-    });
-
-    // Add agency nodes for this jurisdiction
-    agencies.forEach((agency, index) => {
-      const agencyY = currentY + index * (nodeHeight + nodeGap);
-      nodes.push({
-        id: `agency-${agency.id}`,
-        type: 'default',
-        position: { x: 50 + columnGap, y: agencyY },
-        data: {
-          label: agency.acronym || agency.name.substring(0, 15),
-          type: 'agency',
-          originalData: agency,
-        },
-        style: {
-          background: styles.agencyBg,
-          color: styles.agencyForeground,
-          border: `2px solid ${styles.agencyBorder}`,
-          borderRadius: '10px',
-          padding: '10px 16px',
-          fontWeight: 500,
-          fontSize: '12px',
-          width: 130,
-          boxShadow: `0 4px 12px color-mix(in srgb, ${styles.agencyBorder} 28%, transparent)`,
-        },
-        sourcePosition: Position.Right,
-        targetPosition: Position.Left,
-      });
-
-      // Connect agency to jurisdiction
-      edges.push({
-        id: `edge-${agency.id}-${agency.jurisdiction}`,
-        source: `jurisdiction-${agency.jurisdiction}`,
-        target: `agency-${agency.id}`,
-        type: 'smoothstep',
-        animated: false,
-        style: { stroke: styles.edge, strokeWidth: 1.5 },
-        markerEnd: { type: MarkerType.ArrowClosed, color: styles.edge, width: 12, height: 12 },
-      });
-    });
-
-    // Add policy nodes for this jurisdiction
-    policies.forEach((policy, index) => {
-      const policyY = currentY + index * (nodeHeight + nodeGap);
-      const colors = getStatusColors(policy.status);
-
-      nodes.push({
-        id: `policy-${policy.id}`,
-        type: 'default',
-        position: { x: 50 + columnGap * 2, y: policyY },
-        data: {
-          label: policy.title.length > 30 ? policy.title.substring(0, 30) + '...' : policy.title,
-          type: 'policy',
-          status: policy.status,
-          policyType: policy.type,
-          originalData: policy,
-        },
-        style: {
-          background: colors.bg,
-          color: 'white',
-          border: `2px solid ${colors.border}`,
-          borderRadius: '10px',
-          padding: '10px 14px',
-          width: 220,
-          fontSize: '11px',
-          fontWeight: 500,
-          boxShadow: `0 4px 12px ${colors.border}40`,
-        },
-        sourcePosition: Position.Right,
-        targetPosition: Position.Left,
-      });
-
-      // Connect policy to its agencies within this jurisdiction
-      policy.agencies.forEach((agencyRef) => {
-        const agency = filteredAgencies.find(
-          (a) =>
-            a.id.toLowerCase() === agencyRef.toLowerCase() ||
-            a.acronym.toLowerCase() === agencyRef.toLowerCase() ||
-            a.name.toLowerCase() === agencyRef.toLowerCase()
-        );
-
-        if (agency) {
-          edges.push({
-            id: `edge-policy-${policy.id}-${agency.id}`,
-            source: `agency-${agency.id}`,
-            target: `policy-${policy.id}`,
-            type: 'smoothstep',
-            animated: policy.status === 'active',
-            style: {
-              stroke: policy.status === 'active' ? styles.activeBorder : styles.edge,
-              strokeWidth: policy.status === 'active' ? 2 : 1.5,
-            },
-            markerEnd: {
-              type: MarkerType.ArrowClosed,
-              color: policy.status === 'active' ? styles.activeBorder : styles.edge,
-              width: 12,
-              height: 12,
-            },
-          });
-        }
-      });
-    });
-
-    // Move to next jurisdiction group
-    currentY += groupHeight + jurisdictionGap;
-  });
-
-  return { nodes, edges };
-}
-
-// Statistics calculation
-function calculateStats(
-  filterJurisdiction: string,
-  filterStatus: string,
-  filterType: string,
-  searchQuery: string,
-  policiesData: Policy[],
-) {
-  const filteredPolicies = policiesData.filter((p) => {
-    const matchesJurisdiction = filterJurisdiction === 'all' || p.jurisdiction === filterJurisdiction;
-    const matchesStatus = filterStatus === 'all' || p.status === filterStatus;
-    const matchesType = filterType === 'all' || p.type === filterType;
-    const matchesSearch =
-      searchQuery === '' ||
-      p.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      p.description.toLowerCase().includes(searchQuery.toLowerCase());
-    return matchesJurisdiction && matchesStatus && matchesType && matchesSearch;
-  });
-
-  const activePolicies = filteredPolicies.filter((p) => p.status === 'active').length;
-  const proposedPolicies = filteredPolicies.filter((p) => p.status === 'proposed').length;
-  const jurisdictions = new Set(filteredPolicies.map((p) => p.jurisdiction)).size;
-
-  return {
-    totalPolicies: filteredPolicies.length,
-    activePolicies,
-    proposedPolicies,
-    jurisdictions,
-  };
-}
+import { ForceGraph } from '@/components/network/ForceGraph';
+import { NetworkToolbar } from '@/components/network/NetworkToolbar';
+import { NetworkSidebar } from '@/components/network/NetworkSidebar';
+import { JURISDICTION_COLORS, resolveColor } from '@/components/network/jurisdiction-colors';
+import { JURISDICTION_NAMES, type Jurisdiction } from '@/types';
+import type { NetworkNode, NetworkEdge } from '@/app/api/network/route';
 
 export default function NetworkPage() {
-  const [policiesData, setPoliciesData] = useState<Policy[]>([]);
-  const [agenciesData, setAgenciesData] = useState<Agency[]>([]);
-  const [dataLoading, setDataLoading] = useState(true);
-  const [filterJurisdiction, setFilterJurisdiction] = useState<string>('all');
-  const [filterStatus, setFilterStatus] = useState<string>('all');
-  const [filterType, setFilterType] = useState<string>('all');
-  const [searchQuery, setSearchQuery] = useState<string>('');
-  const [selectedNode, setSelectedNode] = useState<Node<NodeData> | null>(null);
-  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [nodes, setNodes] = useState<NetworkNode[]>([]);
+  const [edges, setEdges] = useState<NetworkEdge[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeJurisdictions, setActiveJurisdictions] = useState<Set<string>>(new Set());
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
-  useEffect(() => {
-    Promise.all([
-      fetch('/api/policies').then((r) => r.json()),
-      fetch('/api/agencies').then((r) => r.json()),
-    ])
-      .then(([policiesJson, agenciesJson]) => {
-        setPoliciesData(policiesJson.data ?? []);
-        setAgenciesData(agenciesJson.data ?? []);
-      })
-      .catch((err) => console.error('Failed to load network data:', err))
-      .finally(() => setDataLoading(false));
-  }, []);
-
-  // Generate graph data based on filters
-  const { nodes: graphNodes, edges: graphEdges } = useMemo(
-    () => generateGraphData(filterJurisdiction, filterStatus, filterType, searchQuery, policiesData, agenciesData),
-    [filterJurisdiction, filterStatus, filterType, searchQuery, policiesData, agenciesData]
-  );
-
-  // Calculate statistics
-  const stats = useMemo(
-    () => calculateStats(filterJurisdiction, filterStatus, filterType, searchQuery, policiesData),
-    [filterJurisdiction, filterStatus, filterType, searchQuery, policiesData]
-  );
-
-  const [nodes, setNodes, onNodesChange] = useNodesState(graphNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(graphEdges);
-
-  // Update nodes and edges when filters change
-  useEffect(() => {
-    setNodes(graphNodes);
-    setEdges(graphEdges);
-  }, [graphNodes, graphEdges, setNodes, setEdges]);
-
-  const onNodeClick = useCallback((_: React.MouseEvent, node: Node<NodeData>) => {
-    setSelectedNode(node);
-  }, []);
-
-  const onNodeMouseEnter = useCallback((_: React.MouseEvent, node: Node<NodeData>) => {
-    setHoveredNode(node.id);
-  }, []);
-
-  const onNodeMouseLeave = useCallback(() => {
-    setHoveredNode(null);
-  }, []);
-
-  const clearFilters = () => {
-    setFilterJurisdiction('all');
-    setFilterStatus('all');
-    setFilterType('all');
-    setSearchQuery('');
-  };
-
-  const hasActiveFilters =
-    filterJurisdiction !== 'all' || filterStatus !== 'all' || filterType !== 'all' || searchQuery !== '';
-
-  // Highlight connected edges on hover - subtle effect
-  const highlightedEdges = useMemo(() => {
-    if (!hoveredNode) return edges;
-    return edges.map((edge) => {
-      const isConnected = edge.source === hoveredNode || edge.target === hoveredNode;
-      return {
-        ...edge,
-        style: {
-          ...edge.style,
-          strokeWidth: isConnected ? 3 : edge.style?.strokeWidth,
-          opacity: isConnected ? 1 : 0.6,
-        },
-      };
-    });
-  }, [edges, hoveredNode]);
-
-  // Highlight connected nodes on hover - subtle effect without aggressive fading
-  const highlightedNodes = useMemo(() => {
-    if (!hoveredNode) return nodes;
-    const connectedNodeIds = new Set<string>();
-    connectedNodeIds.add(hoveredNode);
-    edges.forEach((edge) => {
-      if (edge.source === hoveredNode) connectedNodeIds.add(edge.target);
-      if (edge.target === hoveredNode) connectedNodeIds.add(edge.source);
-    });
-
-    return nodes.map((node) => {
-      const isConnected = connectedNodeIds.has(node.id);
-      const isHovered = node.id === hoveredNode;
-      return {
-        ...node,
-        style: {
-          ...node.style,
-          opacity: isConnected ? 1 : 0.75,
-          filter: isHovered ? 'brightness(1.1)' : undefined,
-          boxShadow: isHovered
-            ? '0 0 20px rgba(99, 102, 241, 0.5), 0 4px 12px rgba(0,0,0,0.3)'
-            : node.style?.boxShadow,
-        },
-      };
-    });
-  }, [nodes, edges, hoveredNode]);
-
-  // MiniMap node color function
-  const nodeColor = (node: Node<NodeData>) => {
-    switch (node.data.type) {
-      case 'jurisdiction':
-        return 'var(--network-jurisdiction-border)';
-      case 'agency':
-        return 'var(--network-agency-border)';
-      case 'policy':
-        return node.data.status === 'active'
-          ? 'var(--network-active-border)'
-          : node.data.status === 'proposed'
-            ? 'var(--network-proposed-border)'
-            : node.data.status === 'amended'
-              ? 'var(--network-amended-border)'
-              : 'var(--network-default-border)';
-      default:
-        return 'var(--network-default-border)';
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/network');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error || 'Failed to load');
+      setNodes(json.nodes);
+      setEdges(json.edges);
+      // Initialize all jurisdictions as active
+      const jurisdictions = new Set<string>(json.nodes.map((n: NetworkNode) => n.jurisdiction));
+      setActiveJurisdictions(jurisdictions);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load network data');
+    } finally {
+      setLoading(false);
     }
-  };
+  }, []);
 
-  if (dataLoading) {
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  // Jurisdiction info for toolbar
+  const jurisdictionInfo = useMemo(() => {
+    const counts: Record<string, number> = {};
+    for (const node of nodes) {
+      counts[node.jurisdiction] = (counts[node.jurisdiction] || 0) + 1;
+    }
+    return Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([key, count]) => ({
+        key,
+        label: JURISDICTION_NAMES[key as Jurisdiction] || key,
+        color: resolveColor(JURISDICTION_COLORS[key] || 'var(--chart-1)'),
+        count,
+      }));
+  }, [nodes]);
+
+  const toggleJurisdiction = useCallback((key: string) => {
+    setActiveJurisdictions((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  // Selected policy and its connections
+  const selectedPolicy = useMemo(
+    () => nodes.find((n) => n.id === selectedNodeId) ?? null,
+    [nodes, selectedNodeId],
+  );
+
+  const connectedPolicies = useMemo(() => {
+    if (!selectedNodeId) return [];
+    const connected: { id: string; title: string; jurisdiction: string }[] = [];
+    for (const edge of edges) {
+      if (edge.source === selectedNodeId) {
+        const target = nodes.find((n) => n.id === edge.target);
+        if (target) connected.push({ id: target.id, title: target.title, jurisdiction: target.jurisdiction });
+      } else if (edge.target === selectedNodeId) {
+        const source = nodes.find((n) => n.id === edge.source);
+        if (source) connected.push({ id: source.id, title: source.title, jurisdiction: source.jurisdiction });
+      }
+    }
+    return connected;
+  }, [selectedNodeId, edges, nodes]);
+
+  // Loading state
+  if (loading) {
     return (
-      <div className="container mx-auto max-w-7xl px-4 py-8 md:py-10">
-        <div className="flex items-center justify-center min-h-[60vh]">
-          <div className="animate-pulse text-muted-foreground">Loading network data...</div>
-        </div>
+      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)] gap-3">
+        <div className="animate-spin rounded-full h-8 w-8 border-2 border-muted-foreground border-t-foreground" />
+        <p className="text-sm text-muted-foreground">Loading network...</p>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)] gap-4">
+        <AlertCircle className="h-12 w-12 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">Failed to load network data</p>
+        <p className="text-xs text-muted-foreground/60">{error}</p>
+        <Button variant="outline" size="sm" onClick={fetchData}>
+          <RefreshCw className="h-3 w-3 mr-2" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (nodes.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)] gap-4">
+        <Network className="h-12 w-12 text-muted-foreground/30" />
+        <p className="text-sm text-muted-foreground">No policies found</p>
+        <Link href="/" className="text-xs text-primary hover:underline">
+          Browse policies →
+        </Link>
       </div>
     );
   }
 
   return (
-    <div className="container mx-auto max-w-7xl px-4 py-8 md:py-10">
-      {/* Header */}
-      <div className="mb-8 space-y-2">
-        <div className="flex items-center gap-3">
-          <div className="rounded-xl bg-primary/10 p-3">
-            <Network className="h-6 w-6 text-primary" />
-          </div>
-          <h1 className="text-3xl font-bold tracking-tight">Relationship Network</h1>
+    <div className="relative w-full h-[calc(100vh-4rem)] overflow-hidden">
+      <NetworkToolbar
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        jurisdictions={jurisdictionInfo}
+        activeJurisdictions={activeJurisdictions}
+        onToggleJurisdiction={toggleJurisdiction}
+        totalPolicies={nodes.length}
+      />
+
+      <ForceGraph
+        nodes={nodes}
+        edges={edges}
+        searchQuery={searchQuery}
+        activeJurisdictions={activeJurisdictions}
+        selectedNodeId={selectedNodeId}
+        onNodeClick={setSelectedNodeId}
+      />
+
+      <NetworkSidebar
+        policy={selectedPolicy}
+        connectedPolicies={connectedPolicies}
+        onClose={() => setSelectedNodeId(null)}
+        onNavigateToNode={setSelectedNodeId}
+      />
+
+      {/* Partial data note */}
+      {edges.length === 0 && nodes.length > 0 && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-card/90 backdrop-blur border border-border rounded-lg px-4 py-2 text-xs text-muted-foreground">
+          No cross-policy connections found yet — policies may not share enough tags
         </div>
-        <p className="max-w-3xl text-muted-foreground">
-          Visualise connections between AI policies, government agencies, and jurisdictions across Australia
-        </p>
-      </div>
-
-      {/* Statistics Cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <Card className="border-indigo-500/15 bg-indigo-500/5 shadow-sm dark:border-indigo-400/20 dark:bg-indigo-400/10">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-indigo-500/20">
-                <Map className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold tabular-nums">{stats.jurisdictions}</div>
-                <p className="text-xs text-muted-foreground">Jurisdictions</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="border-green-500/15 bg-green-500/5 shadow-sm dark:border-green-400/20 dark:bg-green-400/10">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-green-500/20">
-                <FileText className="h-4 w-4 text-green-600 dark:text-green-400" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold tabular-nums">{stats.activePolicies}</div>
-                <p className="text-xs text-muted-foreground">Active Policies</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="border-amber-500/15 bg-amber-500/5 shadow-sm dark:border-amber-400/20 dark:bg-amber-400/10">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-amber-500/20">
-                <GitBranch className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold tabular-nums">{stats.proposedPolicies}</div>
-                <p className="text-xs text-muted-foreground">Proposed</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        <Card className="border-purple-500/15 bg-purple-500/5 shadow-sm dark:border-purple-400/20 dark:bg-purple-400/10">
-          <CardContent className="pt-4 pb-3">
-            <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-purple-500/20">
-                <BarChart3 className="h-4 w-4 text-purple-600 dark:text-purple-400" />
-              </div>
-              <div>
-                <div className="text-2xl font-bold tabular-nums">{stats.totalPolicies}</div>
-                <p className="text-xs text-muted-foreground">Total Policies</p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div className="grid lg:grid-cols-4 gap-6">
-        {/* Sidebar: Filters & Legend */}
-        <div className="space-y-4 lg:col-span-1 lg:sticky lg:top-24 lg:self-start">
-          {/* Search */}
-          <Card className="shadow-sm">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Search className="h-4 w-4" />
-                Search
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="relative">
-                <Input
-                  placeholder="Search policies..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="pr-8"
-                />
-                {searchQuery && (
-                  <button
-                    onClick={() => setSearchQuery('')}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  >
-                    <X className="h-4 w-4" />
-                  </button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Filters */}
-          <Card className="shadow-sm">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Filter className="h-4 w-4" />
-                Filters
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div>
-                <label className="text-xs font-medium mb-1.5 block text-muted-foreground">Jurisdiction</label>
-                <Select value={filterJurisdiction} onValueChange={setFilterJurisdiction}>
-                  <SelectTrigger className="h-9">
-                    <SelectValue placeholder="All Jurisdictions" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Jurisdictions</SelectItem>
-                    {Object.entries(JURISDICTION_NAMES).map(([key, name]) => (
-                      <SelectItem key={key} value={key}>
-                        {name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <label className="text-xs font-medium mb-1.5 block text-muted-foreground">Status</label>
-                <Select value={filterStatus} onValueChange={setFilterStatus}>
-                  <SelectTrigger className="h-9">
-                    <SelectValue placeholder="All Statuses" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Statuses</SelectItem>
-                    {Object.entries(POLICY_STATUS_NAMES).map(([key, name]) => (
-                      <SelectItem key={key} value={key}>
-                        {name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <label className="text-xs font-medium mb-1.5 block text-muted-foreground">Type</label>
-                <Select value={filterType} onValueChange={setFilterType}>
-                  <SelectTrigger className="h-9">
-                    <SelectValue placeholder="All Types" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Types</SelectItem>
-                    {Object.entries(POLICY_TYPE_NAMES).map(([key, name]) => (
-                      <SelectItem key={key} value={key}>
-                        {name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {hasActiveFilters && (
-                <Button variant="outline" size="sm" onClick={clearFilters} className="w-full">
-                  <X className="h-3 w-3 mr-1" />
-                  Clear Filters
-                </Button>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Legend */}
-          <Card className="shadow-sm">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm flex items-center gap-2">
-                <Info className="h-4 w-4" />
-                Legend
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2.5">
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-jurisdiction-bg)' }}
-                />
-                <span className="text-xs">Jurisdiction</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-agency-bg)' }}
-                />
-                <span className="text-xs">Agency</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-active-bg)' }}
-                />
-                <span className="text-xs">Active Policy</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-proposed-bg)' }}
-                />
-                <span className="text-xs">Proposed Policy</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div
-                  className="h-4 w-8 rounded"
-                  style={{ background: 'var(--network-amended-bg)' }}
-                />
-                <span className="text-xs">Amended Policy</span>
-              </div>
-              <div className="mt-3 pt-3 border-t">
-                <div className="flex items-center gap-2 mb-1.5">
-                  <div className="h-0.5 w-8 bg-green-500 rounded animate-pulse" />
-                  <span className="text-xs">Active Connection</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <div className="h-0.5 w-8 bg-slate-400 rounded" />
-                  <span className="text-xs">Connection</span>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* How to Use */}
-          <Card className="shadow-sm">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm">Controls</CardTitle>
-            </CardHeader>
-            <CardContent className="text-xs text-muted-foreground space-y-1.5">
-              <p>• Drag to pan the view</p>
-              <p>• Scroll to zoom in/out</p>
-              <p>• Click nodes for details</p>
-              <p>• Hover to highlight connections</p>
-              <p>• Drag nodes to rearrange</p>
-              <p>• Use minimap for navigation</p>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Network Graph */}
-        <div className="lg:col-span-3">
-          <Card className="h-[440px] overflow-hidden shadow-sm lg:h-[700px]">
-            <CardContent className="p-0 h-full">
-              {highlightedNodes.length === 0 ? (
-                <div className="flex flex-col items-center justify-center h-full text-center p-8">
-                  <Network className="h-16 w-16 text-muted-foreground/30 mb-4" />
-                  <h3 className="text-lg font-medium mb-2">No Results Found</h3>
-                  <p className="text-sm text-muted-foreground mb-4">
-                    Try adjusting your filters or search query to see the network graph.
-                  </p>
-                  <Button variant="outline" size="sm" onClick={clearFilters}>
-                    Clear All Filters
-                  </Button>
-                </div>
-              ) : (
-                <ReactFlow
-                  nodes={highlightedNodes}
-                  edges={highlightedEdges}
-                  onNodesChange={onNodesChange}
-                  onEdgesChange={onEdgesChange}
-                  onNodeClick={onNodeClick}
-                  onNodeMouseEnter={onNodeMouseEnter}
-                  onNodeMouseLeave={onNodeMouseLeave}
-                  fitView
-                  fitViewOptions={{ padding: 0.2 }}
-                  attributionPosition="bottom-left"
-                  minZoom={0.3}
-                  maxZoom={2}
-                  defaultEdgeOptions={{
-                    type: 'smoothstep',
-                  }}
-                >
-                  <Controls showInteractive={false} />
-                  <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="var(--border)" />
-                  <MiniMap
-                    nodeColor={nodeColor}
-                    maskColor="var(--network-minimap-mask)"
-                    className="bg-background/80 backdrop-blur-sm border border-border rounded-lg"
-                    position="bottom-right"
-                  />
-                </ReactFlow>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-
-      {/* Node Detail Dialog */}
-      <Dialog open={!!selectedNode} onOpenChange={() => setSelectedNode(null)}>
-        <DialogContent className="max-w-lg">
-          {selectedNode?.data.type === 'policy' && (
-            <>
-              <DialogHeader>
-                <div className="flex items-center gap-2">
-                  <div className="p-2 rounded-lg bg-primary/10">
-                    <FileText className="h-5 w-5 text-primary" />
-                  </div>
-                  <div>
-                    <DialogTitle className="text-lg">Policy Details</DialogTitle>
-                    <DialogDescription className="text-xs">View policy information</DialogDescription>
-                  </div>
-                </div>
-              </DialogHeader>
-              <ScrollArea className="max-h-[400px] mt-4">
-                <div className="space-y-4">
-                  <h3 className="font-semibold">
-                    {(selectedNode.data.originalData as Policy).title}
-                  </h3>
-                  <div className="flex flex-wrap gap-2">
-                    <Badge
-                      variant={
-                        (selectedNode.data.originalData as Policy).status === 'active'
-                          ? 'default'
-                          : 'secondary'
-                      }
-                      className={
-                        (selectedNode.data.originalData as Policy).status === 'active'
-                          ? 'bg-[var(--status-active)] hover:opacity-90 text-background'
-                          : ''
-                      }
-                    >
-                      {
-                        POLICY_STATUS_NAMES[
-                          (selectedNode.data.originalData as Policy).status as PolicyStatus
-                        ]
-                      }
-                    </Badge>
-                    <Badge variant="outline">
-                      {
-                        POLICY_TYPE_NAMES[
-                          (selectedNode.data.originalData as Policy).type as PolicyType
-                        ]
-                      }
-                    </Badge>
-                    <Badge variant="secondary">
-                      {
-                        JURISDICTION_NAMES[
-                          (selectedNode.data.originalData as Policy).jurisdiction as Jurisdiction
-                        ]
-                      }
-                    </Badge>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {(selectedNode.data.originalData as Policy).description}
-                  </p>
-                  {(selectedNode.data.originalData as Policy).aiSummary && (
-                    <div className="p-4 bg-muted rounded-lg">
-                      <h4 className="text-sm font-medium mb-2">AI Summary</h4>
-                      <p className="text-sm text-muted-foreground">
-                        {(selectedNode.data.originalData as Policy).aiSummary}
-                      </p>
-                    </div>
-                  )}
-                  <div className="flex flex-wrap gap-2">
-                    {(selectedNode.data.originalData as Policy).tags?.map((tag) => (
-                      <Badge key={tag} variant="outline" className="text-xs">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                  {(selectedNode.data.originalData as Policy).sourceUrl && (
-                    <a
-                      href={(selectedNode.data.originalData as Policy).sourceUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-                    >
-                      <ExternalLink className="h-4 w-4" />
-                      View Source
-                    </a>
-                  )}
-                </div>
-              </ScrollArea>
-            </>
-          )}
-
-          {selectedNode?.data.type === 'agency' && (
-            <>
-              <DialogHeader>
-                <div className="flex items-center gap-2">
-                  <div className="p-2 rounded-lg bg-amber-500/10 dark:bg-amber-400/15">
-                    <Building2 className="h-5 w-5 text-amber-600 dark:text-amber-400" />
-                  </div>
-                  <div>
-                    <DialogTitle className="text-lg">Agency Details</DialogTitle>
-                    <DialogDescription className="text-xs">View agency information</DialogDescription>
-                  </div>
-                </div>
-              </DialogHeader>
-              <div className="space-y-4 mt-4">
-                <h3 className="font-semibold">
-                  {(selectedNode.data.originalData as Agency).name}
-                </h3>
-                <div className="flex flex-wrap gap-2">
-                  <Badge variant="default">
-                    {(selectedNode.data.originalData as Agency).acronym}
-                  </Badge>
-                  <Badge variant="outline">
-                    {(selectedNode.data.originalData as Agency).level}
-                  </Badge>
-                  <Badge variant="secondary">
-                    {
-                      JURISDICTION_NAMES[
-                        (selectedNode.data.originalData as Agency).jurisdiction as Jurisdiction
-                      ]
-                    }
-                  </Badge>
-                </div>
-                {(selectedNode.data.originalData as Agency).aiTransparencyStatement && (
-                  <div className="p-4 bg-muted rounded-lg">
-                    <h4 className="text-sm font-medium mb-2">AI Transparency Statement</h4>
-                    <p className="text-sm text-muted-foreground">
-                      {(selectedNode.data.originalData as Agency).aiTransparencyStatement}
-                    </p>
-                  </div>
-                )}
-                {(selectedNode.data.originalData as Agency).aiUsageDisclosure && (
-                  <div className="p-4 bg-blue-500/10 dark:bg-blue-400/10 rounded-lg border border-blue-500/20 dark:border-blue-400/20">
-                    <h4 className="text-sm font-medium mb-2">AI Usage Disclosure</h4>
-                    <p className="text-sm text-muted-foreground">
-                      {(selectedNode.data.originalData as Agency).aiUsageDisclosure}
-                    </p>
-                  </div>
-                )}
-                <a
-                  href={(selectedNode.data.originalData as Agency).website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-primary hover:underline inline-flex items-center gap-1"
-                >
-                  <ExternalLink className="h-4 w-4" />
-                  Visit Website
-                </a>
-              </div>
-            </>
-          )}
-
-          {selectedNode?.data.type === 'jurisdiction' && (
-            <>
-              <DialogHeader>
-                <div className="flex items-center gap-2">
-                  <div className="p-2 rounded-lg bg-indigo-500/10 dark:bg-indigo-400/15">
-                    <Map className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
-                  </div>
-                  <div>
-                    <DialogTitle className="text-lg">Jurisdiction</DialogTitle>
-                    <DialogDescription className="text-xs">
-                      {
-                        JURISDICTION_NAMES[
-                          (selectedNode.data.originalData as { jurisdiction: Jurisdiction }).jurisdiction
-                        ]
-                      }
-                    </DialogDescription>
-                  </div>
-                </div>
-              </DialogHeader>
-              <div className="space-y-4 mt-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <Card className="bg-gradient-to-br from-green-500/10 to-green-500/5 border-green-500/20 dark:from-green-400/15 dark:to-green-400/5 dark:border-green-400/20">
-                    <CardContent className="pt-4 pb-3">
-                      <div className="text-2xl font-bold">
-                        {
-                          policiesData.filter(
-                            (p) =>
-                              p.jurisdiction ===
-                              (selectedNode.data.originalData as { jurisdiction: Jurisdiction }).jurisdiction
-                          ).length
-                        }
-                      </div>
-                      <p className="text-xs text-muted-foreground">Policies</p>
-                    </CardContent>
-                  </Card>
-                  <Card className="bg-gradient-to-br from-amber-500/10 to-amber-500/5 border-amber-500/20 dark:from-amber-400/15 dark:to-amber-400/5 dark:border-amber-400/20">
-                    <CardContent className="pt-4 pb-3">
-                      <div className="text-2xl font-bold">
-                        {
-                          agenciesData.filter(
-                            (a) =>
-                              a.jurisdiction ===
-                              (selectedNode.data.originalData as { jurisdiction: Jurisdiction }).jurisdiction
-                          ).length
-                        }
-                      </div>
-                      <p className="text-xs text-muted-foreground">Agencies</p>
-                    </CardContent>
-                  </Card>
-                </div>
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  onClick={() => {
-                    setFilterJurisdiction(
-                      (selectedNode.data.originalData as { jurisdiction: Jurisdiction }).jurisdiction
-                    );
-                    setSelectedNode(null);
-                  }}
-                >
-                  <Filter className="h-4 w-4 mr-2" />
-                  Filter by this Jurisdiction
-                </Button>
-              </div>
-            </>
-          )}
-        </DialogContent>
-      </Dialog>
+      )}
     </div>
   );
 }

--- a/src/components/network/ForceGraph.tsx
+++ b/src/components/network/ForceGraph.tsx
@@ -1,0 +1,297 @@
+'use client';
+
+import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import { zoom as d3Zoom, type ZoomBehavior } from 'd3-zoom';
+import { select } from 'd3-selection';
+import { drag as d3Drag } from 'd3-drag';
+import type { NetworkNode, NetworkEdge } from '@/app/api/network/route';
+import { useForceSimulation, type SimNode } from './use-force-simulation';
+import { JURISDICTION_COLORS, resolveColor } from './jurisdiction-colors';
+import { JURISDICTION_NAMES, type Jurisdiction } from '@/types';
+
+interface ForceGraphProps {
+  nodes: NetworkNode[];
+  edges: NetworkEdge[];
+  searchQuery: string;
+  activeJurisdictions: Set<string>;
+  selectedNodeId: string | null;
+  onNodeClick: (id: string) => void;
+}
+
+const STATUS_RING_COLORS: Record<string, string> = {
+  active: 'var(--status-active)',
+  proposed: 'var(--status-proposed)',
+  amended: 'var(--status-amended)',
+  repealed: 'var(--status-repealed)',
+};
+
+export function ForceGraph({
+  nodes,
+  edges,
+  searchQuery,
+  activeJurisdictions,
+  selectedNodeId,
+  onNodeClick,
+}: ForceGraphProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const gRef = useRef<SVGGElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
+  const [hoveredNode, setHoveredNode] = useState<string | null>(null);
+  const [transform, setTransform] = useState({ x: 0, y: 0, k: 1 });
+
+  // Measure container
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect;
+      if (width > 0 && height > 0) setDimensions({ width, height });
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const { simNodes, simEdges, simulation } = useForceSimulation(
+    nodes,
+    edges,
+    dimensions.width,
+    dimensions.height,
+  );
+
+  // Compute cluster centroids for labels
+  const clusterLabels = useMemo(() => {
+    const groups: Record<string, { xs: number[]; ys: number[] }> = {};
+    for (const node of simNodes) {
+      if (!groups[node.jurisdiction]) groups[node.jurisdiction] = { xs: [], ys: [] };
+      groups[node.jurisdiction].xs.push(node.x);
+      groups[node.jurisdiction].ys.push(node.y);
+    }
+    return Object.entries(groups).map(([jurisdiction, { xs, ys }]) => ({
+      jurisdiction,
+      label: JURISDICTION_NAMES[jurisdiction as Jurisdiction] || jurisdiction,
+      x: xs.reduce((a, b) => a + b, 0) / xs.length,
+      y: ys.reduce((a, b) => a + b, 0) / ys.length - 30,
+    }));
+  }, [simNodes]);
+
+  // Zoom behavior
+  useEffect(() => {
+    if (!svgRef.current) return;
+    const svg = select(svgRef.current);
+    const zoomBehavior: ZoomBehavior<SVGSVGElement, unknown> = d3Zoom<SVGSVGElement, unknown>()
+      .scaleExtent([0.3, 3])
+      .on('zoom', (event) => {
+        setTransform({ x: event.transform.x, y: event.transform.y, k: event.transform.k });
+      });
+    svg.call(zoomBehavior);
+    return () => { svg.on('.zoom', null); };
+  }, []);
+
+  // Drag behavior
+  const handleDragStart = useCallback(
+    (nodeId: string) => {
+      const sim = simulation.current;
+      if (sim) sim.alphaTarget(0.3).restart();
+      const node = sim?.nodes().find((n) => (n as SimNode).id === nodeId) as SimNode | undefined;
+      if (node) node.fx = node.x;
+      if (node) node.fy = node.y;
+    },
+    [simulation],
+  );
+
+  const handleDrag = useCallback(
+    (nodeId: string, dx: number, dy: number) => {
+      const sim = simulation.current;
+      const node = sim?.nodes().find((n) => (n as SimNode).id === nodeId) as SimNode | undefined;
+      if (node) {
+        node.fx = (node.fx ?? node.x) + dx / transform.k;
+        node.fy = (node.fy ?? node.y) + dy / transform.k;
+      }
+    },
+    [simulation, transform.k],
+  );
+
+  const handleDragEnd = useCallback(
+    (nodeId: string) => {
+      const sim = simulation.current;
+      if (sim) sim.alphaTarget(0);
+      const node = sim?.nodes().find((n) => (n as SimNode).id === nodeId) as SimNode | undefined;
+      if (node) { node.fx = null; node.fy = null; }
+    },
+    [simulation],
+  );
+
+  // Node visibility
+  const isNodeVisible = useCallback(
+    (node: SimNode) => {
+      if (!activeJurisdictions.has(node.jurisdiction)) return false;
+      if (searchQuery && !node.title.toLowerCase().includes(searchQuery.toLowerCase())) return false;
+      return true;
+    },
+    [activeJurisdictions, searchQuery],
+  );
+
+  // Connected node highlighting
+  const connectedIds = useMemo(() => {
+    if (!hoveredNode) return new Set<string>();
+    const ids = new Set<string>();
+    ids.add(hoveredNode);
+    for (const edge of simEdges) {
+      const src = typeof edge.source === 'object' ? (edge.source as SimNode).id : String(edge.source);
+      const tgt = typeof edge.target === 'object' ? (edge.target as SimNode).id : String(edge.target);
+      if (src === hoveredNode) ids.add(tgt);
+      if (tgt === hoveredNode) ids.add(src);
+    }
+    return ids;
+  }, [hoveredNode, simEdges]);
+
+  return (
+    <div ref={containerRef} className="w-full h-full relative">
+      <svg
+        ref={svgRef}
+        width={dimensions.width}
+        height={dimensions.height}
+        className="cursor-grab active:cursor-grabbing"
+      >
+        {/* Background pattern */}
+        <defs>
+          <pattern id="network-dots" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+            <circle cx="10" cy="10" r="0.8" className="fill-border" />
+          </pattern>
+        </defs>
+        <rect width={dimensions.width} height={dimensions.height} fill="url(#network-dots)" />
+
+        <g ref={gRef} transform={`translate(${transform.x},${transform.y}) scale(${transform.k})`}>
+          {/* Edges */}
+          {simEdges.map((edge, i) => {
+            const src = edge.source as SimNode;
+            const tgt = edge.target as SimNode;
+            if (!isNodeVisible(src) || !isNodeVisible(tgt)) return null;
+
+            const isHighlighted = hoveredNode && (connectedIds.has(src.id) && connectedIds.has(tgt.id));
+            const jurisdictionColor = resolveColor(JURISDICTION_COLORS[src.jurisdiction] || 'var(--chart-1)');
+
+            return (
+              <line
+                key={`edge-${i}`}
+                x1={src.x}
+                y1={src.y}
+                x2={tgt.x}
+                y2={tgt.y}
+                stroke={edge.crossJurisdiction ? '#a855f7' : jurisdictionColor}
+                strokeWidth={isHighlighted ? 2.5 : 1}
+                strokeDasharray={edge.crossJurisdiction ? '6,3' : undefined}
+                opacity={hoveredNode ? (isHighlighted ? 0.8 : 0.15) : 0.3}
+                className="transition-opacity duration-200"
+              />
+            );
+          })}
+
+          {/* Cluster labels */}
+          {clusterLabels
+            .filter((cl) => activeJurisdictions.has(cl.jurisdiction))
+            .map((cl) => (
+              <text
+                key={`label-${cl.jurisdiction}`}
+                x={cl.x}
+                y={cl.y}
+                textAnchor="middle"
+                className="fill-muted-foreground font-sans text-[11px] font-medium pointer-events-none select-none"
+                opacity={0.5}
+              >
+                {cl.label}
+              </text>
+            ))}
+
+          {/* Nodes */}
+          {simNodes.map((node) => {
+            const visible = isNodeVisible(node);
+            const isHovered = hoveredNode === node.id;
+            const isSelected = selectedNodeId === node.id;
+            const isConnected = connectedIds.has(node.id);
+            const jurisdictionColor = resolveColor(JURISDICTION_COLORS[node.jurisdiction] || 'var(--chart-1)');
+            const statusColor = resolveColor(STATUS_RING_COLORS[node.status] || 'var(--status-repealed)');
+
+            const nodeOpacity = !visible
+              ? 0.08
+              : hoveredNode
+                ? isConnected
+                  ? 1
+                  : 0.25
+                : 1;
+
+            return (
+              <g
+                key={node.id}
+                transform={`translate(${node.x},${node.y})`}
+                opacity={nodeOpacity}
+                className="transition-opacity duration-200 cursor-pointer"
+                onMouseEnter={() => setHoveredNode(node.id)}
+                onMouseLeave={() => setHoveredNode(null)}
+                onClick={() => onNodeClick(node.id)}
+                onMouseDown={(e) => {
+                  const startX = e.clientX;
+                  const startY = e.clientY;
+                  let dragged = false;
+                  handleDragStart(node.id);
+
+                  const onMove = (ev: MouseEvent) => {
+                    const dx = ev.clientX - startX;
+                    const dy = ev.clientY - startY;
+                    if (Math.abs(dx) > 3 || Math.abs(dy) > 3) dragged = true;
+                    handleDrag(node.id, ev.movementX, ev.movementY);
+                  };
+                  const onUp = () => {
+                    handleDragEnd(node.id);
+                    window.removeEventListener('mousemove', onMove);
+                    window.removeEventListener('mouseup', onUp);
+                    if (!dragged) onNodeClick(node.id);
+                  };
+                  window.addEventListener('mousemove', onMove);
+                  window.addEventListener('mouseup', onUp);
+                  e.stopPropagation();
+                }}
+              >
+                {/* Status ring */}
+                <circle
+                  r={node.radius + 2}
+                  fill="none"
+                  stroke={statusColor}
+                  strokeWidth={isSelected ? 2.5 : 1.5}
+                  opacity={isHovered || isSelected ? 1 : 0.6}
+                />
+                {/* Node circle */}
+                <circle
+                  r={isHovered ? node.radius * 1.2 : node.radius}
+                  fill={jurisdictionColor}
+                  className="transition-all duration-150"
+                />
+                {/* Hover label */}
+                {isHovered && (
+                  <>
+                    <rect
+                      x={-node.title.length * 3.2}
+                      y={-node.radius - 26}
+                      width={node.title.length * 6.4}
+                      height={18}
+                      rx={4}
+                      className="fill-card stroke-border"
+                      strokeWidth={0.5}
+                    />
+                    <text
+                      y={-node.radius - 14}
+                      textAnchor="middle"
+                      className="fill-foreground font-sans text-[10px] pointer-events-none select-none"
+                    >
+                      {node.title.length > 40 ? node.title.slice(0, 37) + '...' : node.title}
+                    </text>
+                  </>
+                )}
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+    </div>
+  );
+}

--- a/src/components/network/NetworkSidebar.tsx
+++ b/src/components/network/NetworkSidebar.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { X, ExternalLink, ArrowRight } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { JURISDICTION_NAMES, POLICY_TYPE_NAMES, POLICY_STATUS_NAMES, type Jurisdiction, type PolicyType, type PolicyStatus } from '@/types';
+import type { NetworkNode } from '@/app/api/network/route';
+import { JURISDICTION_COLORS, resolveColor } from './jurisdiction-colors';
+
+interface ConnectedPolicy {
+  id: string;
+  title: string;
+  jurisdiction: string;
+}
+
+interface NetworkSidebarProps {
+  policy: NetworkNode | null;
+  connectedPolicies: ConnectedPolicy[];
+  onClose: () => void;
+  onNavigateToNode: (id: string) => void;
+}
+
+export function NetworkSidebar({
+  policy,
+  connectedPolicies,
+  onClose,
+  onNavigateToNode,
+}: NetworkSidebarProps) {
+  return (
+    <div
+      className={`absolute top-0 right-0 bottom-0 w-80 bg-card/95 backdrop-blur-xl border-l border-border transition-transform duration-300 z-20 ${
+        policy ? 'translate-x-0' : 'translate-x-full'
+      }`}
+    >
+      {policy && (
+        <ScrollArea className="h-full">
+          <div className="p-5 space-y-4">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground font-semibold">
+                Policy Detail
+              </span>
+              <button
+                onClick={onClose}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            {/* Badges */}
+            <div className="flex flex-wrap gap-1.5">
+              <Badge
+                variant="default"
+                className="text-[10px]"
+                style={{
+                  backgroundColor: `var(--status-${policy.status}-bg)`,
+                  color: `var(--status-${policy.status})`,
+                  border: 'none',
+                }}
+              >
+                {POLICY_STATUS_NAMES[policy.status as PolicyStatus] || policy.status}
+              </Badge>
+              <Badge variant="outline" className="text-[10px]">
+                {POLICY_TYPE_NAMES[policy.type as PolicyType] || policy.type}
+              </Badge>
+              <Badge variant="secondary" className="text-[10px]">
+                {JURISDICTION_NAMES[policy.jurisdiction as Jurisdiction] || policy.jurisdiction}
+              </Badge>
+            </div>
+
+            {/* Title */}
+            <h3 className="text-base font-semibold leading-snug">{policy.title}</h3>
+
+            {/* Date */}
+            {policy.effectiveDate && (
+              <p className="text-[11px] text-muted-foreground">
+                Effective: {new Date(policy.effectiveDate).toLocaleDateString('en-AU', {
+                  day: 'numeric',
+                  month: 'short',
+                  year: 'numeric',
+                })}
+              </p>
+            )}
+
+            {/* Description */}
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {policy.description.length > 250
+                ? policy.description.slice(0, 247) + '...'
+                : policy.description}
+            </p>
+
+            {/* Connected policies */}
+            {connectedPolicies.length > 0 && (
+              <div>
+                <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground font-semibold block mb-2">
+                  Connected Policies
+                </span>
+                <div className="space-y-1">
+                  {connectedPolicies.map((cp) => (
+                    <button
+                      key={cp.id}
+                      onClick={() => onNavigateToNode(cp.id)}
+                      className="flex items-center gap-2 w-full px-2.5 py-2 rounded-lg bg-muted/50 hover:bg-muted text-left transition-colors group"
+                    >
+                      <div
+                        className="w-2 h-2 rounded-full flex-shrink-0"
+                        style={{ backgroundColor: resolveColor(JURISDICTION_COLORS[cp.jurisdiction] || 'var(--chart-1)') }}
+                      />
+                      <span className="text-xs text-foreground truncate flex-1">
+                        {cp.title}
+                      </span>
+                      <ArrowRight className="h-3 w-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Agencies */}
+            {policy.agencies.length > 0 && (
+              <div>
+                <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground font-semibold block mb-2">
+                  Agencies
+                </span>
+                <div className="space-y-1">
+                  {policy.agencies.map((agency) => (
+                    <p key={agency} className="text-xs text-muted-foreground">
+                      {agency}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Tags */}
+            {policy.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {policy.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="bg-muted text-muted-foreground px-2 py-0.5 rounded text-[10px]"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex gap-2 pt-2">
+              <a
+                href={`/policies/${policy.id}`}
+                className="flex-1 flex items-center justify-center gap-1 px-3 py-2 bg-muted hover:bg-accent border border-border rounded-lg text-xs font-medium transition-colors"
+              >
+                View Full Policy
+                <ArrowRight className="h-3 w-3" />
+              </a>
+              {policy.sourceUrl && (
+                <a
+                  href={policy.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 px-3 py-2 bg-muted/50 hover:bg-muted border border-border rounded-lg text-xs text-muted-foreground transition-colors"
+                >
+                  Source
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              )}
+            </div>
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  );
+}

--- a/src/components/network/NetworkToolbar.tsx
+++ b/src/components/network/NetworkToolbar.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { Search, X } from 'lucide-react';
+import { JURISDICTION_NAMES, type Jurisdiction } from '@/types';
+import { JURISDICTION_COLORS } from './jurisdiction-colors';
+
+interface JurisdictionInfo {
+  key: string;
+  label: string;
+  color: string;
+  count: number;
+}
+
+interface NetworkToolbarProps {
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+  jurisdictions: JurisdictionInfo[];
+  activeJurisdictions: Set<string>;
+  onToggleJurisdiction: (key: string) => void;
+  totalPolicies: number;
+}
+
+export function NetworkToolbar({
+  searchQuery,
+  onSearchChange,
+  jurisdictions,
+  activeJurisdictions,
+  onToggleJurisdiction,
+  totalPolicies,
+}: NetworkToolbarProps) {
+  return (
+    <div className="absolute top-4 left-4 right-4 z-10 flex items-center gap-3 bg-card/90 backdrop-blur-lg border border-border rounded-xl px-4 py-2.5 shadow-sm">
+      {/* Search */}
+      <div className="relative flex-shrink-0 w-48">
+        <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+        <input
+          type="text"
+          placeholder="Search policies..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-full bg-muted/50 border border-border rounded-lg pl-7 pr-7 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/60"
+        />
+        {searchQuery && (
+          <button
+            onClick={() => onSearchChange('')}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+
+      {/* Divider */}
+      <div className="w-px h-6 bg-border" />
+
+      {/* Jurisdiction pills */}
+      <div className="flex gap-1.5 flex-wrap flex-1 min-w-0">
+        {jurisdictions.map((j) => {
+          const active = activeJurisdictions.has(j.key);
+          return (
+            <button
+              key={j.key}
+              onClick={() => onToggleJurisdiction(j.key)}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium transition-all"
+              style={
+                active
+                  ? { background: j.color, color: 'white' }
+                  : { background: 'transparent', color: 'var(--muted-foreground)', border: '1px solid var(--border)' }
+              }
+            >
+              {j.label}
+              <span className="opacity-70">{j.count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Stats */}
+      <div className="flex-shrink-0 font-mono text-[11px] text-muted-foreground whitespace-nowrap">
+        <strong className="text-foreground">{totalPolicies}</strong> policies
+      </div>
+    </div>
+  );
+}

--- a/src/components/network/jurisdiction-colors.ts
+++ b/src/components/network/jurisdiction-colors.ts
@@ -1,0 +1,20 @@
+export const JURISDICTION_COLORS: Record<string, string> = {
+  federal: 'var(--chart-1)',
+  nsw: 'var(--chart-2)',
+  wa: 'var(--chart-3)',
+  qld: 'var(--chart-3)',
+  act: 'var(--chart-4)',
+  vic: 'var(--chart-4)',
+  sa: 'var(--chart-5)',
+  tas: 'var(--chart-5)',
+  nt: 'var(--chart-5)',
+};
+
+/** Resolve CSS variable to a concrete color for D3 (which can't use CSS vars in SVG). */
+export function resolveColor(cssVar: string): string {
+  if (typeof window === 'undefined') return '#888';
+  const resolved = getComputedStyle(document.documentElement)
+    .getPropertyValue(cssVar.replace('var(', '').replace(')', ''))
+    .trim();
+  return resolved || '#888';
+}

--- a/src/components/network/use-force-simulation.ts
+++ b/src/components/network/use-force-simulation.ts
@@ -1,0 +1,142 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import {
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCollide,
+  forceX,
+  forceY,
+  type Simulation,
+  type SimulationNodeDatum,
+  type SimulationLinkDatum,
+} from 'd3-force';
+import type { NetworkNode, NetworkEdge } from '@/app/api/network/route';
+
+export interface SimNode extends SimulationNodeDatum, NetworkNode {
+  x: number;
+  y: number;
+  radius: number;
+}
+
+export interface SimEdge extends SimulationLinkDatum<SimNode> {
+  weight: number;
+  crossJurisdiction: boolean;
+}
+
+/** Compute cluster centroids for jurisdiction-based grouping. */
+function getJurisdictionCentroids(
+  jurisdictions: string[],
+  width: number,
+  height: number,
+): Record<string, { x: number; y: number }> {
+  const centroids: Record<string, { x: number; y: number }> = {};
+  const count = jurisdictions.length;
+  const cx = width / 2;
+  const cy = height / 2;
+  const radius = Math.min(width, height) * 0.3;
+
+  jurisdictions.forEach((j, i) => {
+    const angle = (2 * Math.PI * i) / count - Math.PI / 2;
+    centroids[j] = {
+      x: cx + radius * Math.cos(angle),
+      y: cy + radius * Math.sin(angle),
+    };
+  });
+
+  return centroids;
+}
+
+export function useForceSimulation(
+  nodes: NetworkNode[],
+  edges: NetworkEdge[],
+  width: number,
+  height: number,
+) {
+  const simRef = useRef<Simulation<SimNode, SimEdge> | null>(null);
+  const [simNodes, setSimNodes] = useState<SimNode[]>([]);
+  const [simEdges, setSimEdges] = useState<SimEdge[]>([]);
+  const tickRef = useRef(0);
+
+  const updatePositions = useCallback(() => {
+    if (!simRef.current) return;
+    const currentNodes = simRef.current.nodes() as SimNode[];
+    // Only update state every 3 ticks for performance
+    tickRef.current++;
+    if (tickRef.current % 3 === 0 || tickRef.current < 10) {
+      setSimNodes([...currentNodes]);
+      setSimEdges([...(simRef.current.force('link') as ReturnType<typeof forceLink<SimNode, SimEdge>>).links()]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (nodes.length === 0 || width === 0 || height === 0) return;
+
+    // Build jurisdiction centroids
+    const jurisdictions = [...new Set(nodes.map((n) => n.jurisdiction))];
+    const centroids = getJurisdictionCentroids(jurisdictions, width, height);
+
+    // Create simulation nodes with initial positions near their jurisdiction centroid
+    const simNodeData: SimNode[] = nodes.map((n) => {
+      const centroid = centroids[n.jurisdiction] || { x: width / 2, y: height / 2 };
+      return {
+        ...n,
+        x: centroid.x + (Math.random() - 0.5) * 80,
+        y: centroid.y + (Math.random() - 0.5) * 80,
+        radius: Math.max(5, Math.min(12, 4 + n.tags.length)),
+      };
+    });
+
+    // Create simulation edges (referencing node objects)
+    const nodeMap = new Map(simNodeData.map((n) => [n.id, n]));
+    const simEdgeData: SimEdge[] = edges
+      .filter((e) => nodeMap.has(e.source) && nodeMap.has(e.target))
+      .map((e) => ({
+        source: nodeMap.get(e.source)!,
+        target: nodeMap.get(e.target)!,
+        weight: e.weight,
+        crossJurisdiction: e.crossJurisdiction,
+      }));
+
+    // Stop previous simulation
+    if (simRef.current) simRef.current.stop();
+
+    tickRef.current = 0;
+
+    const simulation = forceSimulation<SimNode>(simNodeData)
+      .force(
+        'link',
+        forceLink<SimNode, SimEdge>(simEdgeData)
+          .id((d) => d.id)
+          .distance(60)
+          .strength((d) => 0.1 * d.weight),
+      )
+      .force('charge', forceManyBody<SimNode>().strength(-120))
+      .force('collide', forceCollide<SimNode>().radius((d) => d.radius + 4))
+      // Cluster force: attract toward jurisdiction centroid
+      .force(
+        'x',
+        forceX<SimNode>()
+          .x((d) => centroids[d.jurisdiction]?.x ?? width / 2)
+          .strength(0.15),
+      )
+      .force(
+        'y',
+        forceY<SimNode>()
+          .y((d) => centroids[d.jurisdiction]?.y ?? height / 2)
+          .strength(0.15),
+      )
+      .on('tick', updatePositions)
+      .alphaDecay(0.02);
+
+    simRef.current = simulation;
+
+    // Final positions after simulation settles
+    return () => {
+      simulation.stop();
+    };
+  }, [nodes, edges, width, height, updatePositions]);
+
+  return { simNodes, simEdges, simulation: simRef };
+}

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -34,6 +34,14 @@ export async function analyseContentRelevance(
         role: 'user',
         content: `Analyse the following web content and determine if it's relevant to Australian AI policy, regulation, or governance.
 
+Only mark content as relevant when the page itself materially discusses AI or automated decision-making policy, regulation, standards, frameworks, guidance, assurance, safety, ethics, procurement, or government adoption.
+
+Do NOT mark content as relevant if it is primarily:
+- generic site navigation or landing-page content
+- privacy policies, accessibility statements, cookie notices, terms, or copyright pages
+- generic "mission", "commitments", or organisational strategy pages unless they explicitly govern AI
+- a general policy hub that is not specifically about AI policy/governance
+
 Source URL: ${sourceUrl}
 
 Content:

--- a/src/lib/data-service.ts
+++ b/src/lib/data-service.ts
@@ -151,6 +151,33 @@ export async function getPolicyById(id: string): Promise<Policy | null> {
   return policies.find((p) => p.id === id) || null;
 }
 
+export async function getPolicyBySourceUrl(sourceUrl: string): Promise<Policy | null> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = await getSupabase();
+      const { data, error } = await supabase
+        .from('policies')
+        .select('*')
+        .eq('sourceUrl', sourceUrl)
+        .maybeSingle();
+      if (!error && data) return data as Policy;
+      if (!error) return null;
+      console.warn('[data-service] Supabase getPolicyBySourceUrl failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase getPolicyBySourceUrl exception, falling back to JSON:', err);
+    }
+  }
+
+  const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
+  return policies.find((p) => p.sourceUrl === sourceUrl) || null;
+}
+
+function isSupabaseDuplicateError(message?: string): boolean {
+  if (!message) return false;
+  const normalized = message.toLowerCase();
+  return normalized.includes('duplicate key') || normalized.includes('unique constraint');
+}
+
 export async function createPolicy(policy: Policy): Promise<Policy> {
   if (isSupabaseConfigured) {
     try {
@@ -161,8 +188,14 @@ export async function createPolicy(policy: Policy): Promise<Policy> {
         .select()
         .single();
       if (!error && data) return data as Policy;
+      if (isSupabaseDuplicateError(error?.message)) {
+        throw new DuplicatePolicyError(policy.id);
+      }
       console.warn('[data-service] Supabase createPolicy failed, falling back to JSON:', error?.message);
     } catch (err) {
+      if (err instanceof DuplicatePolicyError) {
+        throw err;
+      }
       console.warn('[data-service] Supabase createPolicy exception, falling back to JSON:', err);
     }
   }
@@ -235,6 +268,11 @@ export async function deletePolicy(id: string): Promise<boolean> {
 /** Check if a policy with a given ID already exists. */
 export async function policyExists(id: string): Promise<boolean> {
   const policy = await getPolicyById(id);
+  return policy !== null;
+}
+
+export async function policyExistsBySourceUrl(sourceUrl: string): Promise<boolean> {
+  const policy = await getPolicyBySourceUrl(sourceUrl);
   return policy !== null;
 }
 

--- a/src/lib/scraper-filter.ts
+++ b/src/lib/scraper-filter.ts
@@ -76,7 +76,6 @@ const SUBSECTION_URL_PATTERNS = [
   /\/identifying-ai(?:\/|$)/i,
   /\/ai-guidance-and-tools(?:\/|$)/i,
   /\/ai-governance-assurance-and-frameworks(?:\/|$)/i,
-  /\/nsw-ai-assessment-framework(?:\/|$)/i,
 ];
 
 export function cleanScrapedLinkTitle(title: string): string {
@@ -100,6 +99,14 @@ function hasAiSignalInTitleOrUrl(title: string, url: string): boolean {
 
 function hasGovernanceSignal(text: string): boolean {
   return hasAnyKeyword(normalize(text), GOVERNANCE_KEYWORDS);
+}
+
+function isPdfUrl(url: string): boolean {
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith('.pdf');
+  } catch {
+    return /\.pdf(?:[?#].*)?$/i.test(url);
+  }
 }
 
 function isGenericPage(title: string, url: string): boolean {
@@ -135,7 +142,7 @@ export function isRelevantScrapedCandidate(link: ScrapedLinkLike): boolean {
     return false;
   }
 
-  return hasGovernanceSignal(context) || link.url.toLowerCase().endsWith('.pdf');
+  return hasGovernanceSignal(context) || isPdfUrl(link.url);
 }
 
 export function shouldCreatePolicyFromAnalysis(

--- a/src/lib/scraper-filter.ts
+++ b/src/lib/scraper-filter.ts
@@ -1,0 +1,169 @@
+import type { ContentAnalysis } from '@/lib/claude';
+
+interface ScrapedLinkLike {
+  url: string;
+  title: string;
+  text: string;
+}
+
+const AI_KEYWORDS = [
+  'artificial intelligence',
+  'generative ai',
+  'gen ai',
+  'machine learning',
+  'automated decision',
+  'algorithmic',
+  'ai ',
+  ' ai',
+];
+
+const GOVERNANCE_KEYWORDS = [
+  'policy',
+  'guidance',
+  'guideline',
+  'framework',
+  'standard',
+  'regulation',
+  'governance',
+  'ethic',
+  'safety',
+  'assurance',
+  'assessment',
+  'adoption',
+  'principle',
+  'plan',
+  'roadmap',
+  'statement',
+  'procurement',
+  'transparency',
+];
+
+const GENERIC_TITLE_PATTERNS = [
+  /^privacy policy$/i,
+  /^privacy$/i,
+  /^policy\s*(?:&|and)\s*guidelines?$/i,
+  /^commitments$/i,
+  /^mission\s+\d+[a-z]?\b/i,
+  /^terms(?: of use)?$/i,
+  /^accessibility$/i,
+  /^contact(?: us)?$/i,
+  /^cookies?$/i,
+  /^copyright$/i,
+  /^sitemap$/i,
+];
+
+const GENERIC_URL_PATTERNS = [
+  /\/privacy(?:-policy)?(?:\/|$)/i,
+  /\/cookies?(?:\/|$)/i,
+  /\/accessibility(?:\/|$)/i,
+  /\/terms(?:-of-use)?(?:\/|$)/i,
+  /\/contact(?:\/|$)/i,
+  /\/about\/policies?(?:\/|$)/i,
+  /\/policies\/privacy(?:\/|$)/i,
+];
+
+const HUB_TITLE_PATTERNS = [
+  /^learn about\b/i,
+  /^identifying\b/i,
+  /\band tools\b/i,
+  /\band frameworks?\b/i,
+  /\bresponsibilit(?:y|ies)\b/i,
+];
+
+const SUBSECTION_URL_PATTERNS = [
+  /\/node\/\d+(?:\/|$)/i,
+  /\/responsibilities(?:\/|$)/i,
+  /\/identifying-ai(?:\/|$)/i,
+  /\/ai-guidance-and-tools(?:\/|$)/i,
+  /\/ai-governance-assurance-and-frameworks(?:\/|$)/i,
+  /\/nsw-ai-assessment-framework(?:\/|$)/i,
+];
+
+export function cleanScrapedLinkTitle(title: string): string {
+  return title
+    .replace(/(?:\s+|_)?(?:north_?east|north_?west|south_?east|south_?west|east|west|north|south)$/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalize(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function hasAnyKeyword(text: string, keywords: string[]): boolean {
+  return keywords.some((keyword) => text.includes(keyword));
+}
+
+function hasAiSignalInTitleOrUrl(title: string, url: string): boolean {
+  return hasAnyKeyword(normalize(`${title} ${url}`), AI_KEYWORDS);
+}
+
+function hasGovernanceSignal(text: string): boolean {
+  return hasAnyKeyword(normalize(text), GOVERNANCE_KEYWORDS);
+}
+
+function isGenericPage(title: string, url: string): boolean {
+  return (
+    GENERIC_TITLE_PATTERNS.some((pattern) => pattern.test(title.trim())) ||
+    GENERIC_URL_PATTERNS.some((pattern) => pattern.test(url))
+  );
+}
+
+function isStrongDocumentCandidate(link: ScrapedLinkLike): boolean {
+  const normalizedTitle = normalize(link.title);
+
+  if (HUB_TITLE_PATTERNS.some((pattern) => pattern.test(normalizedTitle))) {
+    return false;
+  }
+
+  if (SUBSECTION_URL_PATTERNS.some((pattern) => pattern.test(link.url))) {
+    return false;
+  }
+
+  return hasGovernanceSignal(`${link.title} ${link.url}`);
+}
+
+export function isRelevantScrapedCandidate(link: ScrapedLinkLike): boolean {
+  const context = `${link.title} ${link.url} ${link.text}`;
+  const titleOrUrlHasAiSignal = hasAiSignalInTitleOrUrl(link.title, link.url);
+
+  if (isGenericPage(link.title, link.url) && !titleOrUrlHasAiSignal) {
+    return false;
+  }
+
+  if (!titleOrUrlHasAiSignal) {
+    return false;
+  }
+
+  return hasGovernanceSignal(context) || link.url.toLowerCase().endsWith('.pdf');
+}
+
+export function shouldCreatePolicyFromAnalysis(
+  link: ScrapedLinkLike,
+  analysis: ContentAnalysis,
+): boolean {
+  if (!analysis.isRelevant || analysis.relevanceScore < 0.8 || !isStrongDocumentCandidate(link)) {
+    return false;
+  }
+
+  const analysisContext = normalize(
+    `${analysis.summary} ${analysis.tags.join(' ')} ${analysis.relatedTopics.join(' ')}`,
+  );
+
+  return hasAiSignalInTitleOrUrl(link.title, link.url) || hasAnyKeyword(analysisContext, AI_KEYWORDS);
+}
+
+export function shouldQueuePolicyForReview(
+  link: ScrapedLinkLike,
+  analysis: ContentAnalysis,
+): boolean {
+  if (!analysis.isRelevant || analysis.relevanceScore < 0.5) {
+    return false;
+  }
+
+  const analysisContext = normalize(
+    `${analysis.summary} ${analysis.tags.join(' ')} ${analysis.relatedTopics.join(' ')}`,
+  );
+
+  return hasAiSignalInTitleOrUrl(link.title, link.url) || hasAnyKeyword(analysisContext, AI_KEYWORDS);
+}


### PR DESCRIPTION
## Summary
- add `force-dynamic` to cron handlers and tighten production cron execution behavior
- harden scraper relevance filtering, title cleanup, and duplicate handling to reduce noisy policy creation
- update AI relevance guidance and data-service helpers used by scraper workflows
- refresh the network page and supporting graph components, toolbar, sidebar, and simulation logic
- include related content and spec updates for the DTA guidance post and network redesign

## Testing
- `npm run lint -- src/lib/scraper-filter.ts src/app/api/cron/scrape/route.ts src/app/api/admin/run-scraper/route.ts src/lib/data-service.ts src/lib/claude.ts`
- `npm run build`
- manually triggered production cron runs to verify authenticated execution and filtered NSW scrape output