### PR TITLE
Fix Supabase RLS migration and admin access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ OPENROUTER_API_KEY=
 # Supabase (optional - falls back to JSON files in public/data/)
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+# Server-only. Required for admin/cron writes when Supabase RLS is enabled.
+# Never expose this in client code or prefix it with NEXT_PUBLIC_.
+SUPABASE_SERVICE_ROLE_KEY=
 
 # Vercel Cron Jobs authentication
 CRON_SECRET=

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ cp .env.example .env.local
 
 The app works without any keys by falling back to JSON files in `public/data/`. See `.env.example` for all available variables.
 
+For Supabase-backed deployments, run the RLS migration and configure the server-only `SUPABASE_SERVICE_ROLE_KEY` so protected admin and cron routes can write while the public anon key remains read-only. See [Supabase RLS setup](./docs/supabase-rls.md).
+
 ## Commands
 
 ```bash
@@ -83,6 +85,7 @@ This keeps local development simple while allowing production deployments to use
 
 - [Documentation index](./docs/README.md)
 - [Scraper operations guide](./docs/scraper.md)
+- [Supabase RLS setup](./docs/supabase-rls.md)
 - [Scripts overview](./scripts/README.md)
 - [Agent instructions](./AGENTS.md)
 

--- a/content/blog/how-policai-updates-itself.mdx
+++ b/content/blog/how-policai-updates-itself.mdx
@@ -1,0 +1,121 @@
+---
+title: "How Policai Updates Itself"
+date: "2026-04-13"
+description: "A look at the automated discovery, verification, and update pipeline that keeps Policai current — and where human review still matters."
+---
+
+One of the core goals behind Policai is that it should not depend on somebody manually refreshing a spreadsheet every time an Australian government department publishes a new AI-related policy document.
+
+So how does the site update itself?
+
+The short answer is: Policai runs an automated discovery and review pipeline that scans known government sources, extracts likely AI policy material, verifies it, and then pushes approved changes into the public dataset.
+
+The more accurate answer is: it is automated, but not blindly automated. That distinction matters.
+
+## The update loop
+
+Policai currently has two main update mechanisms working together.
+
+### 1. Scheduled source scraping
+
+The first layer is a scheduled scraper runner. Policai maintains a set of tracked government sources — such as DTA, DISER, CSIRO Data61, OAIC, NSW Digital, and other relevant policy pages — each with its own run frequency.
+
+The scraper runner checks whether each source is due to run based on its schedule:
+
+- daily
+- weekly
+- monthly
+
+When a source is due, Policai calls the scraper endpoint, fetches the source page, extracts likely policy and document links, and then fetches the underlying content.
+
+This is the system that handles repeat monitoring of known sources.
+
+### 2. The AI review pipeline
+
+The second layer is a broader research and verification pipeline. This is the part that makes Policai more than a simple scraper.
+
+That pipeline runs in stages:
+
+1. **Research**
+   Policai scans configured sources, fetches pages, and uses AI analysis to identify potential policy findings.
+
+2. **Discovery**
+   It can also look for newly discovered `.gov.au` pages so the tracker is not limited only to a static list of known URLs.
+
+3. **Verification**
+   Findings are cross-checked by a verifier agent, which looks at source support, extracted metadata, corroborating evidence, and overall confidence.
+
+4. **Implementation**
+   Verified findings can be turned into policy entries or used to update existing records in the policy database.
+
+The result is a pipeline that does not just scrape links — it tries to reason about whether a page actually contains a meaningful AI policy development.
+
+## What happens when a new page is found
+
+When Policai encounters a promising document or page, it does not immediately treat it as a trustworthy policy record.
+
+Instead, it processes the content in steps:
+
+- fetch the page content
+- clean and extract readable text
+- analyse relevance and likely policy type
+- infer metadata such as jurisdiction, agencies, and dates
+- check for duplicates or likely overlaps with existing records
+- either create a new record, update an existing one, or hold the finding for review
+
+There is also threshold logic involved. High-confidence findings can move forward automatically, while medium-confidence findings are routed into a review flow instead of being published straight away.
+
+## Why it is not fully automatic
+
+It would be easy to say that Policai "automatically updates itself" and leave it there. But that would flatten an important part of how the system actually works.
+
+Some parts are automatic:
+
+- source monitoring
+- page fetching
+- link extraction
+- AI-assisted analysis
+- deduplication
+- verification scoring
+- policy record generation
+
+But the system is deliberately designed to pause for human review at key points.
+
+That is because policy tracking is not just a technical ingestion problem. Government documents are often ambiguous, spread across multiple pages, updated quietly, or written in a way that makes classification non-trivial. A fully automated pipeline that never stops to check itself would be faster, but it would also be much more likely to introduce bad records.
+
+So Policai is built as an automation-first system with review checkpoints, not as a fully autonomous publishing robot.
+
+## What gets stored
+
+Once approved, findings are turned into structured policy entries with fields such as:
+
+- title
+- description
+- jurisdiction
+- policy type
+- status
+- effective date
+- agencies
+- source URL
+- tags
+- AI summary
+
+Depending on deployment configuration, that data can be written through the app's data layer to the current backing store used by the site.
+
+## Why this matters
+
+Australian AI policy is fragmented across jurisdictions, agencies, consultations, frameworks, standards, and technical guidance. The real challenge is not just reading documents once they are known. It is discovering them consistently, checking whether they matter, and integrating them into a public tracker without creating noise.
+
+That is the problem Policai is trying to solve.
+
+The automation layer reduces the amount of repetitive monitoring work. The verification and review layers reduce the chance that the tracker drifts into low-quality or misleading coverage. Together, they make it possible for the site to stay current without depending entirely on manual upkeep.
+
+## In plain English
+
+If you want the non-technical version:
+
+Policai keeps itself updated by regularly scanning government sources, using AI to identify relevant policy developments, checking what it finds, and then turning approved findings into structured records on the site.
+
+It updates itself — but with guardrails.
+
+That is the real design principle.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory holds the project-facing documentation that should stay in sync w
 ## Available Docs
 
 - [Scraper operations guide](./scraper.md) — setup, local runs, automation, data files, and troubleshooting for the policy scraper.
+- [Supabase RLS setup](./supabase-rls.md) — row-level security model, required environment variables, and migration instructions.
 
 ## Canonical Sources
 

--- a/docs/supabase-rls.md
+++ b/docs/supabase-rls.md
@@ -1,0 +1,73 @@
+# Supabase RLS Setup
+
+This document records the RLS model for Policai's Supabase-backed deployment.
+
+## Audit Summary
+
+Policai stores public catalog data and operational admin data in the `public` schema:
+
+| Table | Data classification | Public Data API access |
+| --- | --- | --- |
+| `policies` | Published public catalog data, with `trashed` rows treated as non-public | `SELECT` for `anon` and `authenticated` only when `status in ('proposed', 'active', 'amended', 'repealed')` |
+| `news_items` | Published public catalog data | `SELECT` for `anon` and `authenticated` |
+| `timeline_events` | Published public catalog data | `SELECT` for `anon` and `authenticated` |
+| `agencies` | Public-facing agency fields plus possible sensitive/admin fields such as contacts, accountable officials, and audit notes | No direct `anon` or `authenticated` table access; public API responses are served by Next.js and strip sensitive agency fields |
+| `scraper_runs` | Operational logs | No direct `anon` or `authenticated` table access |
+| `pipeline_runs` | Admin workflow state | No direct `anon` or `authenticated` table access |
+| `research_findings` | AI-discovered source content and review state | No direct `anon` or `authenticated` table access |
+| `verification_results` | AI verification notes and factual issues | No direct `anon` or `authenticated` table access |
+
+The public app reads policy data through `/api/policies` and can also read published rows directly through the Supabase Data API with the anon key. Admin and cron writes go through authenticated Next.js routes and use a server-only service-role client.
+
+## Environment
+
+Production Supabase deployments need:
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=...
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+SUPABASE_SERVICE_ROLE_KEY=...
+```
+
+`SUPABASE_SERVICE_ROLE_KEY` must be configured only in server environments, such as Vercel project environment variables. Do not add it to browser code and do not prefix it with `NEXT_PUBLIC_`.
+
+## SQL to Run
+
+Run the migration in `supabase/migrations/002_enable_rls.sql` in the Supabase SQL editor or with the Supabase CLI:
+
+```bash
+supabase db push
+```
+
+If you are not using the Supabase CLI, paste the contents of:
+
+```text
+supabase/migrations/002_enable_rls.sql
+```
+
+into the Supabase SQL editor and run it once. The migration is idempotent: it skips missing optional tables, enables RLS, removes existing policies on the known tables, reapplies the intended policies, and revokes direct `anon`/`authenticated` table privileges before granting back only the public `SELECT` permissions.
+
+## Expected Access After Migration
+
+Use the anon key:
+
+```sql
+select * from public.policies;
+```
+
+returns only rows whose status is `proposed`, `active`, `amended`, or `repealed`.
+
+Use the anon key:
+
+```sql
+select * from public.policies where status = 'trashed';
+select * from public.agencies;
+select * from public.scraper_runs;
+select * from public.pipeline_runs;
+select * from public.research_findings;
+select * from public.verification_results;
+```
+
+returns no data or a permission error.
+
+Admin and cron routes continue to write through the server-only service-role client after `SUPABASE_SERVICE_ROLE_KEY` is configured.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,8 @@ const eslintConfig = defineConfig([
   globalIgnores([
     // Default ignores of eslint-config-next:
     ".next/**",
+    ".vercel/**",
+    "coverage/**",
     "out/**",
     "build/**",
     "next-env.d.ts",

--- a/src/app/agencies/page.tsx
+++ b/src/app/agencies/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { Fragment, useState, useMemo, useEffect } from 'react';
 import { Search } from 'lucide-react';
 import {
   Select,
@@ -9,7 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { Agency } from '@/types';
+import { JURISDICTION_NAMES, type Agency } from '@/types';
 
 export default function AgenciesPage() {
   const [agencies, setAgencies] = useState<Agency[]>([]);
@@ -90,91 +90,131 @@ export default function AgenciesPage() {
 
       {/* Main area */}
       <main className="flex-1 min-w-0 p-6">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b-2 border-foreground">
-              <th className="text-left font-mono text-xs uppercase tracking-wider py-2 pr-4">Agency</th>
-              <th className="text-left font-mono text-xs uppercase tracking-wider py-2 pr-4">Acronym</th>
-              <th className="text-left font-mono text-xs uppercase tracking-wider py-2 pr-4">Jurisdiction</th>
-              <th className="text-left font-mono text-xs uppercase tracking-wider py-2">Statement</th>
-            </tr>
-          </thead>
-          <tbody>
-            {filteredAgencies.length === 0 ? (
-              <tr>
-                <td colSpan={4} className="py-12 text-center text-muted-foreground">
-                  No agencies found matching your filters.
-                </td>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[44rem] table-fixed text-sm">
+            <colgroup>
+              <col />
+              <col className="w-28" />
+              <col className="w-44" />
+              <col className="w-32" />
+            </colgroup>
+            <thead>
+              <tr className="border-b-2 border-foreground">
+                <th className="py-2 pr-4 text-left font-mono text-xs uppercase tracking-wider">Agency</th>
+                <th className="py-2 pr-4 text-left font-mono text-xs uppercase tracking-wider">Acronym</th>
+                <th className="py-2 pr-4 text-left font-mono text-xs uppercase tracking-wider">Jurisdiction</th>
+                <th className="py-2 text-left font-mono text-xs uppercase tracking-wider">Statement</th>
               </tr>
-            ) : (
-              filteredAgencies.map((agency) => {
-                const isExpanded = expandedId === agency.id;
-                return (
-                  <tr
-                    key={agency.id}
-                    className="group cursor-pointer border-b border-border/30 transition-colors hover:bg-[var(--row-hover)]"
-                    onClick={() => setExpandedId(isExpanded ? null : agency.id)}
-                  >
-                    <td colSpan={4} className="p-0">
-                      <div className="grid grid-cols-[1fr_auto_auto_auto] items-center py-2.5 pr-4">
-                        <span className="pr-4">{agency.name}</span>
-                        <span className="pr-4 font-mono text-xs text-muted-foreground w-[100px]">{agency.acronym}</span>
-                        <span className="pr-4 text-muted-foreground w-[120px] capitalize">{agency.jurisdiction}</span>
-                        <span className={`w-[100px] ${agency.hasPublishedStatement ? 'text-[var(--status-active)]' : 'text-[var(--status-proposed)]'}`}>
+            </thead>
+            <tbody>
+              {filteredAgencies.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="py-12 text-center text-muted-foreground">
+                    No agencies found matching your filters.
+                  </td>
+                </tr>
+              ) : (
+                filteredAgencies.map((agency) => {
+                  const isExpanded = expandedId === agency.id;
+
+                  return (
+                    <Fragment key={agency.id}>
+                      <tr
+                        className="cursor-pointer border-b border-border/30 align-top transition-colors hover:bg-[var(--row-hover)]"
+                        onClick={() => setExpandedId(isExpanded ? null : agency.id)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            setExpandedId(isExpanded ? null : agency.id);
+                          }
+                        }}
+                        role="button"
+                        tabIndex={0}
+                        aria-expanded={isExpanded}
+                        aria-controls={`agency-details-${agency.id}`}
+                      >
+                        <td className="py-3 pr-4">
+                          <span className="block font-medium text-foreground">{agency.name}</span>
+                        </td>
+                        <td className="py-3 pr-4 align-top font-mono text-xs text-muted-foreground">
+                          {agency.acronym}
+                        </td>
+                        <td className="py-3 pr-4 align-top text-muted-foreground">
+                          {JURISDICTION_NAMES[agency.jurisdiction]}
+                        </td>
+                        <td
+                          className={`py-3 align-top ${
+                            agency.hasPublishedStatement
+                              ? 'text-[var(--status-active)]'
+                              : 'text-[var(--status-proposed)]'
+                          }`}
+                        >
                           {agency.hasPublishedStatement ? 'Published' : 'Pending'}
-                        </span>
-                      </div>
+                        </td>
+                      </tr>
                       {isExpanded && (
-                        <div className="pb-4 pr-4 space-y-3 text-sm text-muted-foreground border-b border-border/20">
-                          {agency.aiTransparencyStatement && (
-                            <div>
-                              <span className="font-medium text-foreground text-xs uppercase tracking-wider font-mono">Transparency Statement</span>
-                              <p className="mt-1">{agency.aiTransparencyStatement}</p>
+                        <tr id={`agency-details-${agency.id}`} className="border-b border-border/20">
+                          <td colSpan={4} className="pb-4 pr-4 text-sm text-muted-foreground">
+                            <div className="space-y-3">
+                              {agency.aiTransparencyStatement && (
+                                <div>
+                                  <span className="font-mono text-xs font-medium uppercase tracking-wider text-foreground">
+                                    Transparency Statement
+                                  </span>
+                                  <p className="mt-1">{agency.aiTransparencyStatement}</p>
+                                </div>
+                              )}
+                              {agency.aiUsageDisclosure && (
+                                <div>
+                                  <span className="font-mono text-xs font-medium uppercase tracking-wider text-foreground">
+                                    AI Usage
+                                  </span>
+                                  <p className="mt-1">{agency.aiUsageDisclosure}</p>
+                                </div>
+                              )}
+                              {agency.lastUpdated && (
+                                <div>
+                                  <span className="font-mono text-xs font-medium uppercase tracking-wider text-foreground">
+                                    Last Updated
+                                  </span>
+                                  <p className="mt-1">
+                                    {new Date(agency.lastUpdated).toLocaleDateString('en-AU', {
+                                      year: 'numeric',
+                                      month: 'long',
+                                      day: 'numeric',
+                                    })}
+                                  </p>
+                                </div>
+                              )}
+                              {agency.website && (
+                                <div>
+                                  <span className="font-mono text-xs font-medium uppercase tracking-wider text-foreground">
+                                    Website
+                                  </span>
+                                  <p className="mt-1">
+                                    <a
+                                      href={agency.website}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="text-primary hover:underline"
+                                      onClick={(e) => e.stopPropagation()}
+                                    >
+                                      {agency.website}
+                                    </a>
+                                  </p>
+                                </div>
+                              )}
                             </div>
-                          )}
-                          {agency.aiUsageDisclosure && (
-                            <div>
-                              <span className="font-medium text-foreground text-xs uppercase tracking-wider font-mono">AI Usage</span>
-                              <p className="mt-1">{agency.aiUsageDisclosure}</p>
-                            </div>
-                          )}
-                          {agency.lastUpdated && (
-                            <div>
-                              <span className="font-medium text-foreground text-xs uppercase tracking-wider font-mono">Last Updated</span>
-                              <p className="mt-1">
-                                {new Date(agency.lastUpdated).toLocaleDateString('en-AU', {
-                                  year: 'numeric',
-                                  month: 'long',
-                                  day: 'numeric',
-                                })}
-                              </p>
-                            </div>
-                          )}
-                          {agency.website && (
-                            <div>
-                              <span className="font-medium text-foreground text-xs uppercase tracking-wider font-mono">Website</span>
-                              <p className="mt-1">
-                                <a
-                                  href={agency.website}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="text-primary hover:underline"
-                                  onClick={(e) => e.stopPropagation()}
-                                >
-                                  {agency.website}
-                                </a>
-                              </p>
-                            </div>
-                          )}
-                        </div>
+                          </td>
+                        </tr>
                       )}
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+                    </Fragment>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
       </main>
     </div>
   );

--- a/src/app/api/admin/pipeline/route.ts
+++ b/src/app/api/admin/pipeline/route.ts
@@ -14,7 +14,7 @@ import {
 import { getPolicies } from '@/lib/data-service';
 
 async function getExistingPolicyTitles(): Promise<string[]> {
-  const policies = await getPolicies();
+  const policies = await getPolicies(undefined, { access: 'admin' });
   return policies.map((p) => p.title);
 }
 

--- a/src/app/api/cron/agencies/route.ts
+++ b/src/app/api/cron/agencies/route.ts
@@ -10,7 +10,7 @@
 import { NextResponse } from 'next/server';
 import { runAgencyDiscoveryAgent } from '@/lib/agents/agency-discovery-agent';
 import { getAgencies } from '@/lib/data-service';
-import { isSupabaseConfigured } from '@/lib/data-service';
+import { isSupabaseAdminConfigured } from '@/lib/data-service';
 
 export const maxDuration = 300;
 export const dynamic = 'force-dynamic';
@@ -42,7 +42,7 @@ export async function GET(request: Request) {
 
   try {
     // Get existing agency names for dedup
-    const existingAgencies = await getAgencies();
+    const existingAgencies = await getAgencies(undefined, { access: 'admin' });
     const existingNames = existingAgencies.map((a) => a.name);
 
     // Run discovery
@@ -52,8 +52,9 @@ export async function GET(request: Request) {
     let created = 0;
     let updated = 0;
 
-    if (isSupabaseConfigured && updates.length > 0) {
-      const { supabase } = await import('@/lib/supabase');
+    if (isSupabaseAdminConfigured && updates.length > 0) {
+      const { createSupabaseAdminClient } = await import('@/lib/supabase-admin');
+      const supabase = createSupabaseAdminClient();
 
       for (const update of updates) {
         // Try to find existing agency by name (case-insensitive)

--- a/src/app/api/cron/pipeline/route.ts
+++ b/src/app/api/cron/pipeline/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: Request) {
   console.log(`[cron/pipeline] Starting pipeline at ${new Date().toISOString()}`);
 
   try {
-    const policies = await getPolicies();
+    const policies = await getPolicies(undefined, { access: 'admin' });
     const existingTitles = policies.map((p) => p.title);
     const existingSourceUrls = policies.map((p) => p.sourceUrl).filter(Boolean);
 

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -14,8 +14,17 @@ export async function GET(request: Request) {
   const type = searchParams.get('type') || undefined;
   const status = searchParams.get('status') || undefined;
   const search = searchParams.get('search') || undefined;
+  const requiresAdmin = status === 'trashed';
 
-  const filteredPolicies = await getPolicies({ jurisdiction, type, status, search });
+  if (requiresAdmin) {
+    const user = await verifyAuth(request);
+    if (!user) return unauthorizedResponse();
+  }
+
+  const filters = { jurisdiction, type, status, search };
+  const filteredPolicies = requiresAdmin
+    ? await getPolicies(filters, { access: 'admin' })
+    : await getPolicies(filters);
 
   return NextResponse.json({
     data: filteredPolicies,

--- a/src/lib/agents/implementation-agent.ts
+++ b/src/lib/agents/implementation-agent.ts
@@ -124,7 +124,7 @@ export async function runImplementationAgent(
   let updatedCount = 0;
   let skippedCount = 0;
 
-  const policies = await getPolicies();
+  const policies = await getPolicies(undefined, { access: 'admin' });
   const verificationMap = new Map(verifications.map(v => [v.findingId, v]));
 
   // Only implement verified findings

--- a/src/lib/agents/pipeline-storage.ts
+++ b/src/lib/agents/pipeline-storage.ts
@@ -6,15 +6,15 @@ import type {
   VerificationResult,
 } from '@/types';
 import { readJsonFile, writeJsonFile } from '@/lib/file-store';
-import { isSupabaseConfigured } from '@/lib/data-service';
+import { isSupabaseConfigured, isSupabaseAdminConfigured } from '@/lib/data-service';
 
 // ---------------------------------------------------------------------------
 // Supabase helper (lazy import to avoid build errors without env vars)
 // ---------------------------------------------------------------------------
 
 async function getSupabase() {
-  const { supabase } = await import('@/lib/supabase');
-  return supabase;
+  const { createSupabaseAdminClient } = await import('@/lib/supabase-admin');
+  return createSupabaseAdminClient();
 }
 
 // ---------------------------------------------------------------------------
@@ -40,7 +40,7 @@ async function writeJsonWithDir(filePath: string, data: unknown) {
 // ---------------------------------------------------------------------------
 
 export async function getPipelineRuns(): Promise<PipelineRun[]> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       const { data, error } = await supabase
@@ -52,13 +52,15 @@ export async function getPipelineRuns(): Promise<PipelineRun[]> {
     } catch (err) {
       console.warn('[pipeline-storage] Supabase getPipelineRuns exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for getPipelineRuns');
   }
 
   return readJsonFile<PipelineRun[]>(RUNS_FILE, []);
 }
 
 export async function getPipelineRun(id: string): Promise<PipelineRun | null> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       const { data, error } = await supabase
@@ -72,6 +74,8 @@ export async function getPipelineRun(id: string): Promise<PipelineRun | null> {
     } catch (err) {
       console.warn('[pipeline-storage] Supabase getPipelineRun exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for getPipelineRun');
   }
 
   const runs = await getPipelineRuns();
@@ -79,7 +83,7 @@ export async function getPipelineRun(id: string): Promise<PipelineRun | null> {
 }
 
 export async function getLatestPipelineRun(): Promise<PipelineRun | null> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       const { data, error } = await supabase
@@ -94,6 +98,8 @@ export async function getLatestPipelineRun(): Promise<PipelineRun | null> {
     } catch (err) {
       console.warn('[pipeline-storage] Supabase getLatestPipelineRun exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for getLatestPipelineRun');
   }
 
   const runs = await getPipelineRuns();
@@ -102,7 +108,7 @@ export async function getLatestPipelineRun(): Promise<PipelineRun | null> {
 }
 
 export async function savePipelineRun(run: PipelineRun) {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       const { error } = await supabase
@@ -113,6 +119,8 @@ export async function savePipelineRun(run: PipelineRun) {
     } catch (err) {
       console.warn('[pipeline-storage] Supabase savePipelineRun exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for savePipelineRun');
   }
 
   const runs = await readJsonFile<PipelineRun[]>(RUNS_FILE, []);
@@ -145,7 +153,7 @@ function sanitizeForPostgres<T>(obj: T): T {
 // ---------------------------------------------------------------------------
 
 export async function getFindings(pipelineRunId?: string): Promise<ResearchFinding[]> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       let query = supabase.from('research_findings').select('*');
@@ -158,6 +166,8 @@ export async function getFindings(pipelineRunId?: string): Promise<ResearchFindi
     } catch (err) {
       console.warn('[pipeline-storage] Supabase getFindings exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for getFindings');
   }
 
   const findings = await readJsonFile<ResearchFinding[]>(FINDINGS_FILE, []);
@@ -168,7 +178,7 @@ export async function getFindings(pipelineRunId?: string): Promise<ResearchFindi
 }
 
 export async function getFinding(id: string): Promise<ResearchFinding | null> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       const { data, error } = await supabase
@@ -182,6 +192,8 @@ export async function getFinding(id: string): Promise<ResearchFinding | null> {
     } catch (err) {
       console.warn('[pipeline-storage] Supabase getFinding exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for getFinding');
   }
 
   const findings = await readJsonFile<ResearchFinding[]>(FINDINGS_FILE, []);
@@ -189,7 +201,7 @@ export async function getFinding(id: string): Promise<ResearchFinding | null> {
 }
 
 export async function saveFindings(newFindings: ResearchFinding[]) {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       const sanitized = sanitizeForPostgres(newFindings);
@@ -201,6 +213,8 @@ export async function saveFindings(newFindings: ResearchFinding[]) {
     } catch (err) {
       console.warn('[pipeline-storage] Supabase saveFindings exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for saveFindings');
   }
 
   const existing = await readJsonFile<ResearchFinding[]>(FINDINGS_FILE, []);
@@ -216,7 +230,7 @@ export async function saveFindings(newFindings: ResearchFinding[]) {
 }
 
 export async function updateFindingStatus(id: string, status: ResearchFinding['status']) {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       const { error } = await supabase
@@ -228,6 +242,8 @@ export async function updateFindingStatus(id: string, status: ResearchFinding['s
     } catch (err) {
       console.warn('[pipeline-storage] Supabase updateFindingStatus exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for updateFindingStatus');
   }
 
   const findings = await readJsonFile<ResearchFinding[]>(FINDINGS_FILE, []);
@@ -243,7 +259,7 @@ export async function updateFindingStatus(id: string, status: ResearchFinding['s
 // ---------------------------------------------------------------------------
 
 export async function getVerifications(pipelineRunId?: string): Promise<VerificationResult[]> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       let query = supabase.from('verification_results').select('*');
@@ -256,6 +272,8 @@ export async function getVerifications(pipelineRunId?: string): Promise<Verifica
     } catch (err) {
       console.warn('[pipeline-storage] Supabase getVerifications exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for getVerifications');
   }
 
   const results = await readJsonFile<VerificationResult[]>(VERIFICATIONS_FILE, []);
@@ -266,7 +284,7 @@ export async function getVerifications(pipelineRunId?: string): Promise<Verifica
 }
 
 export async function saveVerifications(newResults: VerificationResult[]) {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
       const supabase = await getSupabase();
       const { error } = await supabase
@@ -277,6 +295,8 @@ export async function saveVerifications(newResults: VerificationResult[]) {
     } catch (err) {
       console.warn('[pipeline-storage] Supabase saveVerifications exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[pipeline-storage] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for saveVerifications');
   }
 
   const existing = await readJsonFile<VerificationResult[]>(VERIFICATIONS_FILE, []);

--- a/src/lib/data-service.ts
+++ b/src/lib/data-service.ts
@@ -19,9 +19,11 @@ import type { Policy, Agency, TimelineEvent, ScraperRunLog } from '@/types';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 
 /** True when the env vars are set and non-empty. */
 export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
+export const isSupabaseAdminConfigured = Boolean(supabaseUrl && supabaseServiceRoleKey);
 
 /**
  * Lazily import the Supabase client so the JSON-only path never triggers
@@ -30,6 +32,44 @@ export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
 async function getSupabase() {
   const { supabase } = await import('@/lib/supabase');
   return supabase;
+}
+
+async function getSupabaseAdmin() {
+  const { createSupabaseAdminClient } = await import('@/lib/supabase-admin');
+  return createSupabaseAdminClient();
+}
+
+type DataAccess = 'public' | 'admin';
+
+interface DataServiceOptions {
+  access?: DataAccess;
+}
+
+const PUBLIC_POLICY_STATUSES = new Set(['proposed', 'active', 'amended', 'repealed']);
+
+function isPublicPolicy(policy: Policy): boolean {
+  return PUBLIC_POLICY_STATUSES.has(policy.status);
+}
+
+function applyPublicPolicyFilter(policies: Policy[]): Policy[] {
+  return policies.filter(isPublicPolicy);
+}
+
+function toPublicAgencies(agencies: Agency[]): Agency[] {
+  return agencies.map((agency) => ({
+    id: agency.id,
+    name: agency.name,
+    acronym: agency.acronym,
+    level: agency.level,
+    jurisdiction: agency.jurisdiction,
+    aiTransparencyStatement: agency.aiTransparencyStatement,
+    aiUsageDisclosure: agency.aiUsageDisclosure,
+    website: agency.website,
+    policies: agency.policies,
+    transparencyStatementUrl: agency.transparencyStatementUrl,
+    lastUpdated: agency.lastUpdated,
+    hasPublishedStatement: agency.hasPublishedStatement,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -79,15 +119,25 @@ export class DuplicatePolicyError extends Error {
   }
 }
 
-export async function getPolicies(filters?: PolicyFilters): Promise<Policy[]> {
+export async function getPolicies(
+  filters?: PolicyFilters,
+  options: DataServiceOptions = {},
+): Promise<Policy[]> {
+  const access = options.access ?? 'public';
+
   if (isSupabaseConfigured) {
     try {
-      const supabase = await getSupabase();
+      const supabase = access === 'admin' && isSupabaseAdminConfigured
+        ? await getSupabaseAdmin()
+        : await getSupabase();
       let query = supabase.from('policies').select('*');
 
       if (filters?.jurisdiction) query = query.eq('jurisdiction', filters.jurisdiction);
       if (filters?.type) query = query.eq('type', filters.type);
       if (filters?.status) query = query.eq('status', filters.status);
+      if (access === 'public') {
+        query = query.in('status', Array.from(PUBLIC_POLICY_STATUSES));
+      }
       if (filters?.search) {
         const sanitized = sanitizeSearchInput(filters.search);
         query = query.or(
@@ -105,6 +155,9 @@ export async function getPolicies(filters?: PolicyFilters): Promise<Policy[]> {
 
   // JSON fallback
   let policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
+  if (access === 'public') {
+    policies = applyPublicPolicyFilter(policies);
+  }
 
   if (filters?.jurisdiction) {
     policies = policies.filter((p) => p.jurisdiction === filters.jurisdiction);
@@ -130,15 +183,25 @@ export async function getPolicies(filters?: PolicyFilters): Promise<Policy[]> {
   );
 }
 
-export async function getPolicyById(id: string): Promise<Policy | null> {
+export async function getPolicyById(
+  id: string,
+  options: DataServiceOptions = {},
+): Promise<Policy | null> {
+  const access = options.access ?? 'public';
+
   if (isSupabaseConfigured) {
     try {
-      const supabase = await getSupabase();
-      const { data, error } = await supabase
+      const supabase = access === 'admin' && isSupabaseAdminConfigured
+        ? await getSupabaseAdmin()
+        : await getSupabase();
+      let query = supabase
         .from('policies')
         .select('*')
-        .eq('id', id)
-        .maybeSingle();
+        .eq('id', id);
+      if (access === 'public') {
+        query = query.in('status', Array.from(PUBLIC_POLICY_STATUSES));
+      }
+      const { data, error } = await query.maybeSingle();
       if (!error && data) return data as Policy;
       if (!error) return null;
       console.warn('[data-service] Supabase getPolicyById failed, falling back to JSON:', error?.message);
@@ -148,18 +211,30 @@ export async function getPolicyById(id: string): Promise<Policy | null> {
   }
 
   const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
-  return policies.find((p) => p.id === id) || null;
+  const policy = policies.find((p) => p.id === id) || null;
+  if (policy && access === 'public' && !isPublicPolicy(policy)) return null;
+  return policy;
 }
 
-export async function getPolicyBySourceUrl(sourceUrl: string): Promise<Policy | null> {
+export async function getPolicyBySourceUrl(
+  sourceUrl: string,
+  options: DataServiceOptions = {},
+): Promise<Policy | null> {
+  const access = options.access ?? 'public';
+
   if (isSupabaseConfigured) {
     try {
-      const supabase = await getSupabase();
-      const { data, error } = await supabase
+      const supabase = access === 'admin' && isSupabaseAdminConfigured
+        ? await getSupabaseAdmin()
+        : await getSupabase();
+      let query = supabase
         .from('policies')
         .select('*')
-        .eq('sourceUrl', sourceUrl)
-        .maybeSingle();
+        .eq('sourceUrl', sourceUrl);
+      if (access === 'public') {
+        query = query.in('status', Array.from(PUBLIC_POLICY_STATUSES));
+      }
+      const { data, error } = await query.maybeSingle();
       if (!error && data) return data as Policy;
       if (!error) return null;
       console.warn('[data-service] Supabase getPolicyBySourceUrl failed, falling back to JSON:', error?.message);
@@ -169,7 +244,9 @@ export async function getPolicyBySourceUrl(sourceUrl: string): Promise<Policy | 
   }
 
   const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
-  return policies.find((p) => p.sourceUrl === sourceUrl) || null;
+  const policy = policies.find((p) => p.sourceUrl === sourceUrl) || null;
+  if (policy && access === 'public' && !isPublicPolicy(policy)) return null;
+  return policy;
 }
 
 function isSupabaseDuplicateError(message?: string): boolean {
@@ -179,9 +256,9 @@ function isSupabaseDuplicateError(message?: string): boolean {
 }
 
 export async function createPolicy(policy: Policy): Promise<Policy> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
-      const supabase = await getSupabase();
+      const supabase = await getSupabaseAdmin();
       const { data, error } = await supabase
         .from('policies')
         .insert(policy)
@@ -198,6 +275,8 @@ export async function createPolicy(policy: Policy): Promise<Policy> {
       }
       console.warn('[data-service] Supabase createPolicy exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for createPolicy');
   }
 
   const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
@@ -213,9 +292,9 @@ export async function updatePolicy(
   id: string,
   updates: Partial<PolicyWithTrash>,
 ): Promise<Policy | null> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
-      const supabase = await getSupabase();
+      const supabase = await getSupabaseAdmin();
       const { data, error } = await supabase
         .from('policies')
         .update({ ...updates, updatedAt: new Date().toISOString() })
@@ -227,6 +306,8 @@ export async function updatePolicy(
     } catch (err) {
       console.warn('[data-service] Supabase updatePolicy exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for updatePolicy');
   }
 
   const policies = await readJsonFile<PolicyWithTrash[]>(POLICIES_FILE, []);
@@ -246,15 +327,17 @@ export async function updatePolicy(
 }
 
 export async function deletePolicy(id: string): Promise<boolean> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
-      const supabase = await getSupabase();
+      const supabase = await getSupabaseAdmin();
       const { error } = await supabase.from('policies').delete().eq('id', id);
       if (!error) return true;
       console.warn('[data-service] Supabase deletePolicy failed, falling back to JSON:', error?.message);
     } catch (err) {
       console.warn('[data-service] Supabase deletePolicy exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for deletePolicy');
   }
 
   const policies = await readJsonFile<Policy[]>(POLICIES_FILE, []);
@@ -267,12 +350,12 @@ export async function deletePolicy(id: string): Promise<boolean> {
 
 /** Check if a policy with a given ID already exists. */
 export async function policyExists(id: string): Promise<boolean> {
-  const policy = await getPolicyById(id);
+  const policy = await getPolicyById(id, { access: 'admin' });
   return policy !== null;
 }
 
 export async function policyExistsBySourceUrl(sourceUrl: string): Promise<boolean> {
-  const policy = await getPolicyBySourceUrl(sourceUrl);
+  const policy = await getPolicyBySourceUrl(sourceUrl, { access: 'admin' });
   return policy !== null;
 }
 
@@ -280,18 +363,26 @@ export async function policyExistsBySourceUrl(sourceUrl: string): Promise<boolea
 // Agency operations
 // ---------------------------------------------------------------------------
 
-export async function getAgencies(filters?: {
-  level?: string;
-  jurisdiction?: string;
-}): Promise<Agency[]> {
+export async function getAgencies(
+  filters?: {
+    level?: string;
+    jurisdiction?: string;
+  },
+  options: DataServiceOptions = {},
+): Promise<Agency[]> {
+  const access = options.access ?? 'public';
+
   if (isSupabaseConfigured) {
     try {
-      const supabase = await getSupabase();
+      const supabase = isSupabaseAdminConfigured ? await getSupabaseAdmin() : await getSupabase();
       let query = supabase.from('agencies').select('*');
       if (filters?.level) query = query.eq('level', filters.level);
       if (filters?.jurisdiction) query = query.eq('jurisdiction', filters.jurisdiction);
       const { data, error } = await query.order('name');
-      if (!error && data) return data as Agency[];
+      if (!error && data) {
+        const agencies = data as Agency[];
+        return access === 'admin' ? agencies : toPublicAgencies(agencies);
+      }
       console.warn('[data-service] Supabase getAgencies failed, falling back to JSON:', error?.message);
     } catch (err) {
       console.warn('[data-service] Supabase getAgencies exception, falling back to JSON:', err);
@@ -305,25 +396,34 @@ export async function getAgencies(filters?: {
   if (filters?.jurisdiction) {
     agencies = agencies.filter((a) => a.jurisdiction === filters.jurisdiction);
   }
-  return agencies.sort((a, b) => a.name.localeCompare(b.name));
+  const sorted = agencies.sort((a, b) => a.name.localeCompare(b.name));
+  return access === 'admin' ? sorted : toPublicAgencies(sorted);
 }
 
-export async function getCommonwealthAgencies(): Promise<Agency[]> {
+export async function getCommonwealthAgencies(
+  options: DataServiceOptions = {},
+): Promise<Agency[]> {
+  const access = options.access ?? 'public';
+
   if (isSupabaseConfigured) {
     try {
-      const supabase = await getSupabase();
+      const supabase = isSupabaseAdminConfigured ? await getSupabaseAdmin() : await getSupabase();
       const { data, error } = await supabase
         .from('agencies')
         .select('*')
         .eq('level', 'federal')
         .order('name');
-      if (!error && data) return data as Agency[];
+      if (!error && data) {
+        const agencies = data as Agency[];
+        return access === 'admin' ? agencies : toPublicAgencies(agencies);
+      }
     } catch {
       // fall through
     }
   }
 
-  return readJsonFile<Agency[]>(COMMONWEALTH_AGENCIES_FILE, []);
+  const agencies = await readJsonFile<Agency[]>(COMMONWEALTH_AGENCIES_FILE, []);
+  return access === 'admin' ? agencies : toPublicAgencies(agencies);
 }
 
 // ---------------------------------------------------------------------------
@@ -372,15 +472,17 @@ export async function getTimelineEvents(filters?: {
 const SCRAPER_RUNS_FILE = path.join(process.cwd(), 'data', 'scraper-runs.json');
 
 export async function logScraperRun(run: ScraperRunLog): Promise<void> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
-      const supabase = await getSupabase();
+      const supabase = await getSupabaseAdmin();
       const { error } = await supabase.from('scraper_runs').insert(run);
       if (!error) return;
       console.warn('[data-service] Supabase logScraperRun failed, falling back to JSON:', error?.message);
     } catch (err) {
       console.warn('[data-service] Supabase logScraperRun exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for logScraperRun');
   }
 
   const runs = await readJsonFile<ScraperRunLog[]>(SCRAPER_RUNS_FILE, []);
@@ -390,9 +492,9 @@ export async function logScraperRun(run: ScraperRunLog): Promise<void> {
 }
 
 export async function getRecentScraperRuns(limit = 20): Promise<ScraperRunLog[]> {
-  if (isSupabaseConfigured) {
+  if (isSupabaseAdminConfigured) {
     try {
-      const supabase = await getSupabase();
+      const supabase = await getSupabaseAdmin();
       const { data, error } = await supabase
         .from('scraper_runs')
         .select('*')
@@ -403,6 +505,8 @@ export async function getRecentScraperRuns(limit = 20): Promise<ScraperRunLog[]>
     } catch (err) {
       console.warn('[data-service] Supabase getRecentScraperRuns exception, falling back to JSON:', err);
     }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for getRecentScraperRuns');
   }
 
   const runs = await readJsonFile<ScraperRunLog[]>(SCRAPER_RUNS_FILE, []);

--- a/src/lib/supabase-admin.ts
+++ b/src/lib/supabase-admin.ts
@@ -1,0 +1,25 @@
+import 'server-only';
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+
+/**
+ * Server-only Supabase client for protected admin/cron writes.
+ *
+ * This client uses the service-role key, which bypasses RLS and must never be
+ * imported from client components or exposed to the browser.
+ */
+export function createSupabaseAdminClient(): SupabaseClient {
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is required for Supabase admin writes');
+  }
+
+  return createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}

--- a/supabase/migrations/002_enable_rls.sql
+++ b/supabase/migrations/002_enable_rls.sql
@@ -1,0 +1,100 @@
+-- Enable least-privilege RLS for Policai public-schema tables.
+--
+-- Public Data API access is intentionally narrow:
+-- - anon/authenticated can read only published policy rows.
+-- - anon/authenticated can read published news and timeline rows when those
+--   tables exist.
+-- - agencies, scraper logs, and AI pipeline tables are server-only because
+--   they can contain operational notes, source content, or sensitive fields.
+--
+-- Server-side admin and cron paths should use SUPABASE_SERVICE_ROLE_KEY.
+
+do $$
+declare
+  table_name text;
+  policy_record record;
+begin
+  foreach table_name in array array[
+    'policies',
+    'agencies',
+    'news_items',
+    'timeline_events',
+    'scraper_runs',
+    'pipeline_runs',
+    'research_findings',
+    'verification_results'
+  ]
+  loop
+    if to_regclass(format('public.%I', table_name)) is not null then
+      execute format('alter table public.%I enable row level security', table_name);
+      execute format('revoke all on table public.%I from anon, authenticated', table_name);
+
+      for policy_record in
+        select policyname
+        from pg_policies
+        where schemaname = 'public'
+          and tablename = table_name
+      loop
+        execute format(
+          'drop policy if exists %I on public.%I',
+          policy_record.policyname,
+          table_name
+        );
+      end loop;
+    end if;
+  end loop;
+end $$;
+
+-- Published policy data is public. There is no separate published flag in the
+-- current model, so the allow-list is the existing non-trash public statuses.
+do $$
+begin
+  if to_regclass('public.policies') is not null then
+    grant select on table public.policies to anon, authenticated;
+
+    create policy "Public can read published policies"
+      on public.policies
+      for select
+      to anon, authenticated
+      using (
+        status in ('proposed', 'active', 'amended', 'repealed')
+      );
+
+    if exists (
+      select 1
+      from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'policies'
+        and column_name = 'status'
+    ) then
+      create index if not exists idx_policies_public_status
+        on public.policies (status);
+    end if;
+  end if;
+end $$;
+
+-- Optional public catalog tables. These are safe to expose as full rows because
+-- they model already-published content and do not contain operational source
+-- material.
+do $$
+begin
+  if to_regclass('public.news_items') is not null then
+    grant select on table public.news_items to anon, authenticated;
+
+    create policy "Public can read news items"
+      on public.news_items
+      for select
+      to anon, authenticated
+      using (true);
+  end if;
+
+  if to_regclass('public.timeline_events') is not null then
+    grant select on table public.timeline_events to anon, authenticated;
+
+    create policy "Public can read timeline events"
+      on public.timeline_events
+      for select
+      to anon, authenticated
+      using (true);
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- Added a Supabase RLS migration for public policy reads and locked down operational tables.
- Split public anon reads from server-only admin writes with a service-role client.
- Updated docs and env examples so the new access model is explicit.

## Testing
- `npm test`
- `npm run build`
- Applied the migration directly to the linked Supabase project and verified RLS/policies on the remote tables.