### PR TITLE
fix(ci): alert on collector failure and document the ruleset bypass

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
 
 concurrency:
   group: collect
@@ -24,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20.19.0
           cache: npm
@@ -72,4 +73,27 @@ jobs:
           git config user.email "policai-collector[bot]@users.noreply.github.com"
           git add public/data/developments.json public/data/meta.json data/watch-state.json data/source-reviews.json
           git commit -m "chore(data): daily collection $(date -u +%F)"
+          # Requires the GitHub Actions app as a bypass actor on the
+          # "Protect main" ruleset — see docs/collector.md.
           git push
+
+      - name: Alert on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Open (or comment on) a tracking issue so scheduled failures are
+          # never silent. Deduplicates into one open issue at a time.
+          gh label create collector-failure \
+            --description "Automated alert from collect.yml" \
+            --color D93F0B || true
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          existing=$(gh issue list --label collector-failure --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Still failing: $run_url"
+          else
+            gh issue create \
+              --title "Daily collection workflow is failing" \
+              --label collector-failure \
+              --body "$(printf 'The scheduled collector run failed.\n\nLatest failed run: %s\n\nOpened automatically by collect.yml; further failures are added as comments while this issue stays open. Close it once the workflow is green.' "$run_url")"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added failure alerting to the daily collector workflow: any failed run now opens (or comments on) a `collector-failure` issue, and the README carries a live workflow status badge.
 - Added a dedicated `/courts` page tracking judicial AI practice notes and practice directions across Australian jurisdictions.
 - Added `practice_note` as a new policy type so court instruments are a first-class category alongside legislation, guidelines, frameworks, and standards.
 - Seeded five court practice notes: Federal Court GPN-AI, Federal Circuit & Family Court practice direction, NSW SC Gen 23, Vic Supreme Court guidelines, and Qld Supreme Court practice direction.
@@ -44,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed the daily collector's push to `main` being rejected by the branch-protection ruleset (every scheduled run since 10 July had collected data and then failed to land it); the GitHub Actions app is now a documented bypass actor and the requirement is recorded in the collector docs.
 - Improved blog prose readability in dark mode.
 - Removed unsafe domain casts in pipeline/API/UI paths by normalising untrusted type and jurisdiction strings.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Policai
 
+[![Daily collection](https://github.com/l0cka/policai/actions/workflows/collect.yml/badge.svg)](https://github.com/l0cka/policai/actions/workflows/collect.yml)
+
 Policai is an Australian AI policy tracker. It maintains a curated register of AI policy, regulation, governance and court guidance across federal and state/territory jurisdictions, and automatically detects new developments from official government sources every day.
 
 Product surface:

--- a/docs/collector.md
+++ b/docs/collector.md
@@ -43,6 +43,7 @@ Note: several federal sites (dta.gov.au, industry.gov.au, ag.gov.au, and others 
 2. `npm run validate:data`
 3. Guard: fail if `public/data/policies.json` changed
 4. Commit `developments.json`, `meta.json`, `watch-state.json`, `source-reviews.json` and push
+5. On any failure: open (or comment on) an issue labelled `collector-failure` so scheduled breakage is never silent
 
 The push triggers a Vercel deployment, so the site republishes with the new data. Manual runs: Actions → "Collect AI policy developments" → Run workflow (optionally with a single source id).
 
@@ -50,6 +51,7 @@ The push triggers a Vercel deployment, so the site republishes with the new data
 
 - `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY` secret (optional, enables AI classification)
 - `AI_MODEL` repository variable (optional model override)
+- The "Protect main" ruleset must list the **GitHub Actions** app as a bypass actor (`bypass_mode: always`), otherwise the workflow's direct push to `main` is rejected with `GH013: Repository rule violations`. The safety story does not depend on the ruleset here: the registry-guard step and CI both enforce that automation never touches `policies.json`.
 
 Without secrets the workflow still runs in heuristic mode.
 
@@ -73,6 +75,7 @@ npm run collect -- --dry-run --source=<id>
 
 ## Troubleshooting
 
+- **The workflow fails at `git push` with `GH013: Repository rule violations`** — the GitHub Actions app is missing from the "Protect main" ruleset bypass list. Re-add it (Settings → Rules → Rulesets → Protect main → Bypass list) or via `gh api -X PUT repos/l0cka/policai/rulesets/<id>` with the app in `bypass_actors`.
 - **A source keeps failing** — check `meta.json` → `collector.lastRunErrors`. 403s usually mean bot protection; try from a different network, or disable the source with `enabled: false` and a `notes` explanation.
 - **Nothing new detected** — expected on most days; the feed only grows when monitored pages change. Check `watch-state.json` to confirm URLs are being seen.
 - **Validation fails in CI** — run `npm run validate:data` locally; it prints every structural error with the offending record id.


### PR DESCRIPTION
## Why

The daily collector workflow has failed at `git push` on every run since 10 July. The **Protect main** ruleset requires PRs + status checks, and the workflow pushes with the default `GITHUB_TOKEN` (the GitHub Actions app), which has no bypass — so each day's collected data was gathered, validated, and then discarded. Silently, because nothing alerted on failure.

## What

- **Alert on failure**: a `failure()` step opens (or comments on) a `collector-failure` issue linking the failed run, deduplicating into one open issue at a time. Requires the new `issues: write` permission.
- **README status badge** for the collect workflow.
- **Docs**: `docs/collector.md` now records that the GitHub Actions app must be a bypass actor on the Protect main ruleset, plus a GH013 troubleshooting entry.
- **Housekeeping**: `actions/checkout` and `actions/setup-node` bumped to v5 (clears Node 20 runner deprecation warnings).

## What this PR does *not* do

The ruleset change itself (adding the GitHub Actions app to the bypass list) is repository configuration, applied separately by the repo owner. The registry guard and CI still enforce that automation never touches `policies.json` — the bypass does not weaken that.

## Verification plan

Once the bypass actor is added and this merges: dispatch a manual run and confirm the data commit lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)