### PR TITLE
feat(policai): add local MCP source ingest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ CRON_SECRET=
 
 # Admin dashboard password
 ADMIN_PASSWORD=
+
+# Local-only MCP source ingest writes
+POLICAI_MCP_ADMIN_TOKEN=

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.82.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
@@ -34,7 +35,8 @@
         "openai": "^6.34.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.4.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",
@@ -1245,6 +1247,18 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1866,6 +1880,68 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -5008,6 +5084,19 @@
         "d3-zoom": "^3.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -5045,6 +5134,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -5392,6 +5520,46 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5456,6 +5624,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -5479,7 +5656,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5493,7 +5669,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5744,6 +5919,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5751,11 +5948,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -6418,6 +6649,15 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -6536,7 +6776,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6546,6 +6785,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
@@ -6560,6 +6805,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
@@ -6673,7 +6927,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6683,7 +6936,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6728,7 +6980,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6867,6 +7118,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -7409,6 +7666,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -7417,6 +7704,67 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -7441,7 +7789,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -7488,6 +7835,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -7522,6 +7885,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -7578,6 +7962,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7597,7 +7999,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7658,7 +8059,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7692,7 +8092,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7780,7 +8179,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7889,7 +8287,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7918,7 +8315,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8012,6 +8408,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -8061,6 +8466,26 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iceberg-js": {
@@ -8131,6 +8556,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -8159,6 +8590,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -8503,6 +8952,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8659,7 +9114,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -8727,6 +9181,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -8874,6 +9337,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -9368,7 +9837,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9550,6 +10018,27 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -10171,6 +10660,31 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -10250,6 +10764,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "16.2.3",
@@ -10377,7 +10900,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10387,7 +10909,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10506,6 +11027,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/openai": {
       "version": "6.34.0",
@@ -10683,6 +11225,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10697,7 +11248,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10709,6 +11259,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -10734,6 +11294,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -10858,6 +11427,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10866,6 +11448,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -10888,6 +11485,46 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -11177,7 +11814,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11281,6 +11917,22 @@
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -11415,6 +12067,51 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -11463,6 +12160,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -11526,7 +12229,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -11539,7 +12241,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11549,7 +12250,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11569,7 +12269,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11586,7 +12285,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11605,7 +12303,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11675,6 +12372,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -12081,6 +12787,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -12219,6 +12934,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -12486,6 +13215,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -12619,6 +13357,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",
@@ -12920,7 +13667,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -13048,6 +13794,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -13122,13 +13874,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-      "devOptional": true,
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     "lint": "eslint",
     "scrape": "tsx scripts/run-scheduled-scrapers.ts",
     "pipeline": "tsx scripts/run-daily-pipeline.ts",
+    "mcp": "tsx src/mcp/server.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.82.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
@@ -43,7 +45,8 @@
     "openai": "^6.34.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.4.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.2",

--- a/public/data/sample-policies.json
+++ b/public/data/sample-policies.json
@@ -479,5 +479,42 @@
     "tags": ["practice note", "AI", "Supreme Court", "Queensland", "disclosure", "courts", "judicial"],
     "createdAt": "2026-04-16T00:00:00Z",
     "updatedAt": "2026-04-16T00:00:00Z"
+  },
+  {
+    "id": "asd-frontier-ai-models-cyber-security-2026",
+    "title": "Frontier AI models and their impact on cyber security",
+    "description": "Australian Signals Directorate guidance on the cyber security implications of increasingly capable frontier AI models, including Claude Mythos Preview.",
+    "jurisdiction": "federal",
+    "type": "guideline",
+    "status": "active",
+    "effectiveDate": "2026-04-09",
+    "agencies": [
+      "Australian Signals Directorate",
+      "Australian Cyber Security Centre"
+    ],
+    "sourceUrl": "https://www.cyber.gov.au/about-us/view-all-content/news/frontier-models-and-their-impact-on-cyber-security",
+    "content": "ASD published guidance on 9 April 2026 about the cyber security implications of increasingly capable frontier AI models, following Anthropic's 7 April 2026 announcement of Claude Mythos Preview. The guidance says frontier models reduce the cost, effort and expertise required to discover and exploit software vulnerabilities, while also creating opportunities for defenders to identify and remediate vulnerabilities before exploitation. ASD advises organisations to maintain strong cyber security baselines aligned to the Information Security Manual and Essential Eight, reduce exposed attack paths, patch more frequently, use AI defensively where appropriate, and implement layered security. APRA's 30 April 2026 AI industry letter points regulated entities to ASD advice on frontier AI models.",
+    "aiSummary": "ASD guidance on frontier AI cyber risks, defensive use of AI, patching tempo, attack-surface reduction, and layered cyber resilience.",
+    "tags": ["frontier AI", "Claude Mythos", "cyber security", "AI risk", "Essential Eight", "financial system resilience"],
+    "createdAt": "2026-05-01T00:00:00Z",
+    "updatedAt": "2026-05-01T00:00:00Z"
+  },
+  {
+    "id": "apra-ai-industry-letter-2026",
+    "title": "APRA Letter to Industry on Artificial Intelligence (AI)",
+    "description": "APRA industry letter setting expectations for banks, insurers and superannuation trustees to strengthen governance, assurance, cyber security and operational resilience for AI-related risks.",
+    "jurisdiction": "federal",
+    "type": "guideline",
+    "status": "active",
+    "effectiveDate": "2026-04-30",
+    "agencies": [
+      "Australian Prudential Regulation Authority"
+    ],
+    "sourceUrl": "https://www.apra.gov.au/apra-letter-to-industry-on-artificial-intelligence-ai",
+    "content": "APRA published a 30 April 2026 letter to industry after targeted supervisory engagement with selected large banks, insurers and superannuation trustees in late 2025. APRA found AI adoption accelerating across regulated industries while governance, risk management, assurance and operational resilience practices were not keeping pace. The letter says APRA is engaging across the sector on increased cyber threats from high capability frontier AI models such as Anthropic Mythos, and expects entities to manage AI risk through board literacy, risk appetite, oversight and accountability, stronger information security controls, timely patching, vulnerability remediation, attention to third-party and concentration risks, and credible fallback processes for critical operations. APRA says it may take stronger supervisory action or enforcement where entities fail to identify, manage or control AI risks proportionate to their size, scale and complexity.",
+    "aiSummary": "APRA guidance requiring regulated financial entities to lift AI governance, assurance, cyber resilience and operational-risk controls in response to fast-moving AI risks including Anthropic Mythos.",
+    "tags": ["APRA", "financial system", "AI governance", "operational resilience", "cyber security", "Claude Mythos", "prudential supervision"],
+    "createdAt": "2026-05-01T00:00:00Z",
+    "updatedAt": "2026-05-01T00:00:00Z"
   }
 ]

--- a/public/data/sample-timeline.json
+++ b/public/data/sample-timeline.json
@@ -107,5 +107,34 @@
     "jurisdiction": "federal",
     "relatedPolicyId": "policy-responsible-use-ai-government-v2",
     "sourceUrl": "https://www.digital.gov.au/ai/ai-in-government-policy"
+  },
+  {
+    "id": "12",
+    "date": "2026-04-08",
+    "title": "ASIC Warns on AI-Powered Investment Scams",
+    "description": "ASIC announces expanded takedown action against phishing and investment scam websites and warns that AI-generated videos, fake endorsements and targeted ads are making financial scams more convincing.",
+    "type": "announcement",
+    "jurisdiction": "federal",
+    "sourceUrl": "https://www.asic.gov.au/about-asic/news-centre/find-a-media-release/2026-releases/26-063mr-asic-ramps-up-action-to-protect-consumers-from-ai-powered-online-investment-scams/"
+  },
+  {
+    "id": "13",
+    "date": "2026-04-09",
+    "title": "ASD Issues Frontier AI Cyber Security Guidance",
+    "description": "ASD publishes guidance on frontier AI models after Anthropic's Claude Mythos Preview announcement, warning that AI can accelerate vulnerability discovery and exploitation while also supporting defensive remediation.",
+    "type": "policy_introduced",
+    "jurisdiction": "federal",
+    "relatedPolicyId": "asd-frontier-ai-models-cyber-security-2026",
+    "sourceUrl": "https://www.cyber.gov.au/about-us/view-all-content/news/frontier-models-and-their-impact-on-cyber-security"
+  },
+  {
+    "id": "14",
+    "date": "2026-04-30",
+    "title": "APRA Calls for Step-Change in AI Risk Management",
+    "description": "APRA publishes an industry letter warning banks, insurers and superannuation trustees that AI governance, assurance and operational resilience practices are not keeping pace with AI adoption and frontier-model cyber risks.",
+    "type": "policy_introduced",
+    "jurisdiction": "federal",
+    "relatedPolicyId": "apra-ai-industry-letter-2026",
+    "sourceUrl": "https://www.apra.gov.au/apra-letter-to-industry-on-artificial-intelligence-ai"
   }
 ]

--- a/src/app/api/admin/pending/route.test.ts
+++ b/src/app/api/admin/pending/route.test.ts
@@ -1,0 +1,137 @@
+/* @vitest-environment node */
+
+import { NextResponse } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildPolicy } from '@/test/factories'
+
+const {
+  verifyAuth,
+  getSourceReviews,
+  createSourceReview,
+  updateSourceReview,
+  deleteSourceReview,
+} = vi.hoisted(() => ({
+  verifyAuth: vi.fn(),
+  getSourceReviews: vi.fn(),
+  createSourceReview: vi.fn(),
+  updateSourceReview: vi.fn(),
+  deleteSourceReview: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({
+  verifyAuth,
+  unauthorizedResponse: () =>
+    NextResponse.json(
+      { error: 'Unauthorized - Admin authentication required', success: false },
+      { status: 401 },
+    ),
+}))
+
+vi.mock('@/lib/data-service', () => ({
+  createSourceReview,
+  deleteSourceReview,
+  getSourceReviews,
+  updateSourceReview,
+}))
+
+import { GET, POST, PUT } from './route'
+
+function buildSourceReview() {
+  return {
+    id: 'source-review-1',
+    sourceUrl: 'https://example.gov.au/source',
+    title: 'Source title',
+    entryKind: 'policy',
+    status: 'pending_review',
+    discoveredAt: '2026-05-01T00:00:00.000Z',
+    createdBy: 'admin',
+    analysis: {
+      isRelevant: true,
+      relevanceScore: 0.9,
+      suggestedType: 'guideline',
+      suggestedJurisdiction: 'federal',
+      summary: 'Relevant source.',
+      tags: ['ai'],
+      agencies: ['Agency'],
+    },
+    proposedRecord: buildPolicy({ id: 'source-title' }),
+    updatedAt: '2026-05-01T00:00:00.000Z',
+  }
+}
+
+describe('/api/admin/pending', () => {
+  beforeEach(() => {
+    verifyAuth.mockReset()
+    getSourceReviews.mockReset()
+    createSourceReview.mockReset()
+    updateSourceReview.mockReset()
+    deleteSourceReview.mockReset()
+  })
+
+  it('returns source reviews in the existing pending-item response shape', async () => {
+    verifyAuth.mockResolvedValue({ id: 'admin' })
+    getSourceReviews.mockResolvedValue([buildSourceReview()])
+
+    const response = await GET(new Request('https://example.com/api/admin/pending'))
+
+    await expect(response.json()).resolves.toEqual({
+      data: [
+        expect.objectContaining({
+          id: 'source-review-1',
+          source: 'https://example.gov.au/source',
+          aiAnalysis: expect.objectContaining({ summary: 'Relevant source.' }),
+        }),
+      ],
+      total: 1,
+      success: true,
+    })
+  })
+
+  it('creates source reviews from analysed URL payloads', async () => {
+    verifyAuth.mockResolvedValue({ id: 'admin', email: 'admin@example.com' })
+    createSourceReview.mockImplementation(async (review) => review)
+
+    const response = await POST(
+      new Request('https://example.com/api/admin/pending', {
+        method: 'POST',
+        body: JSON.stringify({
+          url: 'https://example.gov.au/source',
+          title: 'Source title',
+          analysis: {
+            isRelevant: true,
+            relevanceScore: 0.9,
+            policyType: 'guideline',
+            jurisdiction: 'federal',
+            summary: 'Relevant source.',
+            tags: ['ai'],
+            agencies: ['Agency'],
+          },
+        }),
+      }),
+    )
+
+    expect(createSourceReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceUrl: 'https://example.gov.au/source',
+        title: 'Source title',
+        createdBy: 'admin@example.com',
+      }),
+    )
+    expect(response.status).toBe(200)
+  })
+
+  it('updates source review status for existing admin approval flow', async () => {
+    verifyAuth.mockResolvedValue({ id: 'admin' })
+    updateSourceReview.mockResolvedValue({ ...buildSourceReview(), status: 'approved' })
+
+    const response = await PUT(
+      new Request('https://example.com/api/admin/pending', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 'source-review-1', status: 'approved' }),
+      }),
+    )
+
+    expect(updateSourceReview).toHaveBeenCalledWith('source-review-1', { status: 'approved' })
+    expect(response.status).toBe(200)
+  })
+})

--- a/src/app/api/admin/pending/route.ts
+++ b/src/app/api/admin/pending/route.ts
@@ -1,33 +1,40 @@
 import { NextResponse } from 'next/server';
-import path from 'path';
 import { verifyAuth, unauthorizedResponse } from '@/lib/auth';
-import { readJsonFile, writeJsonFile } from '@/lib/file-store';
+import {
+  createSourceReview,
+  deleteSourceReview,
+  getSourceReviews,
+  updateSourceReview,
+} from '@/lib/data-service';
+import type { Policy, SourceReview, SourceReviewStatus, TimelineEvent } from '@/types';
 
-interface PendingItem {
-  id: string;
-  title: string;
-  source: string;
-  discoveredAt: string;
-  status: 'pending_review' | 'approved' | 'rejected';
-  aiAnalysis: {
-    isRelevant: boolean;
-    relevanceScore: number;
-    suggestedType: string | null;
-    suggestedJurisdiction: string | null;
-    summary: string;
-    tags?: string[];
-    agencies?: string[];
+function toPendingItem(review: SourceReview) {
+  return {
+    id: review.id,
+    title: review.title,
+    source: review.sourceUrl,
+    discoveredAt: review.discoveredAt,
+    status: review.status,
+    aiAnalysis: {
+      isRelevant: review.analysis.isRelevant,
+      relevanceScore: review.analysis.relevanceScore,
+      suggestedType: review.analysis.suggestedType,
+      suggestedJurisdiction: review.analysis.suggestedJurisdiction,
+      summary: review.analysis.summary,
+      tags: review.analysis.tags,
+      agencies: review.analysis.agencies,
+    },
+    entryKind: review.entryKind,
+    notes: review.notes,
   };
 }
 
-const PENDING_FILE_PATH = path.join(process.cwd(), 'public', 'data', 'pending-content.json');
-
-async function readPendingContent(): Promise<PendingItem[]> {
-  return readJsonFile<PendingItem[]>(PENDING_FILE_PATH, []);
-}
-
-async function writePendingContent(items: PendingItem[]): Promise<void> {
-  return writeJsonFile(PENDING_FILE_PATH, items);
+function buildPolicyId(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 50);
 }
 
 // GET - Retrieve all pending content
@@ -39,13 +46,10 @@ export async function GET(request: Request) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const status = searchParams.get('status');
+    const status = searchParams.get('status') as SourceReviewStatus | null;
 
-    let items = await readPendingContent();
-
-    if (status) {
-      items = items.filter(item => item.status === status);
-    }
+    const reviews = await getSourceReviews(status ? { status } : undefined);
+    const items = reviews.map(toPendingItem);
 
     return NextResponse.json({
       data: items,
@@ -56,7 +60,7 @@ export async function GET(request: Request) {
     console.error('Error reading pending content:', error);
     return NextResponse.json(
       { error: 'Failed to read pending content', success: false },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -70,55 +74,81 @@ export async function POST(request: Request) {
 
   try {
     const body = await request.json();
-    const { url, title, analysis } = body;
+    const { url, title, analysis, entryKind = 'policy', notes } = body;
 
     if (!url || !analysis) {
       return NextResponse.json(
         { error: 'URL and analysis are required', success: false },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    const items = await readPendingContent();
+    const now = new Date().toISOString();
+    const reviewTitle = title || 'Untitled';
+    const policyId = buildPolicyId(reviewTitle);
+    const proposedRecord: Policy | TimelineEvent = entryKind === 'timeline_event'
+      ? {
+          id: `timeline-${policyId || Date.now()}`,
+          date: now.split('T')[0],
+          title: reviewTitle,
+          description: analysis.summary || '',
+          type: 'announcement' as const,
+          jurisdiction: analysis.jurisdiction || analysis.suggestedJurisdiction || 'federal',
+          sourceUrl: url,
+        } as TimelineEvent
+      : {
+          id: policyId,
+          title: reviewTitle,
+          description: analysis.summary || '',
+          jurisdiction: analysis.jurisdiction || analysis.suggestedJurisdiction || 'federal',
+          type: analysis.policyType || analysis.suggestedType || 'guideline',
+          status: 'active',
+          effectiveDate: now.split('T')[0],
+          agencies: analysis.agencies || [],
+          sourceUrl: url,
+          content: analysis.summary || '',
+          aiSummary: analysis.summary || '',
+          tags: analysis.tags || [],
+          createdAt: now,
+          updatedAt: now,
+        } as Policy;
 
-    // Check if URL already exists
-    const existingIndex = items.findIndex(item => item.source === url);
-    if (existingIndex !== -1) {
-      return NextResponse.json(
-        { error: 'URL already exists in pending content', success: false },
-        { status: 400 }
-      );
-    }
-
-    const newItem: PendingItem = {
-      id: `pending-${Date.now()}`,
-      title: title || 'Untitled',
-      source: url,
-      discoveredAt: new Date().toISOString(),
+    const review = await createSourceReview({
+      id: `source-review-${Date.now()}`,
+      sourceUrl: url,
+      title: reviewTitle,
+      entryKind,
       status: 'pending_review',
-      aiAnalysis: {
+      discoveredAt: now,
+      createdBy: typeof user.email === 'string' ? user.email : user.id || 'admin',
+      notes,
+      analysis: {
         isRelevant: analysis.isRelevant,
         relevanceScore: analysis.relevanceScore,
-        suggestedType: analysis.policyType || null,
-        suggestedJurisdiction: analysis.jurisdiction || null,
+        suggestedType: analysis.policyType || analysis.suggestedType || null,
+        suggestedJurisdiction: analysis.jurisdiction || analysis.suggestedJurisdiction || null,
         summary: analysis.summary,
         tags: analysis.tags,
         agencies: analysis.agencies,
       },
-    };
-
-    items.unshift(newItem);
-    await writePendingContent(items);
+      proposedRecord,
+      updatedAt: now,
+    });
 
     return NextResponse.json({
-      data: newItem,
+      data: toPendingItem(review),
       success: true,
     });
   } catch (error) {
     console.error('Error adding pending content:', error);
     return NextResponse.json(
-      { error: 'Failed to add pending content', success: false },
-      { status: 500 }
+      {
+        error: error instanceof Error && error.name === 'DuplicatePolicyError'
+          ? 'URL already exists in tracked or pending content'
+          : 'Failed to add pending content',
+        success: false,
+      },
+      { status: error instanceof Error && error.name === 'DuplicatePolicyError' ? 400 : 500 },
     );
   }
 }
@@ -137,39 +167,34 @@ export async function PUT(request: Request) {
     if (!id || !status) {
       return NextResponse.json(
         { error: 'ID and status are required', success: false },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    if (!['pending_review', 'approved', 'rejected'].includes(status)) {
+    if (!['pending_review', 'approved', 'published', 'rejected'].includes(status)) {
       return NextResponse.json(
         { error: 'Invalid status', success: false },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    const items = await readPendingContent();
-    const itemIndex = items.findIndex(item => item.id === id);
-
-    if (itemIndex === -1) {
+    const updated = await updateSourceReview(id, { status });
+    if (!updated) {
       return NextResponse.json(
         { error: 'Pending content not found', success: false },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
-    items[itemIndex].status = status;
-    await writePendingContent(items);
-
     return NextResponse.json({
-      data: items[itemIndex],
+      data: toPendingItem(updated),
       success: true,
     });
   } catch (error) {
     console.error('Error updating pending content:', error);
     return NextResponse.json(
       { error: 'Failed to update pending content', success: false },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -188,21 +213,17 @@ export async function DELETE(request: Request) {
     if (!id) {
       return NextResponse.json(
         { error: 'ID is required', success: false },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
-    const items = await readPendingContent();
-    const filteredItems = items.filter(item => item.id !== id);
-
-    if (items.length === filteredItems.length) {
+    const deleted = await deleteSourceReview(id);
+    if (!deleted) {
       return NextResponse.json(
         { error: 'Pending content not found', success: false },
-        { status: 404 }
+        { status: 404 },
       );
     }
-
-    await writePendingContent(filteredItems);
 
     return NextResponse.json({
       success: true,
@@ -211,7 +232,7 @@ export async function DELETE(request: Request) {
     console.error('Error deleting pending content:', error);
     return NextResponse.json(
       { error: 'Failed to delete pending content', success: false },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/src/components/admin/ReviewTab.tsx
+++ b/src/components/admin/ReviewTab.tsx
@@ -26,7 +26,7 @@ export interface PendingItem {
   title: string;
   source: string;
   discoveredAt: string;
-  status: 'pending_review' | 'approved' | 'rejected';
+  status: 'pending_review' | 'approved' | 'published' | 'rejected';
   aiAnalysis: {
     isRelevant: boolean;
     relevanceScore: number;

--- a/src/lib/data-service.test.ts
+++ b/src/lib/data-service.test.ts
@@ -166,4 +166,65 @@ describe('data-service JSON fallback', () => {
     expect(persistedRuns[0]).toEqual(expect.objectContaining({ id: 'latest-run' }))
     expect(persistedRuns.at(-1)).toEqual(expect.objectContaining({ id: 'existing-98' }))
   })
+
+  it('detects duplicate source URLs across tracked policies', async () => {
+    const existing = buildPolicy({ sourceUrl: 'https://example.gov.au/policy' })
+    readJsonFile.mockImplementation(async (filePath: string, fallback: unknown) => {
+      if (filePath.endsWith('sample-policies.json')) return [existing]
+      return fallback
+    })
+
+    const { sourceUrlExists } = await loadDataServiceModule()
+
+    await expect(sourceUrlExists('https://example.gov.au/policy')).resolves.toBe(true)
+  })
+
+  it('creates source reviews in the JSON fallback after duplicate checks', async () => {
+    readJsonFile.mockImplementation(async (_filePath: string, fallback: unknown) => fallback)
+
+    const { createSourceReview } = await loadDataServiceModule()
+    const review = await createSourceReview({
+      id: 'source-review-1',
+      sourceUrl: 'https://example.gov.au/new-policy',
+      title: 'New policy',
+      entryKind: 'policy',
+      status: 'pending_review',
+      discoveredAt: '2026-05-01T00:00:00.000Z',
+      createdBy: 'local-mcp-admin',
+      analysis: {
+        isRelevant: true,
+        relevanceScore: 0.9,
+        suggestedType: 'guideline',
+        suggestedJurisdiction: 'federal',
+        summary: 'A relevant policy.',
+      },
+      proposedRecord: buildPolicy({
+        id: 'new-policy',
+        sourceUrl: 'https://example.gov.au/new-policy',
+      }),
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    })
+
+    expect(review.id).toBe('source-review-1')
+    expect(writeJsonFile).toHaveBeenCalledWith(
+      expect.stringContaining('source-reviews.json'),
+      [expect.objectContaining({ id: 'source-review-1' })],
+    )
+  })
+
+  it('creates manual timeline events in the JSON fallback', async () => {
+    readJsonFile.mockImplementation(async (_filePath: string, fallback: unknown) => fallback)
+
+    const { createTimelineEvent } = await loadDataServiceModule()
+    const event = buildTimelineEvent({
+      id: 'timeline-new',
+      sourceUrl: 'https://example.gov.au/timeline-new',
+    })
+
+    await expect(createTimelineEvent(event)).resolves.toEqual(event)
+    expect(writeJsonFile).toHaveBeenCalledWith(
+      expect.stringContaining('sample-timeline.json'),
+      [event],
+    )
+  })
 })

--- a/src/lib/data-service.ts
+++ b/src/lib/data-service.ts
@@ -11,7 +11,15 @@
 
 import path from 'path';
 import { readJsonFile, writeJsonFile } from '@/lib/file-store';
-import type { Policy, Agency, TimelineEvent, ScraperRunLog } from '@/types';
+import type {
+  Policy,
+  Agency,
+  TimelineEvent,
+  ScraperRunLog,
+  SourceReview,
+  SourceReviewStatus,
+  McpAuditLog,
+} from '@/types';
 
 // ---------------------------------------------------------------------------
 // Supabase availability
@@ -96,6 +104,9 @@ const POLICIES_FILE = path.join(process.cwd(), 'public', 'data', 'sample-policie
 const AGENCIES_FILE = path.join(process.cwd(), 'public', 'data', 'sample-agencies.json');
 const COMMONWEALTH_AGENCIES_FILE = path.join(process.cwd(), 'public', 'data', 'commonwealth-agencies.json');
 const TIMELINE_FILE = path.join(process.cwd(), 'public', 'data', 'sample-timeline.json');
+const SOURCE_REVIEWS_FILE = path.join(process.cwd(), 'data', 'source-reviews.json');
+const LEGACY_PENDING_CONTENT_FILE = path.join(process.cwd(), 'public', 'data', 'pending-content.json');
+const MCP_AUDIT_LOG_FILE = path.join(process.cwd(), 'data', 'mcp-audit-log.json');
 
 // ---------------------------------------------------------------------------
 // Policy operations
@@ -360,6 +371,228 @@ export async function policyExistsBySourceUrl(sourceUrl: string): Promise<boolea
 }
 
 // ---------------------------------------------------------------------------
+// Source review operations
+// ---------------------------------------------------------------------------
+
+interface LegacyPendingItem {
+  id: string;
+  title: string;
+  source: string;
+  discoveredAt: string;
+  status: 'pending_review' | 'approved' | 'rejected';
+  aiAnalysis: SourceReview['analysis'];
+}
+
+function createPolicyFromReview(item: LegacyPendingItem): Policy {
+  const now = new Date().toISOString();
+  const id = item.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 50);
+
+  return {
+    id,
+    title: item.title,
+    description: item.aiAnalysis.summary,
+    jurisdiction: (item.aiAnalysis.suggestedJurisdiction as Policy['jurisdiction']) || 'federal',
+    type: (item.aiAnalysis.suggestedType as Policy['type']) || 'guideline',
+    status: 'active',
+    effectiveDate: item.discoveredAt.split('T')[0] || now.split('T')[0],
+    agencies: item.aiAnalysis.agencies || [],
+    sourceUrl: item.source,
+    content: item.aiAnalysis.summary,
+    aiSummary: item.aiAnalysis.summary,
+    tags: item.aiAnalysis.tags || [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function legacyPendingToSourceReview(item: LegacyPendingItem): SourceReview {
+  return {
+    id: item.id,
+    sourceUrl: item.source,
+    title: item.title,
+    entryKind: 'policy',
+    status: item.status,
+    discoveredAt: item.discoveredAt,
+    createdBy: 'legacy-admin-review',
+    analysis: item.aiAnalysis,
+    proposedRecord: createPolicyFromReview(item),
+    updatedAt: item.discoveredAt,
+  };
+}
+
+async function readSourceReviewsFromJson(): Promise<SourceReview[]> {
+  const reviews = await readJsonFile<SourceReview[]>(SOURCE_REVIEWS_FILE, []);
+  if (reviews.length > 0) return reviews;
+
+  const legacyItems = await readJsonFile<LegacyPendingItem[]>(LEGACY_PENDING_CONTENT_FILE, []);
+  return legacyItems.map(legacyPendingToSourceReview);
+}
+
+export async function getSourceReviews(filters?: {
+  status?: SourceReviewStatus;
+}): Promise<SourceReview[]> {
+  if (isSupabaseAdminConfigured) {
+    try {
+      const supabase = await getSupabaseAdmin();
+      let query = supabase.from('source_reviews').select('*');
+      if (filters?.status) query = query.eq('status', filters.status);
+      const { data, error } = await query.order('discoveredAt', { ascending: false });
+      if (!error && data) return data as SourceReview[];
+      console.warn('[data-service] Supabase getSourceReviews failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase getSourceReviews exception, falling back to JSON:', err);
+    }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for getSourceReviews');
+  }
+
+  let reviews = await readSourceReviewsFromJson();
+  if (filters?.status) {
+    reviews = reviews.filter((review) => review.status === filters.status);
+  }
+  return reviews.sort(
+    (a, b) => new Date(b.discoveredAt).getTime() - new Date(a.discoveredAt).getTime(),
+  );
+}
+
+export async function getSourceReviewById(id: string): Promise<SourceReview | null> {
+  if (isSupabaseAdminConfigured) {
+    try {
+      const supabase = await getSupabaseAdmin();
+      const { data, error } = await supabase
+        .from('source_reviews')
+        .select('*')
+        .eq('id', id)
+        .maybeSingle();
+      if (!error && data) return data as SourceReview;
+      if (!error) return null;
+      console.warn('[data-service] Supabase getSourceReviewById failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase getSourceReviewById exception, falling back to JSON:', err);
+    }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for getSourceReviewById');
+  }
+
+  const reviews = await readSourceReviewsFromJson();
+  return reviews.find((review) => review.id === id) || null;
+}
+
+export async function createSourceReview(review: SourceReview): Promise<SourceReview> {
+  if (await sourceUrlExists(review.sourceUrl)) {
+    throw new DuplicatePolicyError(review.sourceUrl);
+  }
+
+  if (isSupabaseAdminConfigured) {
+    try {
+      const supabase = await getSupabaseAdmin();
+      const { data, error } = await supabase
+        .from('source_reviews')
+        .insert(review)
+        .select()
+        .single();
+      if (!error && data) return data as SourceReview;
+      if (isSupabaseDuplicateError(error?.message)) {
+        throw new DuplicatePolicyError(review.sourceUrl);
+      }
+      console.warn('[data-service] Supabase createSourceReview failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      if (err instanceof DuplicatePolicyError) {
+        throw err;
+      }
+      console.warn('[data-service] Supabase createSourceReview exception, falling back to JSON:', err);
+    }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for createSourceReview');
+  }
+
+  const reviews = await readSourceReviewsFromJson();
+  if (reviews.some((existing) => existing.id === review.id || existing.sourceUrl === review.sourceUrl)) {
+    throw new DuplicatePolicyError(review.sourceUrl);
+  }
+  reviews.unshift(review);
+  await writeJsonFile(SOURCE_REVIEWS_FILE, reviews);
+  return review;
+}
+
+export async function updateSourceReview(
+  id: string,
+  updates: Partial<SourceReview>,
+): Promise<SourceReview | null> {
+  const nextUpdates = { ...updates, updatedAt: new Date().toISOString() };
+
+  if (isSupabaseAdminConfigured) {
+    try {
+      const supabase = await getSupabaseAdmin();
+      const { data, error } = await supabase
+        .from('source_reviews')
+        .update(nextUpdates)
+        .eq('id', id)
+        .select()
+        .single();
+      if (!error && data) return data as SourceReview;
+      console.warn('[data-service] Supabase updateSourceReview failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase updateSourceReview exception, falling back to JSON:', err);
+    }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for updateSourceReview');
+  }
+
+  const reviews = await readSourceReviewsFromJson();
+  const idx = reviews.findIndex((review) => review.id === id);
+  if (idx === -1) return null;
+  reviews[idx] = { ...reviews[idx], ...nextUpdates };
+  await writeJsonFile(SOURCE_REVIEWS_FILE, reviews);
+  return reviews[idx];
+}
+
+export async function deleteSourceReview(id: string): Promise<boolean> {
+  if (isSupabaseAdminConfigured) {
+    try {
+      const supabase = await getSupabaseAdmin();
+      const { error } = await supabase.from('source_reviews').delete().eq('id', id);
+      if (!error) return true;
+      console.warn('[data-service] Supabase deleteSourceReview failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase deleteSourceReview exception, falling back to JSON:', err);
+    }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for deleteSourceReview');
+  }
+
+  const reviews = await readSourceReviewsFromJson();
+  const filtered = reviews.filter((review) => review.id !== id);
+  if (filtered.length === reviews.length) return false;
+  await writeJsonFile(SOURCE_REVIEWS_FILE, filtered);
+  return true;
+}
+
+export async function sourceUrlExists(
+  sourceUrl: string,
+  options: {
+    excludeSourceReviewId?: string;
+  } = {},
+): Promise<boolean> {
+  if (await policyExistsBySourceUrl(sourceUrl)) return true;
+
+  const timelineEvents = await getTimelineEvents(undefined, { includeGenerated: false });
+  if (timelineEvents.some((event) => event.sourceUrl === sourceUrl)) return true;
+
+  const sourceReviews = await getSourceReviews();
+  return sourceReviews.some(
+    (review) =>
+      review.sourceUrl === sourceUrl &&
+      review.id !== options.excludeSourceReviewId &&
+      review.status !== 'rejected',
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Agency operations
 // ---------------------------------------------------------------------------
 
@@ -430,12 +663,78 @@ export async function getCommonwealthAgencies(
 // Timeline operations
 // ---------------------------------------------------------------------------
 
-export async function getTimelineEvents(filters?: {
-  jurisdiction?: string;
-}): Promise<TimelineEvent[]> {
+async function getManualTimelineEvents(): Promise<TimelineEvent[]> {
+  if (isSupabaseConfigured) {
+    try {
+      const supabase = isSupabaseAdminConfigured ? await getSupabaseAdmin() : await getSupabase();
+      const { data, error } = await supabase
+        .from('timeline_events')
+        .select('*')
+        .order('date', { ascending: true });
+      if (!error && data) return data as TimelineEvent[];
+      console.warn('[data-service] Supabase getManualTimelineEvents failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase getManualTimelineEvents exception, falling back to JSON:', err);
+    }
+  }
+
+  return readJsonFile<TimelineEvent[]>(TIMELINE_FILE, []);
+}
+
+export async function createTimelineEvent(
+  event: TimelineEvent,
+  options: {
+    excludeSourceReviewId?: string;
+  } = {},
+): Promise<TimelineEvent> {
+  if (event.sourceUrl && (await sourceUrlExists(event.sourceUrl, options))) {
+    throw new DuplicatePolicyError(event.sourceUrl);
+  }
+
+  if (isSupabaseAdminConfigured) {
+    try {
+      const supabase = await getSupabaseAdmin();
+      const { data, error } = await supabase
+        .from('timeline_events')
+        .insert(event)
+        .select()
+        .single();
+      if (!error && data) return data as TimelineEvent;
+      if (isSupabaseDuplicateError(error?.message)) {
+        throw new DuplicatePolicyError(event.id);
+      }
+      console.warn('[data-service] Supabase createTimelineEvent failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      if (err instanceof DuplicatePolicyError) {
+        throw err;
+      }
+      console.warn('[data-service] Supabase createTimelineEvent exception, falling back to JSON:', err);
+    }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for createTimelineEvent');
+  }
+
+  const events = await readJsonFile<TimelineEvent[]>(TIMELINE_FILE, []);
+  if (events.some((existing) => existing.id === event.id || (event.sourceUrl && existing.sourceUrl === event.sourceUrl))) {
+    throw new DuplicatePolicyError(event.id);
+  }
+  events.push(event);
+  await writeJsonFile(TIMELINE_FILE, events);
+  return event;
+}
+
+export async function getTimelineEvents(
+  filters?: {
+    jurisdiction?: string;
+  },
+  options: {
+    includeGenerated?: boolean;
+  } = {},
+): Promise<TimelineEvent[]> {
+  const includeGenerated = options.includeGenerated ?? true;
   // Generate timeline events from policies + merge with manual curated events
-  const policies = await getPolicies();
-  const manualEvents = await readJsonFile<TimelineEvent[]>(TIMELINE_FILE, []);
+  const policies = includeGenerated ? await getPolicies() : [];
+  const manualEvents = await getManualTimelineEvents();
 
   // Build a set of relatedPolicyIds from manual events for dedup
   const manualPolicyIds = new Set(
@@ -463,6 +762,25 @@ export async function getTimelineEvents(filters?: {
   }
 
   return events.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}
+
+export async function logMcpAuditEvent(log: McpAuditLog): Promise<void> {
+  if (isSupabaseAdminConfigured) {
+    try {
+      const supabase = await getSupabaseAdmin();
+      const { error } = await supabase.from('mcp_audit_log').insert(log);
+      if (!error) return;
+      console.warn('[data-service] Supabase logMcpAuditEvent failed, falling back to JSON:', error?.message);
+    } catch (err) {
+      console.warn('[data-service] Supabase logMcpAuditEvent exception, falling back to JSON:', err);
+    }
+  } else if (isSupabaseConfigured) {
+    console.warn('[data-service] SUPABASE_SERVICE_ROLE_KEY is not configured; falling back to JSON for logMcpAuditEvent');
+  }
+
+  const logs = await readJsonFile<McpAuditLog[]>(MCP_AUDIT_LOG_FILE, []);
+  logs.unshift(log);
+  await writeJsonFile(MCP_AUDIT_LOG_FILE, logs.slice(0, 500));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/file-store.test.ts
+++ b/src/lib/file-store.test.ts
@@ -2,13 +2,15 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { readFile, writeFile } = vi.hoisted(() => ({
+const { mkdir, readFile, writeFile } = vi.hoisted(() => ({
+  mkdir: vi.fn(),
   readFile: vi.fn(),
   writeFile: vi.fn(),
 }))
 
 vi.mock('fs', () => ({
   promises: {
+    mkdir,
     readFile,
     writeFile,
   },
@@ -19,6 +21,7 @@ import { readJsonFile, writeJsonFile } from './file-store'
 describe('file-store', () => {
   beforeEach(() => {
     readFile.mockReset()
+    mkdir.mockReset()
     writeFile.mockReset()
   })
 
@@ -44,6 +47,7 @@ describe('file-store', () => {
     it('writes pretty-printed JSON', async () => {
       await writeJsonFile('/tmp/out.json', { ok: true })
 
+      expect(mkdir).toHaveBeenCalledWith('/tmp', { recursive: true })
       expect(writeFile).toHaveBeenCalledWith('/tmp/out.json', '{\n  "ok": true\n}', 'utf-8')
     })
   })

--- a/src/lib/file-store.ts
+++ b/src/lib/file-store.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+import path from 'path';
 
 /**
  * Read and parse a JSON file, returning the fallback value if the file
@@ -17,5 +18,6 @@ export async function readJsonFile<T>(filePath: string, fallback: T): Promise<T>
  * Write data to a JSON file with pretty-printing.
  */
 export async function writeJsonFile<T>(filePath: string, data: T): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
 }

--- a/src/lib/source-ingest.test.ts
+++ b/src/lib/source-ingest.test.ts
@@ -1,0 +1,22 @@
+/* @vitest-environment node */
+
+import { describe, expect, it } from 'vitest'
+import { validateSourceUrl } from './source-ingest'
+
+describe('source-ingest validation', () => {
+  it('accepts official .gov.au sources', () => {
+    expect(validateSourceUrl('https://www.apra.gov.au/example')).toEqual(
+      expect.objectContaining({ isGovAu: true }),
+    )
+  })
+
+  it('rejects non-government sources unless they are explicitly stage-only', () => {
+    expect(() => validateSourceUrl('https://www.abc.net.au/news/example')).toThrow(
+      'Only .gov.au URLs can be analysed or published directly',
+    )
+
+    expect(validateSourceUrl('https://www.abc.net.au/news/example', { stageOnly: true })).toEqual(
+      expect.objectContaining({ isGovAu: false }),
+    )
+  })
+})

--- a/src/lib/source-ingest.ts
+++ b/src/lib/source-ingest.ts
@@ -1,0 +1,278 @@
+import { randomUUID } from 'node:crypto';
+import { analyseContentRelevance } from '@/lib/claude';
+import { cleanHtmlContent } from '@/lib/utils';
+import {
+  createPolicy,
+  createSourceReview,
+  createTimelineEvent,
+  getPolicies,
+  getSourceReviewById,
+  getSourceReviews,
+  getTimelineEvents,
+  logMcpAuditEvent,
+  sourceUrlExists,
+  updateSourceReview,
+} from '@/lib/data-service';
+import type {
+  McpAuditLog,
+  Policy,
+  SourceReview,
+  SourceReviewEntryKind,
+  SourceReviewStatus,
+  TimelineEvent,
+} from '@/types';
+
+export interface SourceAnalysisResult {
+  url: string;
+  title: string;
+  cleanContent: string;
+  analysis: {
+    isRelevant: boolean;
+    relevanceScore: number;
+    policyType?: string | null;
+    jurisdiction?: string | null;
+    summary: string;
+    tags?: string[];
+    agencies?: string[];
+  };
+  discoveredAt: string;
+}
+
+export function validateSourceUrl(url: string, options: { stageOnly?: boolean } = {}) {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('Invalid URL format');
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new Error('Only HTTP/HTTPS URLs are allowed');
+  }
+
+  const isGovAu = parsed.hostname.endsWith('.gov.au');
+  if (!isGovAu && !options.stageOnly) {
+    throw new Error('Only .gov.au URLs can be analysed or published directly');
+  }
+
+  return { parsed, isGovAu };
+}
+
+export async function analyseSourceUrl(url: string, options: { stageOnly?: boolean } = {}): Promise<SourceAnalysisResult> {
+  validateSourceUrl(url, options);
+
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'Policai/1.0 (Australian AI Policy Tracker)',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch URL: ${response.statusText}`);
+  }
+
+  const html = await response.text();
+  const cleanContent = cleanHtmlContent(html);
+  const analysis = await analyseContentRelevance(cleanContent, url);
+  const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+  const title = titleMatch ? titleMatch[1].trim() : new URL(url).hostname;
+
+  return {
+    url,
+    title,
+    cleanContent,
+    analysis,
+    discoveredAt: new Date().toISOString(),
+  };
+}
+
+function slugify(value: string, maxLength = 60): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, maxLength);
+}
+
+export function buildProposedRecord(
+  entryKind: SourceReviewEntryKind,
+  analysisResult: SourceAnalysisResult,
+): Policy | TimelineEvent {
+  const now = new Date().toISOString();
+  const baseId = slugify(analysisResult.title || new URL(analysisResult.url).hostname) || randomUUID();
+  const jurisdiction = (analysisResult.analysis.jurisdiction || 'federal') as Policy['jurisdiction'];
+
+  if (entryKind === 'timeline_event') {
+    return {
+      id: `timeline-${baseId}`,
+      date: now.split('T')[0],
+      title: analysisResult.title,
+      description: analysisResult.analysis.summary,
+      type: 'announcement',
+      jurisdiction,
+      sourceUrl: analysisResult.url,
+    };
+  }
+
+  return {
+    id: baseId,
+    title: analysisResult.title,
+    description: analysisResult.analysis.summary,
+    jurisdiction,
+    type: (analysisResult.analysis.policyType || 'guideline') as Policy['type'],
+    status: 'active',
+    effectiveDate: now.split('T')[0],
+    agencies: analysisResult.analysis.agencies || [],
+    sourceUrl: analysisResult.url,
+    content: analysisResult.cleanContent.slice(0, 4000),
+    aiSummary: analysisResult.analysis.summary,
+    tags: analysisResult.analysis.tags || [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function stageSourceUrl(input: {
+  url: string;
+  entryKind: SourceReviewEntryKind;
+  notes?: string;
+  actor: string;
+  stageOnly?: boolean;
+}): Promise<SourceReview> {
+  validateSourceUrl(input.url, { stageOnly: input.stageOnly });
+  if (await sourceUrlExists(input.url)) {
+    throw new Error('Source URL already exists in tracked or staged content');
+  }
+
+  const analysisResult = await analyseSourceUrl(input.url, { stageOnly: input.stageOnly });
+  const proposedRecord = buildProposedRecord(input.entryKind, analysisResult);
+  const now = new Date().toISOString();
+
+  return createSourceReview({
+    id: `source-review-${randomUUID()}`,
+    sourceUrl: input.url,
+    title: analysisResult.title,
+    entryKind: input.entryKind,
+    status: 'pending_review',
+    discoveredAt: now,
+    createdBy: input.actor,
+    notes: input.notes,
+    analysis: {
+      isRelevant: analysisResult.analysis.isRelevant,
+      relevanceScore: analysisResult.analysis.relevanceScore,
+      suggestedType: analysisResult.analysis.policyType || null,
+      suggestedJurisdiction: analysisResult.analysis.jurisdiction || null,
+      summary: analysisResult.analysis.summary,
+      tags: analysisResult.analysis.tags,
+      agencies: analysisResult.analysis.agencies,
+    },
+    proposedRecord,
+    updatedAt: now,
+  });
+}
+
+export async function publishStagedSource(id: string): Promise<SourceReview> {
+  const review = await getSourceReviewById(id);
+  if (!review) {
+    throw new Error('Staged source not found');
+  }
+  if (review.status === 'published') {
+    return review;
+  }
+  if (review.status === 'rejected') {
+    throw new Error('Rejected sources cannot be published');
+  }
+  validateSourceUrl(review.sourceUrl);
+
+  const duplicateExists = await sourceUrlExists(review.sourceUrl, { excludeSourceReviewId: review.id });
+  if (duplicateExists) {
+    throw new Error('Source URL already exists in tracked content');
+  }
+
+  if (review.entryKind === 'timeline_event') {
+    await createTimelineEvent(review.proposedRecord as TimelineEvent, {
+      excludeSourceReviewId: review.id,
+    });
+  } else {
+    await createPolicy(review.proposedRecord as Policy);
+  }
+
+  const updated = await updateSourceReview(review.id, {
+    status: 'published',
+    publishedAt: new Date().toISOString(),
+  });
+  if (!updated) {
+    throw new Error('Failed to update staged source after publishing');
+  }
+  return updated;
+}
+
+export async function rejectStagedSource(id: string, reason?: string): Promise<SourceReview> {
+  const updated = await updateSourceReview(id, {
+    status: 'rejected',
+    rejectionReason: reason,
+  });
+  if (!updated) {
+    throw new Error('Staged source not found');
+  }
+  return updated;
+}
+
+export async function checkCoverage(input: { query?: string; sourceUrl?: string }) {
+  const query = input.query?.toLowerCase().trim();
+  const sourceUrl = input.sourceUrl?.trim();
+  const [policies, timelineEvents, sourceReviews] = await Promise.all([
+    getPolicies(undefined, { access: 'admin' }),
+    getTimelineEvents(undefined, { includeGenerated: false }),
+    getSourceReviews(),
+  ]);
+
+  return {
+    policies: policies.filter((policy) =>
+      (sourceUrl && policy.sourceUrl === sourceUrl) ||
+      (query &&
+        [
+          policy.title,
+          policy.description,
+          policy.aiSummary,
+          policy.sourceUrl,
+          ...policy.tags,
+          ...policy.agencies,
+        ].some((value) => value.toLowerCase().includes(query))),
+    ),
+    timelineEvents: timelineEvents.filter((event) =>
+      (sourceUrl && event.sourceUrl === sourceUrl) ||
+      (query &&
+        [event.title, event.description, event.sourceUrl || ''].some((value) =>
+          value.toLowerCase().includes(query),
+        )),
+    ),
+    stagedSources: sourceReviews.filter((review) =>
+      (sourceUrl && review.sourceUrl === sourceUrl) ||
+      (query &&
+        [
+          review.title,
+          review.sourceUrl,
+          review.analysis.summary,
+          ...(review.analysis.tags || []),
+          ...(review.analysis.agencies || []),
+        ].some((value) => value.toLowerCase().includes(query))),
+    ),
+  };
+}
+
+export async function auditMcpTool(input: Omit<McpAuditLog, 'id' | 'createdAt'>): Promise<void> {
+  await logMcpAuditEvent({
+    id: `mcp-audit-${randomUUID()}`,
+    createdAt: new Date().toISOString(),
+    ...input,
+  });
+}
+
+export function normalizeReviewStatus(status?: string): SourceReviewStatus | undefined {
+  if (!status) return undefined;
+  if (['pending_review', 'approved', 'published', 'rejected'].includes(status)) {
+    return status as SourceReviewStatus;
+  }
+  throw new Error('Invalid source review status');
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env tsx
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import {
+  handleAnalyseSourceUrl,
+  handleCheckCoverage,
+  handleListStagedSources,
+  handlePublishStagedSource,
+  handleRejectStagedSource,
+  handleStageSourceUrl,
+  toToolText,
+} from './tool-handlers';
+
+const server = new McpServer({
+  name: 'policai-source-ingest',
+  version: '0.1.0',
+});
+
+server.registerTool(
+  'check_coverage',
+  {
+    title: 'Check Policai coverage',
+    description: 'Read-only search across tracked policies, manual timeline events, and staged sources.',
+    inputSchema: {
+      query: z.string().optional(),
+      sourceUrl: z.string().url().optional(),
+    },
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      destructiveHint: false,
+    },
+  },
+  async (input) => toToolText(await handleCheckCoverage(input)),
+);
+
+server.registerTool(
+  'analyse_source_url',
+  {
+    title: 'Analyse source URL',
+    description: 'Read-only analysis of an official source URL. Non-government URLs require stageOnly.',
+    inputSchema: {
+      url: z.string().url(),
+      stageOnly: z.boolean().optional(),
+    },
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: false,
+      destructiveHint: false,
+    },
+  },
+  async (input) => toToolText(await handleAnalyseSourceUrl(input)),
+);
+
+server.registerTool(
+  'stage_source_url',
+  {
+    title: 'Stage source URL',
+    description: 'Writes a source review proposal. Requires POLICAI_MCP_ADMIN_TOKEN. Does not publish.',
+    inputSchema: {
+      url: z.string().url(),
+      entryKind: z.enum(['policy', 'timeline_event']),
+      notes: z.string().optional(),
+      stageOnly: z.boolean().optional(),
+      adminToken: z.string(),
+    },
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      destructiveHint: true,
+    },
+  },
+  async (input) => toToolText(await handleStageSourceUrl(input)),
+);
+
+server.registerTool(
+  'list_staged_sources',
+  {
+    title: 'List staged sources',
+    description: 'Read-only list of staged source review proposals.',
+    inputSchema: {
+      status: z.enum(['pending_review', 'approved', 'published', 'rejected']).optional(),
+    },
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      destructiveHint: false,
+    },
+  },
+  async (input) => toToolText(await handleListStagedSources(input)),
+);
+
+server.registerTool(
+  'publish_staged_source',
+  {
+    title: 'Publish staged source',
+    description: 'Publishes a staged source review into Policai data. Requires POLICAI_MCP_ADMIN_TOKEN.',
+    inputSchema: {
+      id: z.string(),
+      adminToken: z.string(),
+    },
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      destructiveHint: true,
+    },
+  },
+  async (input) => toToolText(await handlePublishStagedSource(input)),
+);
+
+server.registerTool(
+  'reject_staged_source',
+  {
+    title: 'Reject staged source',
+    description: 'Marks a staged source rejected. Requires POLICAI_MCP_ADMIN_TOKEN.',
+    inputSchema: {
+      id: z.string(),
+      reason: z.string().optional(),
+      adminToken: z.string(),
+    },
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      destructiveHint: true,
+    },
+  },
+  async (input) => toToolText(await handleRejectStagedSource(input)),
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/mcp/tool-handlers.test.ts
+++ b/src/mcp/tool-handlers.test.ts
@@ -1,0 +1,65 @@
+/* @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { stageSourceUrl, publishStagedSource, rejectStagedSource } = vi.hoisted(() => ({
+  stageSourceUrl: vi.fn(),
+  publishStagedSource: vi.fn(),
+  rejectStagedSource: vi.fn(),
+}))
+
+vi.mock('@/lib/source-ingest', () => ({
+  analyseSourceUrl: vi.fn(),
+  auditMcpTool: vi.fn(),
+  checkCoverage: vi.fn(),
+  normalizeReviewStatus: vi.fn((status?: string) => status),
+  stageSourceUrl,
+  publishStagedSource,
+  rejectStagedSource,
+}))
+
+vi.mock('@/lib/data-service', () => ({
+  getSourceReviews: vi.fn(),
+}))
+
+import {
+  handlePublishStagedSource,
+  handleRejectStagedSource,
+  handleStageSourceUrl,
+} from './tool-handlers'
+
+const originalToken = process.env.POLICAI_MCP_ADMIN_TOKEN
+
+describe('MCP tool handlers', () => {
+  beforeEach(() => {
+    process.env.POLICAI_MCP_ADMIN_TOKEN = 'secret-token'
+    stageSourceUrl.mockReset()
+    publishStagedSource.mockReset()
+    rejectStagedSource.mockReset()
+  })
+
+  afterEach(() => {
+    process.env.POLICAI_MCP_ADMIN_TOKEN = originalToken
+  })
+
+  it('rejects mutating tools when the admin token is missing or invalid', async () => {
+    await expect(
+      handleStageSourceUrl({
+        url: 'https://example.gov.au/source',
+        entryKind: 'policy',
+      }),
+    ).rejects.toThrow('Invalid POLICAI_MCP_ADMIN_TOKEN')
+
+    await expect(
+      handlePublishStagedSource({ id: 'source-review-1', adminToken: 'wrong' }),
+    ).rejects.toThrow('Invalid POLICAI_MCP_ADMIN_TOKEN')
+
+    await expect(
+      handleRejectStagedSource({ id: 'source-review-1', adminToken: 'wrong' }),
+    ).rejects.toThrow('Invalid POLICAI_MCP_ADMIN_TOKEN')
+
+    expect(stageSourceUrl).not.toHaveBeenCalled()
+    expect(publishStagedSource).not.toHaveBeenCalled()
+    expect(rejectStagedSource).not.toHaveBeenCalled()
+  })
+})

--- a/src/mcp/tool-handlers.ts
+++ b/src/mcp/tool-handlers.ts
@@ -1,0 +1,119 @@
+import {
+  analyseSourceUrl,
+  auditMcpTool,
+  checkCoverage,
+  normalizeReviewStatus,
+  publishStagedSource,
+  rejectStagedSource,
+  stageSourceUrl,
+} from '@/lib/source-ingest';
+import { getSourceReviews } from '@/lib/data-service';
+import type { SourceReviewEntryKind } from '@/types';
+
+const MCP_ACTOR = 'local-mcp-admin';
+
+export function requireMcpAdminToken(token?: string) {
+  const expected = process.env.POLICAI_MCP_ADMIN_TOKEN;
+  if (!expected) {
+    throw new Error('POLICAI_MCP_ADMIN_TOKEN is not configured');
+  }
+  if (token !== expected) {
+    throw new Error('Invalid POLICAI_MCP_ADMIN_TOKEN');
+  }
+}
+
+export function toToolText(data: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  };
+}
+
+async function audited<T>(
+  toolName: string,
+  input: { sourceUrl?: string; adminToken?: string },
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    const result = await run();
+    await auditMcpTool({
+      actor: MCP_ACTOR,
+      toolName,
+      sourceUrl: input.sourceUrl,
+      status: 'success',
+    });
+    return result;
+  } catch (error) {
+    await auditMcpTool({
+      actor: MCP_ACTOR,
+      toolName,
+      sourceUrl: input.sourceUrl,
+      status: 'error',
+      errorSummary: error instanceof Error ? error.message.slice(0, 300) : 'Unknown error',
+    });
+    throw error;
+  }
+}
+
+export async function handleCheckCoverage(input: { query?: string; sourceUrl?: string }) {
+  if (!input.query && !input.sourceUrl) {
+    throw new Error('Either query or sourceUrl is required');
+  }
+  return checkCoverage(input);
+}
+
+export async function handleAnalyseSourceUrl(input: { url: string; stageOnly?: boolean }) {
+  const result = await analyseSourceUrl(input.url, { stageOnly: input.stageOnly });
+  return {
+    url: result.url,
+    title: result.title,
+    analysis: result.analysis,
+    discoveredAt: result.discoveredAt,
+  };
+}
+
+export async function handleStageSourceUrl(input: {
+  url: string;
+  entryKind: SourceReviewEntryKind;
+  notes?: string;
+  stageOnly?: boolean;
+  adminToken?: string;
+}) {
+  return audited('stage_source_url', { sourceUrl: input.url }, () => {
+    requireMcpAdminToken(input.adminToken);
+    return stageSourceUrl({
+      url: input.url,
+      entryKind: input.entryKind,
+      notes: input.notes,
+      actor: MCP_ACTOR,
+      stageOnly: input.stageOnly,
+    });
+  });
+}
+
+export async function handleListStagedSources(input: { status?: string }) {
+  const status = normalizeReviewStatus(input.status);
+  return getSourceReviews(status ? { status } : undefined);
+}
+
+export async function handlePublishStagedSource(input: { id: string; adminToken?: string }) {
+  return audited('publish_staged_source', {}, () => {
+    requireMcpAdminToken(input.adminToken);
+    return publishStagedSource(input.id);
+  });
+}
+
+export async function handleRejectStagedSource(input: {
+  id: string;
+  reason?: string;
+  adminToken?: string;
+}) {
+  return audited('reject_staged_source', {}, () => {
+    requireMcpAdminToken(input.adminToken);
+    return rejectStagedSource(input.id, input.reason);
+  });
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,6 +86,50 @@ export interface TimelineEvent {
   sourceUrl?: string;
 }
 
+export type SourceReviewEntryKind = 'policy' | 'timeline_event';
+
+export type SourceReviewStatus =
+  | 'pending_review'
+  | 'approved'
+  | 'published'
+  | 'rejected';
+
+export interface SourceReviewAnalysis {
+  isRelevant: boolean;
+  relevanceScore: number;
+  suggestedType: PolicyType | string | null;
+  suggestedJurisdiction: Jurisdiction | string | null;
+  summary: string;
+  tags?: string[];
+  agencies?: string[];
+}
+
+export interface SourceReview {
+  id: string;
+  sourceUrl: string;
+  title: string;
+  entryKind: SourceReviewEntryKind;
+  status: SourceReviewStatus;
+  discoveredAt: string;
+  createdBy: string;
+  notes?: string;
+  analysis: SourceReviewAnalysis;
+  proposedRecord: Policy | TimelineEvent;
+  publishedAt?: string;
+  rejectionReason?: string;
+  updatedAt: string;
+}
+
+export interface McpAuditLog {
+  id: string;
+  createdAt: string;
+  actor: string;
+  toolName: string;
+  sourceUrl?: string;
+  status: 'success' | 'error';
+  errorSummary?: string;
+}
+
 // Map visualization types
 export interface JurisdictionStats {
   jurisdiction: Jurisdiction;

--- a/supabase/migrations/002_enable_rls.sql
+++ b/supabase/migrations/002_enable_rls.sql
@@ -22,7 +22,9 @@ begin
     'scraper_runs',
     'pipeline_runs',
     'research_findings',
-    'verification_results'
+    'verification_results',
+    'source_reviews',
+    'mcp_audit_log'
   ]
   loop
     if to_regclass(format('public.%I', table_name)) is not null then

--- a/supabase/migrations/003_source_reviews_mcp.sql
+++ b/supabase/migrations/003_source_reviews_mcp.sql
@@ -1,0 +1,43 @@
+-- Staged source review and local MCP audit tables.
+-- These tables are server-managed only; public clients must not read or write.
+
+create table if not exists public.source_reviews (
+  id text primary key,
+  "sourceUrl" text not null unique,
+  title text not null,
+  "entryKind" text not null check ("entryKind" in ('policy', 'timeline_event')),
+  status text not null default 'pending_review' check (status in ('pending_review', 'approved', 'published', 'rejected')),
+  "discoveredAt" timestamptz not null,
+  "createdBy" text not null,
+  notes text,
+  analysis jsonb not null default '{}'::jsonb,
+  "proposedRecord" jsonb not null default '{}'::jsonb,
+  "publishedAt" timestamptz,
+  "rejectionReason" text,
+  "updatedAt" timestamptz not null
+);
+
+create table if not exists public.mcp_audit_log (
+  id text primary key,
+  "createdAt" timestamptz not null,
+  actor text not null,
+  "toolName" text not null,
+  "sourceUrl" text,
+  status text not null check (status in ('success', 'error')),
+  "errorSummary" text
+);
+
+create index if not exists idx_source_reviews_status
+  on public.source_reviews (status);
+
+create index if not exists idx_source_reviews_discovered_at
+  on public.source_reviews ("discoveredAt" desc);
+
+create index if not exists idx_mcp_audit_log_created_at
+  on public.mcp_audit_log ("createdAt" desc);
+
+alter table public.source_reviews enable row level security;
+alter table public.mcp_audit_log enable row level security;
+
+revoke all on table public.source_reviews from anon, authenticated;
+revoke all on table public.mcp_audit_log from anon, authenticated;


### PR DESCRIPTION
## Summary
- Adds a local-only stdio MCP server for Policai source ingest.
- Adds staged source review storage backed by Supabase with JSON fallback.
- Adds MCP tools for coverage checks, source analysis, staging, listing, publishing, and rejection.
- Refactors the existing admin pending-content route to use the shared source review helpers.
- Adds APRA/ASIC/ASD source data entries identified during the source coverage check.

## Security
- MCP v1 is stdio-only; no remote HTTP transport or OAuth surface is added.
- Mutating MCP tools require `POLICAI_MCP_ADMIN_TOKEN`.
- No raw SQL, generic Supabase table writes, shell access, or filesystem tools are exposed.
- `source_reviews` and `mcp_audit_log` have RLS enabled and grant no anon/authenticated access.
- Supabase service-role usage stays server-side through existing data-service/admin-client patterns.

## Verification
- `npm run test` passed: 14 test files, 64 tests.
- `npm run lint` passed with existing warnings only.
- MCP smoke check passed: `npm run mcp` starts cleanly.
- `git diff --cached --check` passed before commit.

## Notes
- `npx tsc --noEmit` is still blocked by pre-existing `src/lib/auth.test.ts` assignments to read-only `process.env.NODE_ENV`; no MCP-specific type error remained after fixing the stdio startup path.
- `npm audit --omit=dev` reports 3 moderate existing advisories requiring breaking upgrades; this PR does not force-upgrade them.
- Unrelated local UI edits were left unstaged and are not part of this PR.
