### PR TITLE
Add seed script for practice notes and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Added a dedicated `/courts` page tracking judicial AI practice notes and practice directions across Australian jurisdictions.
+- Added `practice_note` as a new policy type so court instruments are a first-class category alongside legislation, guidelines, frameworks, and standards.
+- Seeded five court practice notes: Federal Court GPN-AI, Federal Circuit & Family Court practice direction, NSW SC Gen 23, Vic Supreme Court guidelines, and Qld Supreme Court practice direction.
+- Added Courts to the primary navigation bar.
+- Integrated Vercel Web Analytics into the root Next.js application layout.
+- Added a D3 force-directed network page for exploring policy relationships.
+- Added dynamic `sitemap.xml` and `robots.txt` generation.
+- Added robust deduplication across the research pipeline.
+- Added automatic timeline generation from policy records and agency transparency discovery.
+- Added a new blog post covering DTA's AI PoC to Scale guidance.
+- Added a new blog post explaining how Policai updates itself automatically.
+
+### Changed
+
+- Simplified the map page back to a single Australia-focused view while the APAC tracker remains on hold.
+- Updated the site disclaimer to emphasise that Policai is a work in progress and that all information should be independently verified.
+- Sorted policies by date and surfaced the most recent research run in the interface.
+- Continued open source preparation with repository cleanup and contribution-focused documentation.
+
+### Fixed
+
+- Improved blog prose readability in dark mode.
+
+### Removed
+
+- Removed the admin login page and admin dashboard UI from the public application shell.
+- Removed client-side admin authentication wrappers and navigation links tied to the deleted admin surface.
+
+### Security
+
+- Added authentication to previously unprotected API endpoints.
+- Addressed P1 security issues in the application and admin surface.
+
+## [0.1.0] - 2026-04-12
+
+### Added
+
+- Initial public release of Policai as an Australian AI policy and governance tracker.
+- Searchable policy browsing, jurisdiction views, agencies directory, timeline views, and interactive visualizations.
+- Admin tooling for review, source management, pipeline operations, and scraper-driven content intake.
+- AI-assisted policy discovery, verification, summarization, and implementation workflows.
+- MDX blog support with listing and detail pages.
+- Hybrid data model with JSON-backed content and optional Supabase integration.
+
+### Changed
+
+- Established the IBM Plex visual system, streamlined navigation, and broader UI normalization across the public site.
+- Expanded automation around policy discovery, scraping, and data refresh workflows.
+
+[Unreleased]: https://github.com/l0cka/policai/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/l0cka/policai/releases/tag/v0.1.0

--- a/scripts/seed-practice-notes.ts
+++ b/scripts/seed-practice-notes.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env tsx
+/**
+ * Seed court practice notes into Supabase.
+ *
+ * Reads the practice_note entries from sample-policies.json and upserts them
+ * into the Supabase policies table. Safe to run multiple times — existing
+ * rows are updated rather than duplicated.
+ *
+ * Usage:
+ *   tsx scripts/seed-practice-notes.ts
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+interface PolicyRow {
+  id: string;
+  title: string;
+  description: string;
+  jurisdiction: string;
+  type: string;
+  status: string;
+  effectiveDate: string;
+  agencies: string[];
+  sourceUrl: string;
+  content: string;
+  aiSummary: string;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+async function main() {
+  const filePath = path.join(process.cwd(), 'public', 'data', 'sample-policies.json');
+  const allPolicies: PolicyRow[] = JSON.parse(readFileSync(filePath, 'utf-8'));
+
+  const practiceNotes = allPolicies.filter((p) => p.type === 'practice_note');
+
+  if (practiceNotes.length === 0) {
+    console.log('No practice notes found in sample-policies.json');
+    return;
+  }
+
+  console.log(`Found ${practiceNotes.length} practice notes to seed...`);
+
+  for (const note of practiceNotes) {
+    const { data, error } = await supabase
+      .from('policies')
+      .upsert(note, { onConflict: 'id' })
+      .select()
+      .single();
+
+    if (error) {
+      console.error(`  FAIL: ${note.title} — ${error.message}`);
+    } else {
+      console.log(`  OK: ${data.title}`);
+    }
+  }
+
+  console.log('Done.');
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Follow-up to #61 — the courts page showed 0 results because the practice notes were only in the JSON fallback file, not in Supabase (the primary data source).

- **Seed script** (`scripts/seed-practice-notes.ts`) — reads `practice_note` entries from `sample-policies.json` and upserts them into Supabase. Safe to run repeatedly. Already executed against the live database — all 5 practice notes are now in Supabase.
- **Changelog** — added the courts page, `practice_note` type, and seeded data to the `[Unreleased]` section.

## Test plan

- [ ] `/courts` page now shows 5 practice notes grouped under Federal, NSW, VIC, QLD
- [ ] `tsx scripts/seed-practice-notes.ts` runs idempotently (re-running doesn't duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)