### PR TITLE
Add ASD Blueprint AI usage policy entry and blog post

### DIFF
--- a/content/blog/asd-blueprint-ai-usage-policy.mdx
+++ b/content/blog/asd-blueprint-ai-usage-policy.mdx
@@ -1,0 +1,37 @@
+---
+title: "ASD's Secure Cloud Blueprint points agencies toward AI usage policies"
+date: "2026-04-20"
+description: "ASD's Blueprint for Secure Cloud is interesting for AI governance because its security documentation now makes a general-purpose AI usage policy part of the secure cloud governance checklist."
+---
+
+The Australian Signals Directorate's [Blueprint for Secure Cloud](https://blueprint.asd.gov.au/security-and-governance/) is not an AI policy document in the usual sense. It was first released on 19 December 2023 and, according to the Blueprint change log, was last updated on 20 April 2026. It is a practical security and governance resource for designing, configuring and operating secure cloud and hybrid workspaces, with a current focus on Microsoft 365.
+
+That is what makes its AI reference interesting.
+
+In the Blueprint's [organisational policies and strategies](https://blueprint.asd.gov.au/security-and-governance/policies/) checklist, ASD identifies a general-purpose artificial intelligence usage policy as a requirement of ISM control ISM-2074. It sits beside more familiar organisational artefacts such as cyber security strategy, incident management policy, event logging policy, supplier relationship management policy, system usage policy and vulnerability disclosure policy.
+
+## Why this matters
+
+Australian Government AI governance is often discussed through DTA-led responsible AI policy, transparency statements, impact assessments and technical standards. Those are still the headline instruments for AI use in government.
+
+The Blueprint points to a different but important layer: operational security governance. If an agency is deploying Microsoft 365, Copilot, cloud collaboration services or related hybrid workspace capabilities, AI usage is no longer just a product adoption question. It is part of the documentation set that supports system authorisation, security planning and ongoing control assurance.
+
+That matters because general-purpose AI tools are increasingly embedded inside the same productivity platforms that agencies already use for email, documents, meetings, search and records. An AI usage policy has to deal with more than model behaviour. It also has to fit with information classification, data loss prevention, identity controls, logging, endpoint management, procurement, outsourcing and incident response.
+
+## What the Blueprint does and does not do
+
+ASD is careful about the status of the Blueprint. The [about page](https://blueprint.asd.gov.au/about/) describes it as better-practice guidance, configuration guides and templates aligned to ASD's Information Security Manual, the Essential Eight, Cloud Security guidance and the Protective Security Policy Framework. It also says implementation will differ by operating context and does not certify or endorse a system for handling OFFICIAL, OFFICIAL: Sensitive or PROTECTED information.
+
+The AI usage policy mention follows the same pattern. The Blueprint does not provide a ready-made AI policy template. Instead, it flags the artefact as something organisations should develop and maintain alongside their other system governance documentation.
+
+That is a useful distinction. It keeps the Blueprint in its lane while still making AI visible inside mainstream security governance.
+
+## The broader pattern
+
+This is another sign that AI governance in Australia is moving from standalone principles into the ordinary machinery of government technology management.
+
+The DTA's responsible AI policy tells agencies what accountable and transparent AI use should look like. The National AI Plan and safety standards set broader expectations. Court practice notes are creating disclosure rules for AI-assisted legal work. ASD's Blueprint adds the security architecture perspective: agencies need to be able to show how AI use is governed inside real systems, real tenants and real operating environments.
+
+For Policai, this is worth tracking because it joins AI policy to the secure cloud baseline that many agencies already use to structure Microsoft 365 implementation and assurance work. It is a small reference, but it is the kind of small reference that can change what gets asked during internal approvals, audits and security reviews.
+
+You can read the source material in ASD's [Security and governance](https://blueprint.asd.gov.au/security-and-governance/) section, the [organisational policies and strategies](https://blueprint.asd.gov.au/security-and-governance/policies/) checklist, and the Blueprint [change log](https://blueprint.asd.gov.au/changelog/).

--- a/public/data/sample-policies.json
+++ b/public/data/sample-policies.json
@@ -1,5 +1,23 @@
 [
   {
+    "id": "asd-blueprint-secure-cloud-ai-usage-policy",
+    "title": "ASD Blueprint for Secure Cloud — Artificial intelligence usage policy requirement",
+    "description": "ASD's Blueprint for Secure Cloud, first released on 19 December 2023 and last updated on 20 April 2026, surfaces an artificial intelligence usage policy as an organisational policy expected under ISM control ISM-2074.",
+    "jurisdiction": "federal",
+    "type": "guideline",
+    "status": "active",
+    "effectiveDate": "2023-12-19",
+    "agencies": [
+      "Australian Signals Directorate"
+    ],
+    "sourceUrl": "https://blueprint.asd.gov.au/security-and-governance/",
+    "content": "ASD's Blueprint for Secure Cloud was initially launched on 19 December 2023 and last updated on 20 April 2026. It is better-practice guidance for designing, configuring and deploying secure cloud and hybrid workspaces, with a current focus on Microsoft 365. Its security and governance section links system security planning, the Essential Eight, system security plan annexes, and organisational policies and strategies. The organisational policies checklist explicitly identifies a general-purpose artificial intelligence usage policy as a requirement of ISM control ISM-2074. The Blueprint does not provide a template for this artefact, but positions it as part of the documentation agencies should review, develop and maintain when operating systems built using the Blueprint.",
+    "aiSummary": "ASD Blueprint guidance, first launched in December 2023 and updated in April 2026, identifies a general-purpose AI usage policy as an ISM-2074 organisational policy requirement.",
+    "tags": ["ASD", "Blueprint for Secure Cloud", "ISM-2074", "AI usage policy", "cloud security", "governance"],
+    "createdAt": "2026-04-20T00:00:00Z",
+    "updatedAt": "2026-04-20T00:00:00Z"
+  },
+  {
     "id": "policy-responsible-use-ai-government-v2",
     "title": "Policy for the Responsible Use of AI in Government",
     "description": "Whole-of-government policy setting mandatory requirements for the safe, transparent, and accountable use of AI by Australian Government agencies.",

--- a/public/data/sample-timeline.json
+++ b/public/data/sample-timeline.json
@@ -1,5 +1,15 @@
 [
   {
+    "id": "12",
+    "date": "2023-12-19",
+    "title": "ASD launches Blueprint for Secure Cloud",
+    "description": "ASD's Blueprint for Secure Cloud launches with security and governance guidance later updated to identify a general-purpose artificial intelligence usage policy as an organisational policy requirement under ISM control ISM-2074.",
+    "type": "policy_introduced",
+    "jurisdiction": "federal",
+    "relatedPolicyId": "asd-blueprint-secure-cloud-ai-usage-policy",
+    "sourceUrl": "https://blueprint.asd.gov.au/security-and-governance/"
+  },
+  {
     "id": "1",
     "date": "2019-11-07",
     "title": "AI Ethics Principles Published",


### PR DESCRIPTION
## Summary
- Add the ASD Blueprint for Secure Cloud as a federal guideline entry in the policy dataset.
- Add a matching timeline event for the Blueprint launch and AI usage policy requirement.
- Publish a blog post explaining why ASD’s secure cloud guidance matters for AI governance.

## Testing
- Not run (not requested)