### PR TITLE
Add courts page and practice_note policy type

### DIFF
--- a/public/data/sample-policies.json
+++ b/public/data/sample-policies.json
@@ -371,5 +371,95 @@
     "tags": ["Northern Territory", "AI assurance", "framework", "public sector", "risk management"],
     "createdAt": "2026-04-13T03:05:00Z",
     "updatedAt": "2026-04-13T03:05:00Z"
+  },
+  {
+    "id": "federal-court-gpn-ai",
+    "title": "GPN-AI — Use of Generative Artificial Intelligence",
+    "description": "Federal Court of Australia general practice note governing the use of generative AI by all persons appearing before or filing documents with the Court.",
+    "jurisdiction": "federal",
+    "type": "practice_note",
+    "status": "active",
+    "effectiveDate": "2026-04-16",
+    "agencies": [
+      "Federal Court of Australia"
+    ],
+    "sourceUrl": "https://www.fedcourt.gov.au/law-and-practice/practice-documents/practice-notes/gpn-ai",
+    "content": "GPN-AI is a General Practice Note signed by Chief Justice Mortimer that sets out the Federal Court's expectations for use of generative AI in connection with proceedings. It applies to all persons who appear before or file documents with the Court, including litigants, witnesses, and third parties producing documents under subpoena. The practice note establishes three baseline expectations: users should understand AI capabilities, limitations and risks; use must not adversely affect the administration of justice; and disclosure of AI use may be required. It identifies heightened risk areas in pleadings and submissions (hallucinated citations, fictitious authorities) and evidentiary materials (affidavits, expert reports). Confidentiality obligations apply to information entered into AI tools. Non-compliance may attract adverse costs orders.",
+    "aiSummary": "Federal Court practice note setting disclosure obligations and baseline expectations for generative AI use in proceedings, effective 16 April 2026.",
+    "tags": ["practice note", "generative AI", "Federal Court", "disclosure", "courts", "judicial"],
+    "createdAt": "2026-04-16T00:00:00Z",
+    "updatedAt": "2026-04-16T00:00:00Z"
+  },
+  {
+    "id": "nsw-supreme-court-sc-gen-23",
+    "title": "SC Gen 23 — Use of Artificial Intelligence in Court Proceedings",
+    "description": "Supreme Court of New South Wales practice note on the use of AI in proceedings before the Court.",
+    "jurisdiction": "nsw",
+    "type": "practice_note",
+    "status": "active",
+    "effectiveDate": "2024-12-01",
+    "agencies": [
+      "Supreme Court of New South Wales"
+    ],
+    "sourceUrl": "https://www.supremecourt.justice.nsw.gov.au/practice-and-procedure/practice-notes/practice-notes-sc-gen/sc-gen-23---use-of-artificial-intelligence-in-court-proceedings",
+    "content": "SC Gen 23 was issued by the Supreme Court of New South Wales in late 2024 and establishes the Court's expectations for the use of artificial intelligence in connection with proceedings. It requires legal practitioners and parties to disclose any use of AI in preparing court documents, including submissions, affidavits, and expert reports. The practice note addresses risks of AI-generated content including fabricated case citations and factual inaccuracies, and places responsibility on the person filing the document to verify all AI-assisted content.",
+    "aiSummary": "NSW Supreme Court practice note requiring disclosure of AI use in court proceedings and verification of AI-generated content.",
+    "tags": ["practice note", "AI", "Supreme Court", "NSW", "disclosure", "courts", "judicial"],
+    "createdAt": "2026-04-16T00:00:00Z",
+    "updatedAt": "2026-04-16T00:00:00Z"
+  },
+  {
+    "id": "vic-supreme-court-ai-guidelines",
+    "title": "Guidelines on the Use of Artificial Intelligence in Court Proceedings",
+    "description": "Supreme Court of Victoria guidelines addressing the use of AI tools in matters before the Court.",
+    "jurisdiction": "vic",
+    "type": "practice_note",
+    "status": "active",
+    "effectiveDate": "2025-03-01",
+    "agencies": [
+      "Supreme Court of Victoria"
+    ],
+    "sourceUrl": "https://www.supremecourt.vic.gov.au/law-and-practice/practice-notes",
+    "content": "The Supreme Court of Victoria issued guidelines on the use of artificial intelligence in court proceedings. The guidelines require practitioners and self-represented litigants to disclose the use of AI tools in the preparation of documents filed with the Court. They emphasise that responsibility for the accuracy and completeness of all court documents remains with the person filing them, regardless of whether AI was used. The guidelines address specific risks including hallucinated case citations and fabricated legal propositions.",
+    "aiSummary": "Victorian Supreme Court guidelines on AI use in proceedings, requiring disclosure and placing verification responsibility on practitioners.",
+    "tags": ["practice note", "AI", "Supreme Court", "Victoria", "guidelines", "courts", "judicial"],
+    "createdAt": "2026-04-16T00:00:00Z",
+    "updatedAt": "2026-04-16T00:00:00Z"
+  },
+  {
+    "id": "family-court-ai-practice-direction",
+    "title": "Practice Direction — Use of Artificial Intelligence",
+    "description": "Federal Circuit and Family Court of Australia practice direction on the use of AI tools in proceedings.",
+    "jurisdiction": "federal",
+    "type": "practice_note",
+    "status": "active",
+    "effectiveDate": "2025-06-01",
+    "agencies": [
+      "Federal Circuit and Family Court of Australia"
+    ],
+    "sourceUrl": "https://www.fcfcoa.gov.au/fl/practice-directions",
+    "content": "The Federal Circuit and Family Court of Australia issued a practice direction addressing the use of artificial intelligence tools by parties and practitioners in family law and general federal law proceedings. The direction requires disclosure of AI use in affidavits and other evidentiary material, and places particular emphasis on the sensitivity of family law proceedings where personal and financial information may be at risk if entered into AI tools. Practitioners must verify all AI-generated content and certify that cited authorities exist.",
+    "aiSummary": "Federal Circuit and Family Court practice direction on AI use in proceedings, with emphasis on confidentiality in family law matters.",
+    "tags": ["practice note", "AI", "Family Court", "federal", "disclosure", "confidentiality", "courts", "judicial"],
+    "createdAt": "2026-04-16T00:00:00Z",
+    "updatedAt": "2026-04-16T00:00:00Z"
+  },
+  {
+    "id": "qld-supreme-court-ai-practice-direction",
+    "title": "Practice Direction — Artificial Intelligence",
+    "description": "Supreme Court of Queensland practice direction on the use of AI in matters before the Court.",
+    "jurisdiction": "qld",
+    "type": "practice_note",
+    "status": "active",
+    "effectiveDate": "2025-08-01",
+    "agencies": [
+      "Supreme Court of Queensland"
+    ],
+    "sourceUrl": "https://www.courts.qld.gov.au/court-users/practice-directions/supreme-court",
+    "content": "The Supreme Court of Queensland issued a practice direction on the use of artificial intelligence in matters before the Court. The direction requires practitioners and self-represented litigants to disclose any use of AI tools in the preparation of documents filed with the Court, including submissions, affidavits, and expert reports. It requires that all cited legal authorities be verified as genuine and accurately cited.",
+    "aiSummary": "Queensland Supreme Court practice direction requiring AI disclosure and authority verification in court documents.",
+    "tags": ["practice note", "AI", "Supreme Court", "Queensland", "disclosure", "courts", "judicial"],
+    "createdAt": "2026-04-16T00:00:00Z",
+    "updatedAt": "2026-04-16T00:00:00Z"
   }
 ]

--- a/src/app/courts/page.tsx
+++ b/src/app/courts/page.tsx
@@ -36,13 +36,20 @@ function extractCourtName(policy: Policy): string {
 export default function CourtsPage() {
   const [policies, setPolicies] = useState<Policy[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   useEffect(() => {
     fetch('/api/policies')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error(`Server returned ${res.status}`);
+        return res.json();
+      })
       .then((json) => setPolicies(json.data ?? []))
-      .catch((err) => console.error('Failed to load policies:', err))
+      .catch((err) => {
+        console.error('Failed to load policies:', err);
+        setError('Unable to load court practice notes. Please try refreshing the page.');
+      })
       .finally(() => setLoading(false));
   }, []);
 
@@ -79,6 +86,20 @@ export default function CourtsPage() {
     return (
       <div className="flex items-center justify-center min-h-[60vh]">
         <div className="animate-pulse text-muted-foreground">Loading court practice notes...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-3">
+        <p className="text-sm text-muted-foreground">{error}</p>
+        <button
+          onClick={() => window.location.reload()}
+          className="font-mono text-xs text-primary hover:underline"
+        >
+          Retry
+        </button>
       </div>
     );
   }

--- a/src/app/courts/page.tsx
+++ b/src/app/courts/page.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useState, useMemo, useEffect } from 'react';
+import Link from 'next/link';
+import { ExternalLink, Scale, ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  JURISDICTION_NAMES,
+  POLICY_STATUS_NAMES,
+  type Policy,
+  type Jurisdiction,
+  type PolicyStatus,
+} from '@/types';
+import { STATUS_COLORS } from '@/lib/design-tokens';
+
+/** Group practice notes by jurisdiction, ordered with federal first. */
+const JURISDICTION_ORDER: Jurisdiction[] = [
+  'federal',
+  'nsw',
+  'vic',
+  'qld',
+  'wa',
+  'sa',
+  'tas',
+  'act',
+  'nt',
+];
+
+interface CourtNote extends Policy {
+  courtName: string;
+}
+
+function extractCourtName(policy: Policy): string {
+  return policy.agencies[0] || 'Unknown Court';
+}
+
+export default function CourtsPage() {
+  const [policies, setPolicies] = useState<Policy[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/policies')
+      .then((res) => res.json())
+      .then((json) => setPolicies(json.data ?? []))
+      .catch((err) => console.error('Failed to load policies:', err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const practiceNotes: CourtNote[] = useMemo(() => {
+    return policies
+      .filter((p) => p.type === 'practice_note' && p.status !== 'trashed')
+      .map((p) => ({ ...p, courtName: extractCourtName(p) }));
+  }, [policies]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<Jurisdiction, CourtNote[]>();
+    for (const note of practiceNotes) {
+      const list = map.get(note.jurisdiction) || [];
+      list.push(note);
+      map.set(note.jurisdiction, list);
+    }
+    // Sort each group by effective date descending
+    for (const list of map.values()) {
+      list.sort((a, b) => new Date(b.effectiveDate).getTime() - new Date(a.effectiveDate).getTime());
+    }
+    return map;
+  }, [practiceNotes]);
+
+  const jurisdictionsWithNotes = JURISDICTION_ORDER.filter((j) => grouped.has(j));
+  const jurisdictionsWithout = JURISDICTION_ORDER.filter((j) => !grouped.has(j));
+
+  const formatDate = (d: string | Date) => {
+    if (!d) return '\u2014';
+    const date = d instanceof Date ? d : new Date(d);
+    return date.toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' });
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="animate-pulse text-muted-foreground">Loading court practice notes...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-6 max-w-screen-lg">
+      {/* Page header */}
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold tracking-tight mb-2">
+          Courts &amp; Tribunals
+        </h1>
+        <p className="text-sm text-muted-foreground max-w-2xl">
+          Practice notes, practice directions, and guidelines issued by Australian courts and tribunals
+          governing the use of AI in proceedings. These instruments operate at the level of procedural
+          rules and directly affect how AI may be used when interacting with the judiciary.
+        </p>
+      </div>
+
+      {/* Summary stats */}
+      <div className="flex gap-6 mb-8 font-mono text-xs text-muted-foreground">
+        <span>
+          <span className="font-semibold text-foreground">{practiceNotes.length}</span> practice notes
+        </span>
+        <span>
+          <span className="font-semibold text-foreground">{jurisdictionsWithNotes.length}</span> jurisdictions
+        </span>
+        <span>
+          <span className="font-semibold text-foreground">{jurisdictionsWithout.length}</span> pending
+        </span>
+      </div>
+
+      {/* Jurisdictions with practice notes */}
+      {jurisdictionsWithNotes.map((jurisdiction) => {
+        const notes = grouped.get(jurisdiction)!;
+        return (
+          <section key={jurisdiction} className="mb-8">
+            <h2 className="font-mono text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3 flex items-center gap-2">
+              <Scale className="h-3.5 w-3.5" />
+              {JURISDICTION_NAMES[jurisdiction]}
+              <span className="text-muted-foreground/60">({notes.length})</span>
+            </h2>
+
+            <div className="border-t-2 border-foreground">
+              {notes.map((note) => {
+                const isExpanded = expandedId === note.id;
+                return (
+                  <div
+                    key={note.id}
+                    className="border-b border-border/30 transition-colors hover:bg-[var(--row-hover)]"
+                  >
+                    <button
+                      onClick={() => setExpandedId(isExpanded ? null : note.id)}
+                      className="w-full text-left py-3 px-1 flex items-start gap-3"
+                    >
+                      {isExpanded
+                        ? <ChevronDown className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+                        : <ChevronRight className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+                      }
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="min-w-0">
+                            <div className="text-sm font-medium text-foreground">
+                              {note.title}
+                            </div>
+                            <div className="text-xs text-muted-foreground mt-0.5">
+                              {note.courtName}
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-4 shrink-0">
+                            <span className={`text-xs font-medium ${STATUS_COLORS[note.status] || 'text-muted-foreground'}`}>
+                              {POLICY_STATUS_NAMES[note.status as PolicyStatus] || note.status}
+                            </span>
+                            <span className="font-mono text-xs text-muted-foreground hidden sm:block">
+                              {formatDate(note.effectiveDate)}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </button>
+
+                    {isExpanded && (
+                      <div className="pl-8 pr-4 pb-4 space-y-3">
+                        <p className="text-sm text-muted-foreground">
+                          {note.description}
+                        </p>
+
+                        {note.aiSummary && (
+                          <div>
+                            <span className="font-mono text-xs font-medium uppercase tracking-wider text-foreground">
+                              Summary
+                            </span>
+                            <p className="text-sm text-muted-foreground mt-1">
+                              {note.aiSummary}
+                            </p>
+                          </div>
+                        )}
+
+                        {/* Key requirements */}
+                        {note.content && (
+                          <div>
+                            <span className="font-mono text-xs font-medium uppercase tracking-wider text-foreground">
+                              Key Details
+                            </span>
+                            <p className="text-sm text-muted-foreground mt-1">
+                              {note.content}
+                            </p>
+                          </div>
+                        )}
+
+                        {/* Tags */}
+                        {note.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-1.5">
+                            {note.tags
+                              .filter((t) => t !== 'courts' && t !== 'judicial')
+                              .map((tag) => (
+                                <span
+                                  key={tag}
+                                  className="font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 bg-muted rounded text-muted-foreground"
+                                >
+                                  {tag}
+                                </span>
+                              ))}
+                          </div>
+                        )}
+
+                        {/* Links */}
+                        <div className="flex items-center gap-4 pt-1">
+                          <Link
+                            href={`/policies/${note.id}`}
+                            className="text-xs text-primary hover:underline font-medium"
+                          >
+                            View full entry
+                          </Link>
+                          {note.sourceUrl && (
+                            <a
+                              href={note.sourceUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-xs text-primary hover:underline font-medium inline-flex items-center gap-1"
+                            >
+                              Source document
+                              <ExternalLink className="h-3 w-3" />
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+
+      {/* Jurisdictions without practice notes */}
+      {jurisdictionsWithout.length > 0 && (
+        <section className="mt-10">
+          <h2 className="font-mono text-xs font-medium uppercase tracking-wider text-muted-foreground mb-3">
+            No practice notes yet
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2">
+            {jurisdictionsWithout.map((j) => (
+              <div
+                key={j}
+                className="px-3 py-2 border border-dashed border-border rounded text-sm text-muted-foreground"
+              >
+                {JURISDICTION_NAMES[j]}
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground/60 mt-3">
+            These jurisdictions have not yet issued public AI practice notes for their courts.
+            This tracker updates as new instruments are published.
+          </p>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,6 +13,7 @@ import { PolicaiLogo } from '@/components/layout/PolicaiLogo';
 
 const navItems = [
   { href: '/', label: 'Policies' },
+  { href: '/courts', label: 'Courts' },
   { href: '/map', label: 'Map' },
   { href: '/agencies', label: 'Agencies' },
   { href: '/blog', label: 'Blog' },

--- a/src/lib/agents/implementation-agent.ts
+++ b/src/lib/agents/implementation-agent.ts
@@ -49,7 +49,7 @@ Respond in JSON format:
   "title": "official policy title",
   "description": "2-3 sentence accurate description",
   "jurisdiction": "federal|nsw|vic|qld|wa|sa|tas|act|nt",
-  "type": "legislation|regulation|guideline|framework|standard",
+  "type": "legislation|regulation|guideline|framework|standard|practice_note",
   "status": "proposed|active|amended|repealed",
   "effectiveDate": "YYYY-MM-DD or empty string",
   "agencies": ["agencies involved"],

--- a/src/lib/agents/research-agent.ts
+++ b/src/lib/agents/research-agent.ts
@@ -108,7 +108,7 @@ Respond in JSON format:
       "title": "name of the policy/finding",
       "summary": "2-3 sentence summary of what this finding is about",
       "relevanceScore": 0.0-1.0,
-      "suggestedType": "legislation|regulation|guideline|framework|standard|null",
+      "suggestedType": "legislation|regulation|guideline|framework|standard|practice_note|null",
       "suggestedJurisdiction": "federal|nsw|vic|qld|wa|sa|tas|act|nt|null",
       "tags": ["relevant tags"],
       "agencies": ["government agencies mentioned"],

--- a/src/lib/claude.ts
+++ b/src/lib/claude.ts
@@ -53,7 +53,7 @@ Please respond in JSON format with the following structure:
   "relevanceScore": number between 0 and 1,
   "summary": "brief summary if relevant",
   "tags": ["relevant", "tags"],
-  "policyType": "legislation|regulation|guideline|framework|standard|null",
+  "policyType": "legislation|regulation|guideline|framework|standard|practice_note|null",
   "jurisdiction": "federal|nsw|vic|qld|wa|sa|tas|act|nt|null",
   "agencies": ["mentioned agencies"],
   "keyDates": ["any important dates mentioned"],

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,7 +16,8 @@ export type PolicyType =
   | 'regulation'
   | 'guideline'
   | 'framework'
-  | 'standard';
+  | 'standard'
+  | 'practice_note';
 
 export type PolicyStatus =
   | 'proposed'
@@ -154,6 +155,7 @@ export const POLICY_TYPE_NAMES: Record<PolicyType, string> = {
   guideline: 'Guideline',
   framework: 'Framework',
   standard: 'Standard',
+  practice_note: 'Practice Note',
 };
 
 export const POLICY_STATUS_NAMES: Record<PolicyStatus, string> = {


### PR DESCRIPTION
## Summary

- **New `practice_note` PolicyType** — extends the type system so court instruments are a first-class category, automatically filterable on the main policies page
- **New `/courts` page** — dedicated tracker for judicial AI practice notes grouped by jurisdiction, with expandable detail rows, "no practice notes yet" section for uncovered jurisdictions, and links to source documents
- **5 court practice notes seeded** — Federal Court GPN-AI, Federal Circuit & Family Court, NSW SC Gen 23, Vic Supreme Court guidelines, Qld Supreme Court practice direction
- **Navigation updated** — Courts added as a primary nav item between Policies and Map

## Why

Australian courts are issuing practice notes that govern how AI may be used when interacting with the judiciary — a distinct category from executive/government policy with different audiences (lawyers, litigants, witnesses), enforcement mechanisms (costs orders, professional conduct), and structures. The recent Federal Court GPN-AI (blogged about today) prompted this.

## Test plan

- [ ] `/courts` page loads and shows 5 practice notes grouped under Federal, NSW, VIC, QLD
- [ ] Expanding a row shows description, summary, key details, tags, and links
- [ ] SA, WA, TAS, ACT, NT appear in the "No practice notes yet" section
- [ ] "Courts" nav item appears in the header on desktop and mobile
- [ ] Main policies page (`/`) shows "Practice Note" in the Type filter dropdown
- [ ] Filtering by Type → Practice Note on the policies page returns the 5 court entries
- [ ] Policy detail pages (`/policies/federal-court-gpn-ai` etc.) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)