### PR TITLE
fix(ci): push collector data via the write deploy key

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -26,6 +26,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # Fetch and push over SSH as the collector deploy key, which is a
+          # bypass actor on the "Protect main" ruleset. The default
+          # GITHUB_TOKEN cannot push to main — see docs/collector.md.
+          ssh-key: ${{ secrets.COLLECTOR_DEPLOY_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -73,8 +78,6 @@ jobs:
           git config user.email "policai-collector[bot]@users.noreply.github.com"
           git add public/data/developments.json public/data/meta.json data/watch-state.json data/source-reviews.json
           git commit -m "chore(data): daily collection $(date -u +%F)"
-          # Requires the GitHub Actions app as a bypass actor on the
-          # "Protect main" ruleset — see docs/collector.md.
           git push
 
       - name: Alert on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed the daily collector's push to `main` being rejected by the branch-protection ruleset (every scheduled run since 10 July had collected data and then failed to land it); the GitHub Actions app is now a documented bypass actor and the requirement is recorded in the collector docs.
+- Fixed the daily collector's push to `main` being rejected by the branch-protection ruleset (every scheduled run since 10 July had collected data and then failed to land it); the workflow now pushes via a dedicated write deploy key that is a ruleset bypass actor, and the setup is recorded in the collector docs.
 - Improved blog prose readability in dark mode.
 - Removed unsafe domain casts in pipeline/API/UI paths by normalising untrusted type and jurisdiction strings.
 

--- a/docs/collector.md
+++ b/docs/collector.md
@@ -51,7 +51,7 @@ The push triggers a Vercel deployment, so the site republishes with the new data
 
 - `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY` secret (optional, enables AI classification)
 - `AI_MODEL` repository variable (optional model override)
-- The "Protect main" ruleset must list the **GitHub Actions** app as a bypass actor (`bypass_mode: always`), otherwise the workflow's direct push to `main` is rejected with `GH013: Repository rule violations`. The safety story does not depend on the ruleset here: the registry-guard step and CI both enforce that automation never touches `policies.json`.
+- `COLLECTOR_DEPLOY_KEY` secret — private half of the repo's write deploy key ("collector (collect.yml push)"). Checkout uses it (`ssh-key:`) so the push authenticates as the deploy key, and the "Protect main" ruleset lists **Deploy keys** as a bypass actor (`bypass_mode: always`). Without this pair the push is rejected with `GH013: Repository rule violations` — the default `GITHUB_TOKEN` cannot be a bypass actor on a user-owned repo. The safety story does not depend on the ruleset here: the registry-guard step and CI both enforce that automation never touches `policies.json`.
 
 Without secrets the workflow still runs in heuristic mode.
 
@@ -75,7 +75,7 @@ npm run collect -- --dry-run --source=<id>
 
 ## Troubleshooting
 
-- **The workflow fails at `git push` with `GH013: Repository rule violations`** — the GitHub Actions app is missing from the "Protect main" ruleset bypass list. Re-add it (Settings → Rules → Rulesets → Protect main → Bypass list) or via `gh api -X PUT repos/l0cka/policai/rulesets/<id>` with the app in `bypass_actors`.
+- **The workflow fails at `git push` with `GH013: Repository rule violations`** — the deploy-key bypass is broken: either the `COLLECTOR_DEPLOY_KEY` secret / write deploy key was removed, or "Deploy keys" is missing from the "Protect main" ruleset bypass list (Settings → Rules → Rulesets → Protect main → Bypass list, or `gh api -X PUT repos/l0cka/policai/rulesets/<id>` with `{"actor_type": "DeployKey", "bypass_mode": "always"}` in `bypass_actors`).
 - **A source keeps failing** — check `meta.json` → `collector.lastRunErrors`. 403s usually mean bot protection; try from a different network, or disable the source with `enabled: false` and a `notes` explanation.
 - **Nothing new detected** — expected on most days; the feed only grows when monitored pages change. Check `watch-state.json` to confirm URLs are being seen.
 - **Validation fails in CI** — run `npm run validate:data` locally; it prints every structural error with the offending record id.


### PR DESCRIPTION
## Why

Follow-up to #67. Adding the GitHub Actions app as a ruleset bypass actor fails with a 422 on user-owned repos, so the app-bypass approach documented there is unsupported. The repo now has a dedicated write deploy key (`collector (collect.yml push)`), its private half in the `COLLECTOR_DEPLOY_KEY` secret, and **Deploy keys** as a bypass actor on the Protect main ruleset.

## What

- `actions/checkout` now takes `ssh-key: ${{ secrets.COLLECTOR_DEPLOY_KEY }}`, so the collector's `git push` authenticates as the deploy key and bypasses the ruleset.
- `docs/collector.md` and the CHANGELOG corrected to describe the deploy-key setup (including the GH013 troubleshooting entry).

## Verification

After merge: dispatch a manual run and confirm the data commit lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)