### PR TITLE
UI/UX refresh: sharpen the register, strip it back, tighten the copy

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -51,7 +51,7 @@ export default async function BlogPostPage({
       </Link>
 
       <header className="mb-9 border-b border-border pb-7">
-        <h1 className="font-display text-[clamp(2.75rem,6vw,5rem)] leading-[1.02] tracking-[-0.035em]">{post.title}</h1>
+        <h1 className="article-title">{post.title}</h1>
         <p className="mt-4 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
           {format(new Date(post.date), 'MMMM d, yyyy')}
         </p>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -18,9 +18,9 @@ export default function BlogPage() {
         title="Research notes"
       />
       {posts.length === 0 ? (
-        <p className="py-12 text-sm text-muted-foreground">No posts yet. Check back soon.</p>
+        <p className="py-12 text-sm text-muted-foreground">No posts yet.</p>
       ) : (
-        <div className="mx-auto max-w-5xl py-7">
+        <div className="max-w-5xl py-7">
           {posts.map((post) => (
             <Link
               key={post.slug}

--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -31,7 +31,7 @@ export default async function FrameworkPage() {
             Back to Policies
           </Link>
         </div>
-        <PageIntro title="AI in Government framework" />
+        <PageIntro title="AI in government framework" />
         <Card className="rounded-none border-[var(--caution)]/30 bg-[var(--status-proposed-bg)]/25 shadow-none">
           <CardHeader>
             <CardTitle>Framework temporarily unavailable</CardTitle>
@@ -71,7 +71,7 @@ export default async function FrameworkPage() {
       </div>
 
       <div className="mb-8 space-y-6">
-        <PageIntro title="AI in Government framework" />
+        <PageIntro title="AI in government framework" />
 
         <Card className="rounded-none border-primary/20 bg-primary/5 shadow-none">
           <CardContent className="p-6">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,172 +46,150 @@
   --radius-4xl: calc(var(--radius) + 16px);
 }
 
+/*
+ * Theme tokens.
+ *
+ * Every colour is declared once with light-dark(); the used value follows the
+ * root `color-scheme`. That keeps one source of truth per token and lets the
+ * theme toggle override the system preference by setting `color-scheme` alone.
+ */
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
   --radius: 0.5rem;
-  --background: #f4f1e8;
-  --foreground: #10213a;
-  --card: #faf8f2;
-  --card-foreground: #10213a;
-  --popover: #fffdf8;
-  --popover-foreground: #10213a;
-  --primary: #3157e8;
-  --primary-foreground: #ffffff;
-  --secondary: #e9edf0;
-  --secondary-foreground: #10213a;
-  --muted: #e9edf0;
-  --muted-foreground: #526176;
-  --accent: #e7ecfa;
-  --accent-foreground: #10213a;
-  --destructive: #b42318;
-  --border: #b8c2ca;
-  --input: #aeb9c4;
-  --ring: #3157e8;
-  --chart-1: #3157e8;
-  --chart-2: #146b5a;
-  --chart-3: #b7791f;
-  --chart-4: #7c3aed;
-  --chart-5: #dc2626;
-  --sidebar: #efede5;
-  --sidebar-foreground: #10213a;
-  --sidebar-primary: #3157e8;
-  --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #e1e5e5;
-  --sidebar-accent-foreground: #10213a;
-  --sidebar-border: #b8c2ca;
-  --sidebar-ring: #3157e8;
-  --row-hover: #eaece8;
-  --status-active: #146b5a;
-  --status-proposed: #9a6109;
-  --status-amended: #3157e8;
-  --status-repealed: #657181;
-  --status-active-bg: #deeee7;
-  --status-proposed-bg: #f6e8c8;
-  --status-amended-bg: #e4eafa;
-  --status-repealed-bg: #e7e9e8;
-  --navy: #102a43;
-  --ink: #10213a;
-  --paper: #f4f1e8;
-  --paper-raised: #faf8f2;
-  --trust: #146b5a;
-  --caution: #b7791f;
-  --map-fill-0: #e8e5e0;
-  --map-fill-1: #c7d2e0;
-  --map-fill-2: #93aacc;
-  --map-fill-3: #5a7db5;
-  --map-fill-4: #1e40af;
-  --map-hover-0: #d4d0c8;
-  --map-hover-1: #aebdd4;
-  --map-hover-2: #7a96be;
-  --map-hover-3: #4468a0;
-  --map-hover-4: #153296;
-  --map-stroke: #a8a29e;
-  --map-label: #57534e;
-  --map-label-muted: #78716c;
-  --network-jurisdiction-bg: #3157e8;
-  --network-jurisdiction-border: #2345c8;
-  --network-agency-bg: #d9a13b;
-  --network-agency-foreground: #10213a;
-  --network-agency-border: #b7791f;
-  --network-active-bg: #2d8a74;
-  --network-active-border: #146b5a;
-  --network-proposed-bg: #d6a344;
-  --network-proposed-border: #b7791f;
-  --network-amended-bg: #5575e6;
-  --network-amended-border: #3157e8;
-  --network-default-bg: #7b8795;
-  --network-default-border: #657181;
-  --network-edge: #7a8797;
-  --network-cross-edge: #a855f7;
-  --network-minimap-mask: rgba(0, 0, 0, 0.1);
-  --background-pattern: rgba(16, 42, 67, 0.025);
+
+  --background: light-dark(#f4f1e8, #10141b);
+  --foreground: light-dark(#10213a, #edf2f7);
+  --card: light-dark(#faf8f2, #151b24);
+  --card-foreground: light-dark(#10213a, #edf2f7);
+  --popover: light-dark(#fffdf8, #171e28);
+  --popover-foreground: light-dark(#10213a, #edf2f7);
+  --primary: light-dark(#2f4fd8, #8fa8ff);
+  --primary-foreground: light-dark(#ffffff, #09101d);
+  --secondary: light-dark(#e9edf0, #202936);
+  --secondary-foreground: light-dark(#10213a, #edf2f7);
+  --muted: light-dark(#e9edf0, #202936);
+  --muted-foreground: light-dark(#526176, #a7b2c3);
+  --accent: light-dark(#e7ecfa, #222e44);
+  --accent-foreground: light-dark(#10213a, #f4f7fb);
+  --destructive: light-dark(#b42318, #ff8175);
+  --border: light-dark(#c3ccd3, #333f4f);
+  --input: light-dark(#aeb9c4, #4a586b);
+  --ring: light-dark(#2f4fd8, #8fa8ff);
+
+  --chart-1: light-dark(#2f4fd8, #8fa8ff);
+  --chart-2: light-dark(#146b5a, #65d2b4);
+  --chart-3: light-dark(#b7791f, #e7b96c);
+  --chart-4: light-dark(#7c3aed, #b89aff);
+  --chart-5: light-dark(#dc2626, #ff8175);
+
+  --sidebar: light-dark(#efede5, #131923);
+  --sidebar-foreground: light-dark(#10213a, #edf2f7);
+  --sidebar-primary: light-dark(#2f4fd8, #8fa8ff);
+  --sidebar-primary-foreground: light-dark(#ffffff, #09101d);
+  --sidebar-accent: light-dark(#e1e5e5, #222b38);
+  --sidebar-accent-foreground: light-dark(#10213a, #edf2f7);
+  --sidebar-border: light-dark(#c3ccd3, #333f4f);
+  --sidebar-ring: light-dark(#2f4fd8, #8fa8ff);
+
+  --row-hover: light-dark(#ebeae2, #1b232e);
+  --status-active: light-dark(#146b5a, #65d2b4);
+  --status-proposed: light-dark(#9a6109, #e7b96c);
+  --status-amended: light-dark(#2f4fd8, #91aaff);
+  --status-repealed: light-dark(#657181, #a9b4c4);
+  --status-active-bg: light-dark(#deeee7, #18362f);
+  --status-proposed-bg: light-dark(#f6e8c8, #3a2f1c);
+  --status-amended-bg: light-dark(#e4eafa, #1f2d55);
+  --status-repealed-bg: light-dark(#e7e9e8, #28303b);
+
+  --navy: light-dark(#102a43, #09182a);
+  --ink: light-dark(#10213a, #edf2f7);
+  --paper: light-dark(#f4f1e8, #10141b);
+  --paper-raised: light-dark(#faf8f2, #151b24);
+  --paper-sunk: light-dark(#eae7dc, #0c1016);
+  --trust: light-dark(#146b5a, #65d2b4);
+  --caution: light-dark(#b7791f, #e7b96c);
+  --alarm: light-dark(#b42318, #ff8175);
+
+  --map-fill-0: light-dark(#e8e5e0, #242c36);
+  --map-fill-1: light-dark(#c7d2e0, #2e3d53);
+  --map-fill-2: light-dark(#93aacc, #3d5b86);
+  --map-fill-3: light-dark(#5a7db5, #557dbd);
+  --map-fill-4: light-dark(#1e40af, #8fa8ff);
+  --map-hover-0: light-dark(#d4d0c8, #303a46);
+  --map-hover-1: light-dark(#aebdd4, #3a4e6b);
+  --map-hover-2: light-dark(#7a96be, #4d70a4);
+  --map-hover-3: light-dark(#4468a0, #6f94d1);
+  --map-hover-4: light-dark(#153296, #acbdff);
+  --map-stroke: light-dark(#a8a29e, #647287);
+  --map-label: light-dark(#57534e, #dce4ee);
+  --map-label-muted: light-dark(#78716c, #a7b2c3);
+
+  --network-jurisdiction-bg: light-dark(#2f4fd8, #8fa8ff);
+  --network-jurisdiction-border: light-dark(#2345c8, #6f8be8);
+  --network-agency-bg: light-dark(#d9a13b, #e7b96c);
+  --network-agency-foreground: light-dark(#10213a, #10141b);
+  --network-agency-border: light-dark(#b7791f, #c18f3e);
+  --network-active-bg: light-dark(#2d8a74, #65d2b4);
+  --network-active-border: light-dark(#146b5a, #3ca98c);
+  --network-proposed-bg: light-dark(#d6a344, #e7b96c);
+  --network-proposed-border: light-dark(#b7791f, #c18f3e);
+  --network-amended-bg: light-dark(#5575e6, #91aaff);
+  --network-amended-border: light-dark(#2f4fd8, #6f8be8);
+  --network-default-bg: light-dark(#7b8795, #8d9aab);
+  --network-default-border: light-dark(#657181, #6c7888);
+  --network-edge: light-dark(#7a8797, #7f8ca0);
+  --network-cross-edge: light-dark(#a855f7, #c79cff);
+  --network-minimap-mask: light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.35));
+
+  --background-pattern: light-dark(rgba(16, 42, 67, 0.028), rgba(255, 255, 255, 0.022));
+
+  /*
+   * Jurisdiction accents, drawn from each government's own livery — Queensland
+   * maroon, Northern Territory ochre, Tasmanian bottle green. They let a reader
+   * place a row by colour before reading the column.
+   */
+  --jd-federal: light-dark(#1e40af, #8fa8ff);
+  --jd-nsw: light-dark(#0f766e, #5ec8bb);
+  --jd-vic: light-dark(#5b21b6, #b89aff);
+  --jd-qld: light-dark(#9d174d, #f4a0c0);
+  --jd-wa: light-dark(#a16207, #e0b558);
+  --jd-sa: light-dark(#b91c1c, #ff9a8f);
+  --jd-tas: light-dark(#15803d, #6cd08a);
+  --jd-act: light-dark(#0369a1, #6cbde8);
+  --jd-nt: light-dark(#c2410c, #ff9c6b);
+
+  /* Print-style rule weights: hairline, rule, heavy. */
+  --rule-hair: light-dark(rgba(16, 33, 58, 0.14), rgba(237, 242, 247, 0.13));
+  --rule: light-dark(rgba(16, 33, 58, 0.28), rgba(237, 242, 247, 0.24));
+  --rule-heavy: light-dark(rgba(16, 33, 58, 0.62), rgba(237, 242, 247, 0.5));
+
+  /* Depth comes from ink on paper, not from drop shadows. */
+  --shadow-raise: light-dark(0 1px 2px rgba(16, 33, 58, 0.06), 0 1px 2px rgba(0, 0, 0, 0.4));
+  --shadow-lift: light-dark(
+    0 10px 24px -14px rgba(16, 33, 58, 0.4),
+    0 12px 28px -16px rgba(0, 0, 0, 0.8)
+  );
+
+  /* Motion */
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-spring: cubic-bezier(0.34, 1.4, 0.64, 1);
+  --dur-fast: 130ms;
+  --dur-base: 220ms;
+  --dur-slow: 420ms;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
-    --background: #10141b;
-    --foreground: #edf2f7;
-    --card: #151b24;
-    --card-foreground: #edf2f7;
-    --popover: #171e28;
-    --popover-foreground: #edf2f7;
-    --primary: #8fa8ff;
-    --primary-foreground: #09101d;
-    --secondary: #202936;
-    --secondary-foreground: #edf2f7;
-    --muted: #202936;
-    --muted-foreground: #a7b2c3;
-    --accent: #222e44;
-    --accent-foreground: #f4f7fb;
-    --destructive: #ff8175;
-    --border: #3b4758;
-    --input: #4a586b;
-    --ring: #8fa8ff;
-    --chart-1: #8fa8ff;
-    --chart-2: #65d2b4;
-    --chart-3: #e7b96c;
-    --chart-4: #b89aff;
-    --chart-5: #ff8175;
-    --sidebar: #131923;
-    --sidebar-foreground: #edf2f7;
-    --sidebar-primary: #8fa8ff;
-    --sidebar-primary-foreground: #09101d;
-    --sidebar-accent: #222b38;
-    --sidebar-accent-foreground: #edf2f7;
-    --sidebar-border: #3b4758;
-    --sidebar-ring: #8fa8ff;
-    --row-hover: #1b232e;
-    --status-active: #65d2b4;
-    --status-proposed: #e7b96c;
-    --status-amended: #91aaff;
-    --status-repealed: #a9b4c4;
-    --status-active-bg: #18362f;
-    --status-proposed-bg: #3a2f1c;
-    --status-amended-bg: #1f2d55;
-    --status-repealed-bg: #28303b;
-    --navy: #09182a;
-    --ink: #edf2f7;
-    --paper: #10141b;
-    --paper-raised: #151b24;
-    --trust: #65d2b4;
-    --caution: #e7b96c;
-    --map-fill-0: #242c36;
-    --map-fill-1: #2e3d53;
-    --map-fill-2: #3d5b86;
-    --map-fill-3: #557dbd;
-    --map-fill-4: #8fa8ff;
-    --map-hover-0: #303a46;
-    --map-hover-1: #3a4e6b;
-    --map-hover-2: #4d70a4;
-    --map-hover-3: #6f94d1;
-    --map-hover-4: #acbdff;
-    --map-stroke: #647287;
-    --map-label: #dce4ee;
-    --map-label-muted: #a7b2c3;
-    --network-jurisdiction-bg: #8fa8ff;
-    --network-jurisdiction-border: #6f8be8;
-    --network-agency-bg: #e7b96c;
-    --network-agency-foreground: #10141b;
-    --network-agency-border: #c18f3e;
-    --network-active-bg: #65d2b4;
-    --network-active-border: #3ca98c;
-    --network-proposed-bg: #e7b96c;
-    --network-proposed-border: #c18f3e;
-    --network-amended-bg: #91aaff;
-    --network-amended-border: #6f8be8;
-    --network-default-bg: #8d9aab;
-    --network-default-border: #6c7888;
-    --network-edge: #7f8ca0;
-    --network-cross-edge: #c79cff;
-    --network-minimap-mask: rgba(0, 0, 0, 0.35);
-    --background-pattern: rgba(255, 255, 255, 0.025);
-  }
+/* The toggle wins over the system preference by pinning `color-scheme`. */
+:root[data-theme='light'] {
+  color-scheme: light;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
 }
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    @apply border-border;
   }
   body {
     @apply bg-background text-foreground font-sans;
@@ -223,6 +201,19 @@
   }
   p {
     text-wrap: pretty;
+  }
+  /*
+   * Keyboard users get a visible ring; pointer users do not. Applied globally
+   * so every control inherits it rather than opting in one at a time.
+   */
+  :focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+  /* Figures line up in columns wherever they are compared. */
+  th, td, time, .tabular {
+    font-variant-numeric: tabular-nums;
   }
 }
 
@@ -246,11 +237,89 @@
 
   /* Staggered page-load reveal */
   .reveal {
-    animation: reveal-rise 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation: reveal-rise 0.6s var(--ease-out-quint) both;
   }
   .reveal-1 { animation-delay: 70ms; }
   .reveal-2 { animation-delay: 140ms; }
   .reveal-3 { animation-delay: 210ms; }
+
+  /* Masthead rule: heavy over hair, the way a broadsheet separates sections. */
+  .rule-masthead {
+    border-bottom: 1px solid var(--rule-heavy);
+    box-shadow: 0 2px 0 -1px var(--rule-hair);
+  }
+
+  .rule-hair {
+    border-color: var(--rule-hair);
+  }
+
+  /* A link that draws its underline on rather than switching it on. */
+  .underline-grow {
+    background-image: linear-gradient(currentColor, currentColor);
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 0% 1px;
+    transition: background-size var(--dur-base) var(--ease-out-quint);
+  }
+  .underline-grow:hover,
+  .underline-grow:focus-visible {
+    background-size: 100% 1px;
+  }
+
+  .hover-lift {
+    transition:
+      transform var(--dur-base) var(--ease-out-quint),
+      box-shadow var(--dur-base) var(--ease-out-quint),
+      border-color var(--dur-base) var(--ease-out-quint);
+  }
+  .hover-lift:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lift);
+  }
+
+  /*
+   * The ink rail: a jurisdiction-tinted spine that wipes down the left edge of
+   * a row or card on hover, so scanning the register feels like running a
+   * finger down a ledger.
+   */
+  .ink-rail {
+    position: relative;
+  }
+  .ink-rail::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: var(--rail-color, var(--primary));
+    transform: scaleY(0);
+    transform-origin: top;
+    transition: transform var(--dur-base) var(--ease-out-quint);
+  }
+  .ink-rail:hover::before,
+  .ink-rail:focus-within::before {
+    transform: scaleY(1);
+  }
+
+  /*
+   * In a table the rail lives on the first cell, so hovering any other cell
+   * would leave it collapsed. Drive it from the row instead.
+   */
+  tr:hover > .ink-rail::before,
+  tr:focus-within > .ink-rail::before {
+    transform: scaleY(1);
+  }
+
+  /* Slow breathing pulse for a live status dot. */
+  .pulse-live::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 9999px;
+    background: currentColor;
+    animation: signal-pulse 2.4s var(--ease-out-quint) infinite;
+  }
 }
 
 @keyframes reveal-rise {
@@ -264,10 +333,16 @@
   }
 }
 
+@keyframes signal-pulse {
+  0% { opacity: 0.55; transform: scale(1); }
+  70% { opacity: 0; transform: scale(2.6); }
+  100% { opacity: 0; transform: scale(2.6); }
+}
+
 @keyframes dropdown-in {
   from {
     opacity: 0;
-    transform: translateY(-0.25rem);
+    transform: translateY(-0.25rem) scale(0.985);
   }
   to {
     opacity: 1;
@@ -276,7 +351,7 @@
 }
 
 .dropdown-in {
-  animation: dropdown-in 0.16s ease-out both;
+  animation: dropdown-in var(--dur-fast) var(--ease-out-quint) both;
 }
 
 .container {
@@ -318,6 +393,19 @@
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+  .hover-lift:hover {
+    transform: none;
+  }
+  .ink-rail::before {
+    transform: scaleY(1);
+    opacity: 0;
+  }
+  .ink-rail:hover::before,
+  .ink-rail:focus-within::before,
+  tr:hover > .ink-rail::before,
+  tr:focus-within > .ink-rail::before {
+    opacity: 1;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -227,6 +227,44 @@
     contain-intrinsic-size: auto 72px;
   }
 
+  /*
+   * Heading scale.
+   *
+   * The register is the thing worth looking at, so page titles stay small and
+   * get out of the way. Only a piece of writing, where the title genuinely is
+   * the content, takes the larger size.
+   */
+  .page-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.625rem;
+    font-weight: 500;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--muted-foreground);
+  }
+
+  .page-title {
+    font-family: var(--font-display);
+    font-size: clamp(1.6rem, 2.2vw, 2rem);
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+  }
+
+  .article-title {
+    font-family: var(--font-display);
+    font-size: clamp(1.9rem, 3vw, 2.6rem);
+    line-height: 1.1;
+    letter-spacing: -0.025em;
+  }
+
+  /* A clear step below .page-title, so sections never rival the page name. */
+  .section-title {
+    font-family: var(--font-display);
+    font-size: 1.15rem;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+  }
+
   /* Hide scrollbars on horizontal tab strips without disabling scroll */
   .no-scrollbar {
     scrollbar-width: none;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { IBM_Plex_Mono, Newsreader, Public_Sans } from 'next/font/google';
 import './globals.css';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
+import { themeInitScript } from '@/components/layout/ThemeToggle';
 import { BackToTop } from '@/components/ui/back-to-top';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { getCollectionMeta } from '@/lib/data-service';
@@ -30,7 +31,7 @@ const metadataMono = IBM_Plex_Mono({
 export const metadata: Metadata = {
   title: 'Policai — Australian AI Policy and Governance Tracker',
   description:
-    'Search and browse Australian AI policy, regulation, and governance developments across federal and state jurisdictions.',
+    'A register of AI policy, regulation and court guidance from Australian federal, state and territory governments, each record linked to its official source.',
   keywords: [
     'Australian AI policy',
     'AI regulation',
@@ -54,7 +55,16 @@ export default async function RootLayout({
     <html
       lang="en-AU"
       className={`${displaySerif.variable} ${interfaceSans.variable} ${metadataMono.variable}`}
+      suppressHydrationWarning
     >
+      <head>
+        {/*
+          Static, developer-authored string with no interpolated input. It sets
+          the stored theme before first paint so the page never flashes the
+          system theme on the way to the chosen one.
+        */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className="antialiased min-h-screen flex flex-col">
         <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-[100] focus:top-2 focus:left-2 focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:text-sm focus:font-medium">
           Skip to content

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -50,7 +50,7 @@ export default async function MethodologyPage() {
         { value: manualCoverage.total, label: 'manual sources' },
       ]} />
 
-      <div className="mx-auto max-w-4xl space-y-10 py-9 text-sm leading-6">
+      <div className="max-w-4xl space-y-10 py-9 text-sm leading-6">
         <section>
           <h2 className="font-display text-3xl">Trust levels</h2>
           <dl className="space-y-4">

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -40,7 +40,7 @@ export default async function MethodologyPage() {
   return (
     <article className="container mx-auto px-4 py-7 sm:px-6 lg:px-8">
       <PageIntro
-        title="Methodology & verification"
+        title="Methodology and verification"
         description="How records are discovered, verified and published."
       />
       <MetricStrip metrics={[
@@ -52,7 +52,7 @@ export default async function MethodologyPage() {
 
       <div className="max-w-4xl space-y-10 py-9 text-sm leading-6">
         <section>
-          <h2 className="font-display text-3xl">Trust levels</h2>
+          <h2 className="section-title">Trust levels</h2>
           <dl className="space-y-4">
             <div className="mt-4 border-l-2 border-[var(--trust)] bg-[var(--status-active-bg)]/25 px-4 py-3">
               <dt className="font-medium">Verified register record</dt>
@@ -74,7 +74,7 @@ export default async function MethodologyPage() {
         </section>
 
         <section className="border-t border-border pt-7">
-          <h2 className="font-display text-3xl">Source and date rules</h2>
+          <h2 className="section-title">Source and date rules</h2>
           <ul className="list-disc pl-5 text-muted-foreground space-y-2">
             <li>
               Verified records use the official instrument page or document.
@@ -95,7 +95,7 @@ export default async function MethodologyPage() {
         </section>
 
         <section className="border-t border-border pt-7">
-          <h2 className="font-display text-3xl">Current register state</h2>
+          <h2 className="section-title">Current register state</h2>
           <p className="text-muted-foreground">
             {publicPolicies.length} records are currently publishable in the
             public register.
@@ -106,7 +106,7 @@ export default async function MethodologyPage() {
         </section>
 
         <section className="border-t border-border pt-7">
-          <h2 className="font-display text-3xl">Collection health</h2>
+          <h2 className="section-title">Collection health</h2>
           <p className="text-muted-foreground">
             The latest run is <strong>{meta.collector.health}</strong>, with{' '}
             {meta.collector.successfulSourceCount} of{' '}
@@ -127,7 +127,7 @@ export default async function MethodologyPage() {
         </section>
 
         <section className="border-t border-border pt-7">
-          <h2 className="font-display text-3xl">Open data and corrections</h2>
+          <h2 className="section-title">Open data and corrections</h2>
           <p className="text-muted-foreground">
             Canonical records are versioned in Git and available as{' '}
             <a

--- a/src/app/policies/[id]/policy-detail-tabs.tsx
+++ b/src/app/policies/[id]/policy-detail-tabs.tsx
@@ -22,6 +22,7 @@ import {
   getPrimaryPolicyDate,
   type Policy,
 } from '@/types';
+import { jurisdictionAccent } from '@/lib/jurisdiction-accent';
 import { EmptyState } from '@/components/ui/empty-state';
 import { formatPolicyDate } from '@/lib/format-policy-date';
 import { cn } from '@/lib/utils';
@@ -126,7 +127,13 @@ export function PolicyDetailTabs({
       <div className="grid gap-8 xl:grid-cols-[minmax(0,1fr)_23rem]">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-3 font-mono text-[10px] uppercase tracking-[0.12em]">
-            <span className="text-primary">{getJurisdictionName(policy.jurisdiction)}</span>
+            <span
+              className="inline-flex items-center gap-1.5"
+              style={{ color: jurisdictionAccent(policy.jurisdiction) }}
+            >
+              <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-current" />
+              {getJurisdictionName(policy.jurisdiction)}
+            </span>
             <span className="h-4 w-px bg-border" />
             <span>{getPolicyTypeName(policy.type)}</span>
             <span className="h-4 w-px bg-border" />

--- a/src/app/policies/[id]/policy-detail-tabs.tsx
+++ b/src/app/policies/[id]/policy-detail-tabs.tsx
@@ -140,7 +140,7 @@ export function PolicyDetailTabs({
             <StatusBadge policy={policy} />
           </div>
 
-          <h1 className="mt-5 max-w-5xl font-display text-[clamp(2.5rem,3.8vw,4rem)] leading-[1.02] tracking-[-0.035em]">
+          <h1 className="article-title mt-5 max-w-4xl">
             {policy.title}
           </h1>
           <p className="mt-4 max-w-4xl text-base leading-7 text-muted-foreground">
@@ -207,7 +207,7 @@ export function PolicyDetailTabs({
 
               <div className="mt-7 grid gap-7 lg:grid-cols-[minmax(0,1fr)_17rem]">
                 <div>
-                  <h2 className="text-lg font-semibold">Key requirements</h2>
+                  <h2 className="section-title">Key requirements</h2>
                   <ol className="mt-3 border-y border-border">
                     {requirements.slice(0, 3).map((requirement, index) => (
                       <li key={`${requirement.slice(0, 30)}-${index}`} className="flex gap-3 border-b border-border px-2 py-3 last:border-b-0">
@@ -226,7 +226,7 @@ export function PolicyDetailTabs({
                 </div>
 
                 <div className="border-l border-border pl-5">
-                  <h2 className="text-sm font-semibold">Policy changes</h2>
+                  <h2 className="page-eyebrow">Policy changes</h2>
                   <ol className="mt-4 space-y-5">
                     {policy.dates.slice(0, 4).map((date, index) => (
                       <li key={`${date.type}-${String(date.date)}`} className="relative pl-5">
@@ -243,7 +243,7 @@ export function PolicyDetailTabs({
 
           {activeTab === 'requirements' ? (
             <div className="py-6">
-              <h2 className="text-xl font-semibold">Key requirements</h2>
+              <h2 className="section-title">Key requirements</h2>
               <ol className="mt-4 max-w-4xl border-y border-border">
                 {requirements.map((requirement, index) => (
                   <li key={`${requirement.slice(0, 30)}-${index}`} className="flex gap-4 border-b border-border py-4 last:border-b-0">
@@ -272,7 +272,7 @@ export function PolicyDetailTabs({
 
         <aside className="space-y-5 xl:pt-0">
           <section className="border border-border bg-card/40 p-5">
-            <h2 className="font-display text-2xl">At a glance</h2>
+            <h2 className="section-title">At a glance</h2>
             <dl className="mt-4 space-y-3 text-sm">
               <div className="grid grid-cols-[7rem_1fr] gap-3"><dt className="text-muted-foreground">Status</dt><dd><StatusBadge policy={policy} /></dd></div>
               <div className="grid grid-cols-[7rem_1fr] gap-3"><dt className="text-muted-foreground">Jurisdiction</dt><dd>{getJurisdictionName(policy.jurisdiction)}</dd></div>
@@ -291,7 +291,7 @@ export function PolicyDetailTabs({
           </section>
 
           <section className="border border-border bg-card/40 p-5">
-            <h2 className="font-display text-2xl">Source verification</h2>
+            <h2 className="section-title">Source verification</h2>
             <p className="mt-4 flex items-center gap-2 border-b border-border pb-4 text-sm">
               <CheckCircle2 className="h-5 w-5 text-[var(--trust)]" fill="currentColor" />
               {policy.verification.status === 'verified' ? 'Verified against the official source' : 'Editorial verification required'}
@@ -310,7 +310,7 @@ export function PolicyDetailTabs({
       </div>
 
       <section className="mt-6 border-t border-border pt-5">
-        <h2 className="font-display text-2xl">Related policies</h2>
+        <h2 className="section-title">Related policies</h2>
         <div className="mt-3"><RelatedPolicies policies={relatedPolicies} /></div>
       </section>
     </div>

--- a/src/components/agencies-browser.tsx
+++ b/src/components/agencies-browser.tsx
@@ -58,7 +58,8 @@ export function AgenciesBrowser({ agencies }: { agencies: Agency[] }) {
   return (
     <div className="container mx-auto px-4 py-7 sm:px-6 lg:px-8">
       <PageIntro
-        title="Agency transparency"
+        title="Agencies"
+        description="Australian government agencies and the AI transparency statements located for each."
       />
       <MetricStrip metrics={[
         { value: stats.total, label: 'agencies' },
@@ -109,7 +110,7 @@ export function AgenciesBrowser({ agencies }: { agencies: Agency[] }) {
               <col className="w-32" />
             </colgroup>
             <thead>
-              <tr className="border-y border-foreground/55">
+              <tr className="border-y border-[var(--rule-heavy)]">
                 <th className="py-2 pr-4 text-left font-mono text-[10px] uppercase tracking-[0.1em]">Agency</th>
                 <th className="py-2 pr-4 text-left font-mono text-[10px] uppercase tracking-[0.1em]">Acronym</th>
                 <th className="py-2 pr-4 text-left font-mono text-[10px] uppercase tracking-[0.1em]">Jurisdiction</th>

--- a/src/components/courts-browser.tsx
+++ b/src/components/courts-browser.tsx
@@ -73,7 +73,7 @@ export function CourtsBrowser({ policies }: { policies: Policy[] }) {
 	return (
 		<div className="container mx-auto px-4 py-7 sm:px-6 lg:px-8">
 			<PageIntro
-				title="Courts & Tribunals"
+				title="Courts and tribunals"
 				description="Court and tribunal guidance on AI in proceedings."
 			/>
 			<MetricStrip metrics={[
@@ -83,7 +83,7 @@ export function CourtsBrowser({ policies }: { policies: Policy[] }) {
 				{ value: jurisdictionsWithout.length, label: "pending" },
 			]} />
 
-			<div className="mx-auto max-w-5xl pt-8">
+			<div className="max-w-5xl pt-8">
 
 			{/* Jurisdictions with practice notes */}
 			{jurisdictionsWithNotes.map((jurisdiction) => {

--- a/src/components/developments-browser.tsx
+++ b/src/components/developments-browser.tsx
@@ -76,7 +76,7 @@ function DevelopmentFeed({ items }: { items: Development[] }) {
   if (items.length === 0) {
     return (
       <div className="border-y border-border py-14 text-center">
-        <p className="font-display text-2xl">No matching developments</p>
+        <p className="section-title">No matching developments</p>
         <p className="mt-2 text-sm text-muted-foreground">Try a broader search or jurisdiction.</p>
       </div>
     );
@@ -171,7 +171,7 @@ export function DevelopmentsBrowser({
   return (
     <div className="container mx-auto px-4 py-7 sm:px-6 lg:px-8">
       <header className="reveal">
-        <h1 className="font-display text-[clamp(2.65rem,4vw,4rem)] leading-none tracking-[-0.035em]">Policy developments</h1>
+        <h1 className="page-title">Policy developments</h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
           Updates found on official sources. Records an editor has checked are
           listed separately from leads that are still unconfirmed.

--- a/src/components/developments-browser.tsx
+++ b/src/components/developments-browser.tsx
@@ -10,6 +10,8 @@ import {
   Filter,
   Search,
 } from 'lucide-react';
+import { HealthSignal } from '@/components/ui/health-signal';
+import { jurisdictionRailStyle } from '@/lib/jurisdiction-accent';
 import { formatPolicyDate } from '@/lib/format-policy-date';
 import {
   JURISDICTION_NAMES,
@@ -84,13 +86,17 @@ function DevelopmentFeed({ items }: { items: Development[] }) {
     <div>
       {Array.from(grouped.entries()).map(([month, developments]) => (
         <section key={month} className="mb-4">
-          <h2 className="border-b border-foreground/55 py-2 font-mono text-[10px] font-medium uppercase tracking-[0.12em]">{month}</h2>
+          <h2 className="border-b border-[var(--rule-heavy)] py-2 font-mono text-[10px] font-medium uppercase tracking-[0.12em]">{month}</h2>
           <div>
             {developments.map((development) => {
               const verified = development.verification.status === 'verified';
               const label = eventType(development);
               return (
-                <article key={development.id} className="content-auto grid gap-2 border-b border-border py-4 sm:grid-cols-[6.5rem_7rem_minmax(0,1fr)] lg:grid-cols-[6.5rem_7rem_minmax(0,1fr)_9rem_10rem]">
+                <article
+                  key={development.id}
+                  style={jurisdictionRailStyle(development.jurisdiction)}
+                  className="ink-rail content-auto grid gap-2 border-b border-border py-4 pl-3 transition-colors duration-[var(--dur-fast)] hover:bg-[var(--row-hover)] sm:grid-cols-[6.5rem_7rem_minmax(0,1fr)] lg:grid-cols-[6.5rem_7rem_minmax(0,1fr)_9rem_10rem]"
+                >
                   <time className="font-mono text-[10px] uppercase text-muted-foreground">{developmentDate(development)}</time>
                   <div>
                     <span className={cn('inline-flex rounded px-2 py-1 font-mono text-[9px] uppercase tracking-[0.08em]', label === 'Consultation' || !verified ? 'bg-[var(--status-proposed-bg)] text-[var(--status-proposed)]' : 'bg-[var(--status-active-bg)] text-[var(--trust)]')}>
@@ -167,7 +173,8 @@ export function DevelopmentsBrowser({
       <header className="reveal">
         <h1 className="font-display text-[clamp(2.65rem,4vw,4rem)] leading-none tracking-[-0.035em]">Policy developments</h1>
         <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
-          Official-source updates, separated by editorial verification.
+          Updates found on official sources. Records an editor has checked are
+          listed separately from leads that are still unconfirmed.
         </p>
       </header>
 
@@ -208,9 +215,9 @@ export function DevelopmentsBrowser({
         <aside className="border-l border-border pl-6">
           <section>
             <h2 className="text-sm font-semibold">Collection status</h2>
-            <div className="mt-3 border border-[var(--trust)]/30 bg-[var(--status-active-bg)]/30 p-4">
-              <p className="flex items-center gap-2 font-medium text-[var(--trust)]"><span className="h-2.5 w-2.5 rounded-full bg-[var(--trust)]" />{collectionHealth === 'healthy' ? 'Healthy' : collectionHealth}</p>
-              {lastCollectedAt ? <p className="mt-3 border-t border-[var(--trust)]/20 pt-3 font-mono text-[9px] uppercase text-muted-foreground">Last checked {formatDate(lastCollectedAt)}</p> : null}
+            <div className="mt-3 rounded-md border border-border bg-card/50 p-4">
+              <HealthSignal health={collectionHealth} className="text-[12px]" />
+              {lastCollectedAt ? <p className="mt-3 border-t border-border pt-3 font-mono text-[9px] uppercase text-muted-foreground">Last checked {formatDate(lastCollectedAt)}</p> : null}
             </div>
             <div className="mt-4 space-y-3">
               {[

--- a/src/components/filter-sidebar.tsx
+++ b/src/components/filter-sidebar.tsx
@@ -110,8 +110,8 @@ export function FilterControls({
 
 export function FilterSidebar(props: FilterControlsProps) {
   return (
-    <aside className="hidden w-64 shrink-0 border-r border-border pr-8 lg:block">
-      <FilterControls {...props} className="sticky top-[8.5rem] py-5" />
+    <aside className="hidden w-64 shrink-0 border-r border-[var(--rule-hair)] pr-8 lg:block">
+      <FilterControls {...props} className="sticky top-[6.75rem] py-5" />
     </aside>
   );
 }

--- a/src/components/filter-sidebar.tsx
+++ b/src/components/filter-sidebar.tsx
@@ -33,7 +33,7 @@ export function FilterControls({
   return (
     <div className={cn('space-y-6', className)}>
       <div className="flex items-center justify-between">
-        <span className="font-mono text-[11px] font-medium uppercase tracking-[0.12em]">
+        <span className="font-mono text-[11px] font-medium uppercase tracking-[0.14em]">
           Filters
         </span>
         {hasActiveFilters ? (
@@ -49,42 +49,60 @@ export function FilterControls({
       </div>
 
       {groups.map((group) => (
-        <fieldset key={group.id} className="border-t border-border pt-4 first:border-t-0 first:pt-0">
-          <legend className="mb-3 text-sm font-medium">{group.label}</legend>
-          <div className="space-y-2.5">
-            {group.options.map((option) => {
-              const checked = group.selectedValues.includes(option.value);
-              return (
-                <label
-                  key={option.value}
-                  className="group flex min-h-6 cursor-pointer items-start gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <input
-                    type="checkbox"
-                    checked={checked}
-                    onChange={() => group.onToggle(option.value)}
-                    className="sr-only"
-                  />
-                  <span
+        // The rule sits on a wrapper rather than the fieldset: a <legend> is
+        // painted inside its fieldset's top border and would cut through it.
+        <div
+          key={group.id}
+          className="border-t border-border pt-4 first:border-t-0 first:pt-0"
+        >
+          <fieldset>
+            <legend className="mb-3 text-sm font-medium">{group.label}</legend>
+            <div className="space-y-1">
+              {group.options.map((option) => {
+                const checked = group.selectedValues.includes(option.value);
+                return (
+                  <label
+                    key={option.value}
                     className={cn(
-                      'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-[3px] border transition-colors',
+                      'group -mx-2 flex min-h-8 cursor-pointer items-start gap-2.5 rounded px-2 py-1 text-sm transition-colors duration-[var(--dur-fast)]',
                       checked
-                        ? 'border-primary bg-primary text-primary-foreground'
-                        : 'border-input bg-background group-hover:border-foreground/50',
+                        ? 'text-foreground'
+                        : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
                     )}
-                    aria-hidden="true"
                   >
-                    {checked ? <Check className="h-3 w-3" strokeWidth={2.5} /> : null}
-                  </span>
-                  <span className="flex-1 leading-5">{option.label}</span>
-                  <span className="font-mono text-[10px] tabular-nums text-muted-foreground/75">
-                    {option.count}
-                  </span>
-                </label>
-              );
-            })}
-          </div>
-        </fieldset>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => group.onToggle(option.value)}
+                      className="peer sr-only"
+                    />
+                    <span
+                      className={cn(
+                        'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-[3px] border transition-all duration-[var(--dur-fast)] peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-[var(--ring)]',
+                        checked
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : 'border-input bg-background group-hover:border-foreground/50',
+                      )}
+                      aria-hidden="true"
+                    >
+                      <Check
+                        className={cn(
+                          'h-3 w-3 transition-transform duration-[var(--dur-fast)] ease-[var(--ease-spring)]',
+                          checked ? 'scale-100' : 'scale-0',
+                        )}
+                        strokeWidth={2.5}
+                      />
+                    </span>
+                    <span className="flex-1 leading-5">{option.label}</span>
+                    <span className="mt-0.5 font-mono text-[10px] tabular-nums text-muted-foreground/75">
+                      {option.count}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+        </div>
       ))}
     </div>
   );

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,23 +1,41 @@
 import Link from 'next/link';
 
+const links = [
+  { href: '/methodology', label: 'Methodology', external: false },
+  { href: '/api/policies', label: 'API', external: false },
+  { href: 'https://github.com/l0cka/policai', label: 'GitHub', external: true },
+];
+
 export function Footer() {
   return (
-    <footer className="border-t border-border">
-      <div className="container mx-auto flex flex-col gap-4 px-4 py-5 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:px-8">
-        <p className="max-w-3xl font-mono text-[9px] uppercase tracking-[0.12em] text-muted-foreground lg:text-[10px]">
-          Public-interest research · official sources · human review
+    <footer className="border-t border-[var(--rule-heavy)]">
+      <div className="container mx-auto flex flex-col gap-4 px-4 py-6 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:px-8">
+        <p className="max-w-3xl text-xs leading-5 text-muted-foreground">
+          An open register of Australian AI policy. Every record is checked
+          against its official source, and the data is versioned in Git.
         </p>
-        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-muted-foreground">
-          <Link href="/methodology" className="transition-colors hover:text-foreground">Methodology</Link>
-          <Link href="/api/policies" className="transition-colors hover:text-foreground">API</Link>
-          <a
-            href="https://github.com/l0cka/policai"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-foreground transition-colors"
-          >
-            GitHub
-          </a>
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2 text-xs text-muted-foreground">
+          {links.map((link) =>
+            link.external ? (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline-grow transition-colors duration-[var(--dur-fast)] hover:text-foreground"
+              >
+                {link.label}
+              </a>
+            ) : (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="underline-grow transition-colors duration-[var(--dur-fast)] hover:text-foreground"
+              >
+                {link.label}
+              </Link>
+            ),
+          )}
         </div>
       </div>
     </footer>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -132,12 +132,12 @@ export function Header({ dataCurrentAt }: { dataCurrentAt: string | null }) {
         </div>
       </div>
 
-      <div className="container mx-auto flex h-16 items-center px-4 sm:h-[5.25rem] sm:px-6 lg:px-8">
+      <div className="container mx-auto flex h-14 items-center px-4 sm:h-[4.25rem] sm:px-6 lg:px-8">
         <Link href="/" aria-label="Policai home" className="shrink-0">
           <PolicaiLogo
             className="transition-opacity duration-[var(--dur-base)] hover:opacity-75"
-            iconClassName="h-12 w-12 max-sm:h-10 max-sm:w-10"
-            textClassName="text-[1.75rem] tracking-[0.08em] max-sm:text-xl"
+            iconClassName="h-9 w-9 max-sm:h-8 max-sm:w-8"
+            textClassName="text-[1.3rem] tracking-[0.08em] max-sm:text-lg"
           />
         </Link>
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { PolicaiLogo } from '@/components/layout/PolicaiLogo';
+import { ThemeToggle } from '@/components/layout/ThemeToggle';
 
 const navItems = [
   { href: '/', label: 'Register' },
@@ -32,7 +33,7 @@ const insightItems = [
 ];
 
 function formatDataDate(value: string | null): string {
-  if (!value) return 'SOURCE STATUS AVAILABLE IN METHODOLOGY';
+  if (!value) return 'SOURCE STATUS IN METHODOLOGY';
 
   return `DATA CURRENT TO ${new Date(value).toLocaleString('en-AU', {
     day: '2-digit',
@@ -43,6 +44,37 @@ function formatDataDate(value: string | null): string {
     hour12: false,
     timeZoneName: 'short',
   }).toUpperCase()}`;
+}
+
+/** Nav label whose underline wipes in from the left, and stays for the current page. */
+function NavLink({
+  href,
+  label,
+  active,
+}: {
+  href: string;
+  label: string;
+  active: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={active ? 'page' : undefined}
+      className={cn(
+        'group relative flex h-full items-center px-1 text-[15px] font-medium transition-colors duration-[var(--dur-fast)]',
+        active ? 'text-primary' : 'text-muted-foreground hover:text-foreground',
+      )}
+    >
+      {label}
+      <span
+        aria-hidden="true"
+        className={cn(
+          'absolute inset-x-0 bottom-0 h-[3px] origin-left bg-primary transition-transform duration-[var(--dur-base)] ease-[var(--ease-out-quint)]',
+          active ? 'scale-x-100' : 'scale-x-0 group-hover:scale-x-100',
+        )}
+      />
+    </Link>
+  );
 }
 
 export function Header({ dataCurrentAt }: { dataCurrentAt: string | null }) {
@@ -76,21 +108,34 @@ export function Header({ dataCurrentAt }: { dataCurrentAt: string | null }) {
   const insightsActive = insightItems.some((item) => isActive(item.href));
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur-md">
+    <header className="rule-masthead sticky top-0 z-50 w-full bg-background/90 backdrop-blur-md">
+      {/* Dateline strip, in the manner of a masthead's edition line. */}
       <div className="bg-[var(--navy)] text-white">
         <div className="container mx-auto flex h-7 items-center justify-between px-4 font-mono text-[9px] uppercase tracking-[0.12em] sm:px-6 lg:px-8 lg:text-[10px]">
           <span className="hidden sm:inline">{formatDataDate(dataCurrentAt)}</span>
-          <span className="sm:hidden">{formatDataDate(dataCurrentAt).replace('DATA CURRENT TO ', 'CURRENT · ')}</span>
+          <span className="sm:hidden">
+            {formatDataDate(dataCurrentAt).replace('DATA CURRENT TO ', 'CURRENT · ')}
+          </span>
           <div className="hidden items-center gap-5 sm:flex">
-            <Link href="/api/policies" className="hover:text-white/75">API</Link>
-            <a href="https://github.com/l0cka/policai/issues" target="_blank" rel="noopener noreferrer" className="hover:text-white/75">Feedback</a>
+            <Link href="/api/policies" className="underline-grow">
+              API
+            </Link>
+            <a
+              href="https://github.com/l0cka/policai/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline-grow"
+            >
+              Feedback
+            </a>
           </div>
         </div>
       </div>
+
       <div className="container mx-auto flex h-16 items-center px-4 sm:h-[5.25rem] sm:px-6 lg:px-8">
-        <Link href="/" aria-label="Policai home">
+        <Link href="/" aria-label="Policai home" className="shrink-0">
           <PolicaiLogo
-            className="transition-opacity hover:opacity-80"
+            className="transition-opacity duration-[var(--dur-base)] hover:opacity-75"
             iconClassName="h-12 w-12 max-sm:h-10 max-sm:w-10"
             textClassName="text-[1.75rem] tracking-[0.08em] max-sm:text-xl"
           />
@@ -98,38 +143,49 @@ export function Header({ dataCurrentAt }: { dataCurrentAt: string | null }) {
 
         <nav className="mx-auto hidden h-full items-center gap-8 md:flex">
           {navItems.map((item) => (
-            <Link
+            <NavLink
               key={item.href}
               href={item.href}
-              className={cn(
-                'flex h-full items-center border-b-[3px] px-1 pt-[3px] text-[15px] font-medium transition-colors',
-                isActive(item.href)
-                  ? 'border-primary text-primary'
-                  : 'border-transparent text-muted-foreground hover:text-foreground'
-              )}
-            >
-              {item.label}
-            </Link>
+              label={item.label}
+              active={isActive(item.href)}
+            />
           ))}
-          {/* Explore dropdown */}
-          <div ref={insightsRef} className="relative">
+
+          <div ref={insightsRef} className="relative h-full">
             <button
               type="button"
               onClick={() => setInsightsOpen(!insightsOpen)}
               aria-haspopup="menu"
               aria-expanded={insightsOpen}
               className={cn(
-                'flex h-full items-center gap-1 border-b-[3px] px-1 pt-[3px] text-[15px] font-medium transition-colors',
+                'group relative flex h-full items-center gap-1 px-1 text-[15px] font-medium transition-colors duration-[var(--dur-fast)]',
                 insightsActive
-                  ? 'border-primary text-primary'
-                  : 'border-transparent text-muted-foreground hover:text-foreground'
+                  ? 'text-primary'
+                  : 'text-muted-foreground hover:text-foreground',
               )}
             >
               Explore
-              <ChevronDown className={cn('h-3 w-3 transition-transform', insightsOpen && 'rotate-180')} />
+              <ChevronDown
+                className={cn(
+                  'h-3 w-3 transition-transform duration-[var(--dur-base)] ease-[var(--ease-out-quint)]',
+                  insightsOpen && 'rotate-180',
+                )}
+              />
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'absolute inset-x-0 bottom-0 h-[3px] origin-left bg-primary transition-transform duration-[var(--dur-base)] ease-[var(--ease-out-quint)]',
+                  insightsActive || insightsOpen
+                    ? 'scale-x-100'
+                    : 'scale-x-0 group-hover:scale-x-100',
+                )}
+              />
             </button>
             {insightsOpen && (
-              <div className="dropdown-in absolute left-0 top-full z-50 min-w-[168px] border border-border bg-popover py-1 shadow-lg" role="menu">
+              <div
+                className="dropdown-in absolute left-0 top-full z-50 min-w-[180px] overflow-hidden rounded-md border border-border bg-popover py-1 shadow-[var(--shadow-lift)]"
+                role="menu"
+              >
                 {insightItems.map((item) => (
                   <Link
                     key={item.href}
@@ -137,10 +193,10 @@ export function Header({ dataCurrentAt }: { dataCurrentAt: string | null }) {
                     onClick={() => setInsightsOpen(false)}
                     role="menuitem"
                     className={cn(
-                      'block px-4 py-2 text-sm transition-colors',
+                      'ink-rail block px-4 py-2 text-sm transition-colors duration-[var(--dur-fast)]',
                       isActive(item.href)
                         ? 'bg-muted text-foreground'
-                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                     )}
                   >
                     {item.label}
@@ -151,22 +207,23 @@ export function Header({ dataCurrentAt }: { dataCurrentAt: string | null }) {
           </div>
         </nav>
 
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto flex items-center gap-1.5 sm:gap-2.5">
           <Link
             href="/#policy-search"
             aria-label="Search the policy register"
-            className="flex h-10 w-10 items-center justify-center text-foreground transition-colors hover:text-primary"
+            className="flex h-10 w-10 items-center justify-center rounded-full text-foreground transition-colors duration-[var(--dur-fast)] hover:bg-muted hover:text-primary"
           >
             <Search className="h-5 w-5" strokeWidth={1.75} />
           </Link>
+          <ThemeToggle className="max-sm:hidden" />
           <Sheet>
             <SheetTrigger asChild className="md:hidden">
-              <Button variant="ghost" size="icon" className="h-8 w-8">
+              <Button variant="ghost" size="icon" className="h-9 w-9">
                 <Menu className="h-5 w-5" />
                 <span className="sr-only">Toggle menu</span>
               </Button>
             </SheetTrigger>
-            <SheetContent side="right" className="w-[250px]">
+            <SheetContent side="right" className="w-[270px]">
               <SheetTitle className="sr-only">Navigation</SheetTitle>
               <SheetDescription className="sr-only">
                 Browse Policai sections and resources.
@@ -177,10 +234,10 @@ export function Header({ dataCurrentAt }: { dataCurrentAt: string | null }) {
                     key={item.href}
                     href={item.href}
                     className={cn(
-                      'px-3 py-2 text-sm font-medium rounded transition-colors',
+                      'rounded px-3 py-2 text-sm font-medium transition-colors duration-[var(--dur-fast)]',
                       isActive(item.href)
                         ? 'bg-muted text-foreground'
-                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                     )}
                   >
                     {item.label}
@@ -195,15 +252,22 @@ export function Header({ dataCurrentAt }: { dataCurrentAt: string | null }) {
                     key={item.href}
                     href={item.href}
                     className={cn(
-                      'px-3 py-2 text-sm font-medium rounded transition-colors',
+                      'rounded px-3 py-2 text-sm font-medium transition-colors duration-[var(--dur-fast)]',
                       isActive(item.href)
                         ? 'bg-muted text-foreground'
-                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground',
                     )}
                   >
                     {item.label}
                   </Link>
                 ))}
+                <div className="my-3 border-t border-border" />
+                <div className="flex items-center justify-between px-3">
+                  <span className="font-mono text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                    Theme
+                  </span>
+                  <ThemeToggle />
+                </div>
               </nav>
             </SheetContent>
           </Sheet>

--- a/src/components/layout/PageIntro.tsx
+++ b/src/components/layout/PageIntro.tsx
@@ -14,19 +14,13 @@ export function PageIntro({
   actions?: ReactNode;
 }) {
   return (
-    <header className="border-b border-[var(--rule-heavy)] pb-6">
+    <header className="pb-5">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
         <div className="reveal">
-          {eyebrow ? (
-            <p className="mb-3 font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-              {eyebrow}
-            </p>
-          ) : null}
-          <h1 className="font-display text-[clamp(2.65rem,4vw,4rem)] leading-none tracking-[-0.035em]">
-            {title}
-          </h1>
+          {eyebrow ? <p className="page-eyebrow mb-2.5">{eyebrow}</p> : null}
+          <h1 className="page-title">{title}</h1>
           {description ? (
-            <div className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
+            <div className="mt-2.5 max-w-2xl text-sm leading-6 text-muted-foreground">
               {description}
             </div>
           ) : null}
@@ -49,32 +43,24 @@ export function MetricStrip({
   className?: string;
 }) {
   return (
+    // Space separates the figures; a single hairline holds the band. Internal
+    // dividers made this read as a table of its own and competed with the data.
     <dl
       className={cn(
-        'reveal reveal-1 grid grid-cols-2 border-b border-border lg:grid-cols-4',
+        'reveal reveal-1 flex flex-wrap gap-x-10 gap-y-4 border-y border-[var(--rule-hair)] py-4',
         className,
       )}
     >
-      {metrics.map((metric, index) => (
-        <div
-          key={metric.label}
-          className={cn(
-            'group relative px-1 py-4 text-center lg:py-5',
-            index % 2 === 1 && 'border-l border-border',
-            index > 1 && 'border-t border-border lg:border-l lg:border-t-0',
-            index === 1 && 'lg:border-l',
-          )}
-        >
-          <dd className="font-display text-4xl leading-none text-primary transition-transform duration-[var(--dur-base)] ease-[var(--ease-out-quint)] group-hover:-translate-y-0.5">
+      {metrics.map((metric) => (
+        <div key={metric.label} className="flex items-baseline gap-2">
+          <dd className="font-mono text-lg leading-none tabular tracking-tight">
             {typeof metric.value === 'number' ? (
               <CountUp value={metric.value} />
             ) : (
               metric.value
             )}
           </dd>
-          <dt className="mt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-            {metric.label}
-          </dt>
+          <dt className="page-eyebrow">{metric.label}</dt>
         </div>
       ))}
     </dl>

--- a/src/components/layout/PageIntro.tsx
+++ b/src/components/layout/PageIntro.tsx
@@ -1,18 +1,27 @@
 import type { ReactNode } from 'react';
+import { CountUp } from '@/components/ui/count-up';
+import { cn } from '@/lib/utils';
 
 export function PageIntro({
   title,
   description,
+  eyebrow,
   actions,
 }: {
   title: string;
   description?: ReactNode;
+  eyebrow?: string;
   actions?: ReactNode;
 }) {
   return (
-    <header className="border-b border-border pb-6">
+    <header className="border-b border-[var(--rule-heavy)] pb-6">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
         <div className="reveal">
+          {eyebrow ? (
+            <p className="mb-3 font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+              {eyebrow}
+            </p>
+          ) : null}
           <h1 className="font-display text-[clamp(2.65rem,4vw,4rem)] leading-none tracking-[-0.035em]">
             {title}
           </h1>
@@ -28,22 +37,44 @@ export function PageIntro({
   );
 }
 
+/**
+ * Column of figures under a page heading, set like a broadsheet statistics
+ * band: a mono label above a display numeral, separated by hairline rules.
+ */
 export function MetricStrip({
   metrics,
+  className,
 }: {
   metrics: Array<{ label: string; value: number | string }>;
+  className?: string;
 }) {
   return (
-    <dl className="reveal reveal-1 grid grid-cols-2 border-b border-border lg:grid-cols-4">
+    <dl
+      className={cn(
+        'reveal reveal-1 grid grid-cols-2 border-b border-border lg:grid-cols-4',
+        className,
+      )}
+    >
       {metrics.map((metric, index) => (
         <div
           key={metric.label}
-          className={`flex items-baseline justify-center gap-2 py-4 ${
-            index % 2 === 1 ? 'border-l border-border' : ''
-          } ${index > 1 ? 'border-t border-border lg:border-l lg:border-t-0' : ''}`}
+          className={cn(
+            'group relative px-1 py-4 text-center lg:py-5',
+            index % 2 === 1 && 'border-l border-border',
+            index > 1 && 'border-t border-border lg:border-l lg:border-t-0',
+            index === 1 && 'lg:border-l',
+          )}
         >
-          <dt className="order-2 text-xs text-muted-foreground">{metric.label}</dt>
-          <dd className="font-display text-3xl leading-none text-primary">{metric.value}</dd>
+          <dd className="font-display text-4xl leading-none text-primary transition-transform duration-[var(--dur-base)] ease-[var(--ease-out-quint)] group-hover:-translate-y-0.5">
+            {typeof metric.value === 'number' ? (
+              <CountUp value={metric.value} />
+            ) : (
+              metric.value
+            )}
+          </dd>
+          <dt className="mt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+            {metric.label}
+          </dt>
         </div>
       ))}
     </dl>

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type ThemeChoice = 'light' | 'dark' | 'system';
+
+export const THEME_STORAGE_KEY = 'policai-theme';
+
+const THEME_EVENT = 'policai:theme';
+
+/**
+ * Runs before first paint so a stored choice is applied without a flash of the
+ * system theme. Kept as a string because it is injected via
+ * `dangerouslySetInnerHTML` in the root layout.
+ */
+export const themeInitScript = `(function(){try{var t=localStorage.getItem('${THEME_STORAGE_KEY}');if(t==='light'||t==='dark'){document.documentElement.dataset.theme=t}}catch(e){}})();`;
+
+const OPTIONS: Array<{ value: ThemeChoice; label: string; Icon: typeof Sun }> = [
+  { value: 'light', label: 'Light', Icon: Sun },
+  { value: 'system', label: 'System', Icon: Monitor },
+  { value: 'dark', label: 'Dark', Icon: Moon },
+];
+
+/**
+ * The `<html>` element is the single source of truth: the init script sets it
+ * before hydration and `select` updates it. Reading from the DOM rather than
+ * from component state keeps every toggle on the page in agreement.
+ */
+function subscribe(onStoreChange: () => void) {
+  window.addEventListener(THEME_EVENT, onStoreChange);
+  return () => window.removeEventListener(THEME_EVENT, onStoreChange);
+}
+
+function getSnapshot(): ThemeChoice {
+  const theme = document.documentElement.dataset.theme;
+  return theme === 'light' || theme === 'dark' ? theme : 'system';
+}
+
+// The server cannot know the visitor's stored choice, so it renders the
+// system option; hydration then swaps in the real one.
+function getServerSnapshot(): ThemeChoice {
+  return 'system';
+}
+
+function select(value: ThemeChoice) {
+  if (value === 'system') delete document.documentElement.dataset.theme;
+  else document.documentElement.dataset.theme = value;
+
+  try {
+    if (value === 'system') localStorage.removeItem(THEME_STORAGE_KEY);
+    else localStorage.setItem(THEME_STORAGE_KEY, value);
+  } catch {
+    // Storage can be unavailable (private mode, blocked cookies). The choice
+    // still applies for this page view, it just will not persist.
+  }
+
+  window.dispatchEvent(new Event(THEME_EVENT));
+}
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const choice = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-0.5 rounded-full border border-border bg-card/60 p-0.5',
+        className,
+      )}
+      role="radiogroup"
+      aria-label="Colour theme"
+    >
+      {OPTIONS.map(({ value, label, Icon }) => {
+        const active = choice === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={label}
+            title={label}
+            onClick={() => select(value)}
+            className={cn(
+              'flex h-7 w-7 items-center justify-center rounded-full transition-colors duration-[var(--dur-fast)]',
+              active
+                ? 'bg-primary text-primary-foreground'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" strokeWidth={1.9} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,3 +1,4 @@
 export { Header } from './Header';
 export { Footer } from './Footer';
 export { PageIntro, MetricStrip } from './PageIntro';
+export { ThemeToggle, themeInitScript } from './ThemeToggle';

--- a/src/components/map-browser.tsx
+++ b/src/components/map-browser.tsx
@@ -81,6 +81,10 @@ export function MapBrowser({ policiesData }: { policiesData: Policy[] }) {
 
 	return (
 		<div className="relative flex min-h-[calc(100svh-7rem)] overflow-hidden bg-background">
+			<h1 className="pointer-events-none absolute left-5 top-4 z-10 font-mono text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground md:left-8 md:top-6">
+				Policies by jurisdiction
+			</h1>
+
 			{/* Map area — takes full width, panel overlays */}
 			<div className="relative flex flex-1 min-w-0 items-start justify-center px-4 pt-4 pb-28 md:px-8 md:pt-6 md:pb-16">
 				<AustraliaMap
@@ -92,9 +96,20 @@ export function MapBrowser({ policiesData }: { policiesData: Policy[] }) {
 			</div>
 
 			{/* Sliding policy panel */}
+			{/*
+				The panel keeps its border and background only while a jurisdiction is
+				selected. Parked off-canvas it would otherwise leave a sliver of card
+				showing past the right edge, because it slides by its own width from an
+				inset position.
+			*/}
 			<div
 				ref={panelRef}
-				className={`absolute inset-x-0 bottom-0 z-10 flex max-h-[60vh] flex-col overflow-hidden border-t border-border bg-background shadow-xl transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] md:bottom-6 md:left-auto md:right-6 md:top-6 md:h-[calc(100%-3rem)] md:max-h-none md:w-[22rem] md:border md:bg-card/95 md:shadow-lg md:backdrop-blur-sm ${
+				aria-hidden={!selectedJurisdiction}
+				className={`absolute inset-x-0 bottom-0 z-10 flex max-h-[60vh] flex-col overflow-hidden transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] md:bottom-6 md:left-auto md:right-6 md:top-6 md:h-[calc(100%-3rem)] md:max-h-none md:w-[22rem] ${
+					selectedJurisdiction
+						? "border-t border-border bg-background shadow-xl md:border md:bg-card/95 md:shadow-lg md:backdrop-blur-sm"
+						: "invisible"
+				} ${
 					panelVisible
 						? "translate-y-0 md:translate-y-0 md:translate-x-0"
 						: "translate-y-full md:translate-y-0 md:translate-x-full"

--- a/src/components/network-browser.tsx
+++ b/src/components/network-browser.tsx
@@ -287,10 +287,10 @@ export function NetworkBrowser({
 						<div className="font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
 							Relationship explorer
 						</div>
-						<h1 className="network-desktop-title mt-2 font-display text-[clamp(2.65rem,4vw,4rem)] leading-none tracking-[-0.035em]">
+						<h1 className="network-desktop-title mt-2 page-title">
 							Policy relationships
 						</h1>
-						<h1 className="network-mobile-title mt-2 hidden font-display text-[2.5rem] leading-[0.98] tracking-[-0.03em]">
+						<h1 className="network-mobile-title page-title mt-2 hidden">
 							Policy relationships
 						</h1>
 						<p className="network-insight-line mt-3 flex items-start gap-2 text-sm font-medium">
@@ -349,7 +349,7 @@ export function NetworkBrowser({
 						<dt className="order-2 text-[11px] text-muted-foreground">
 							{metric.label}
 						</dt>
-						<dd className="font-display text-3xl leading-none text-primary">
+						<dd className="font-mono text-xl leading-none tabular">
 							{metric.value}
 						</dd>
 					</div>

--- a/src/components/network-browser.tsx
+++ b/src/components/network-browser.tsx
@@ -288,10 +288,10 @@ export function NetworkBrowser({
 							Relationship explorer
 						</div>
 						<h1 className="network-desktop-title mt-2 font-display text-[clamp(2.65rem,4vw,4rem)] leading-none tracking-[-0.035em]">
-							Where Australian AI policy converges
+							Policy relationships
 						</h1>
 						<h1 className="network-mobile-title mt-2 hidden font-display text-[2.5rem] leading-[0.98] tracking-[-0.03em]">
-							Court guidance crosses jurisdictions
+							Policy relationships
 						</h1>
 						<p className="network-insight-line mt-3 flex items-start gap-2 text-sm font-medium">
 							<span className="mt-1.5 size-2.5 shrink-0 rounded-full bg-[var(--trust)]" />

--- a/src/components/policy-browser.tsx
+++ b/src/components/policy-browser.tsx
@@ -35,6 +35,9 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
+import { HealthSignal } from '@/components/ui/health-signal';
+import { MetricStrip } from '@/components/layout/PageIntro';
+import { jurisdictionRailStyle } from '@/lib/jurisdiction-accent';
 import { formatPolicyDate } from '@/lib/format-policy-date';
 import {
   JURISDICTION_NAMES,
@@ -248,7 +251,7 @@ export function PolicyBrowser({
   const freshnessDate = lastHealthyAt ?? lastCollectedAt ?? lastReviewedAt;
   const freshLabel =
     collectionHealth === 'healthy'
-      ? 'Continuous monitoring of official sources'
+      ? `All ${dueSourceCount} due sources reached`
       : `${successfulSourceCount}/${dueSourceCount} due sources reached`;
 
   return (
@@ -257,17 +260,16 @@ export function PolicyBrowser({
         <div className="grid gap-6 border-b border-border pb-6 lg:grid-cols-[minmax(0,1fr)_23rem] lg:items-end">
           <div className="reveal">
             <h1 className="max-w-5xl font-display text-[clamp(2.65rem,4.5vw,4.5rem)] leading-[0.98] tracking-[-0.035em]">
-              Australian AI policy, made legible.
+              The Australian AI policy register
             </h1>
             <p className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
-              Track AI policy and governance across Australian governments.
+              Legislation, guidance and court practice notes from federal, state
+              and territory governments. Every record links to the official
+              source it came from.
             </p>
           </div>
           <div className="reveal reveal-1 hidden border-l border-border pl-5 lg:mb-1 lg:block">
-            <p className="flex items-center gap-2 font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-[var(--trust)]">
-              <span className="h-2.5 w-2.5 rounded-full bg-[var(--trust)]" />
-              {collectionHealth === 'healthy' ? 'Live' : collectionHealth}
-            </p>
+            <HealthSignal health={collectionHealth} />
             <p className="mt-2 text-sm">{freshLabel}</p>
             {freshnessDate ? (
               <p className="mt-2 font-mono text-[11px] uppercase text-muted-foreground">
@@ -282,21 +284,17 @@ export function PolicyBrowser({
           <span className="mx-2">·</span>
           <span className="font-display text-2xl text-primary">{distinctJurisdictions.size}</span> jurisdictions
           <span className="mx-2">·</span>
-          <span className="text-[var(--trust)]">Verified sources</span>
+          <span className="font-display text-2xl text-primary">{developmentCount}</span> developments
         </p>
-        <dl className="reveal reveal-1 hidden grid-cols-2 border-b border-border md:grid md:grid-cols-4">
-          {[
-            [policies.length, 'policies'],
-            [distinctJurisdictions.size, 'jurisdictions'],
-            [developmentCount, 'developments'],
-            [automaticSourceCount, 'sources monitored'],
-          ].map(([value, label], index) => (
-            <div key={label} className={cn('flex items-baseline justify-center gap-2 py-4 md:py-5', index % 2 === 1 ? 'border-l border-border' : '', index > 1 ? 'border-t border-border md:border-t-0 md:border-l' : '', index === 1 ? 'md:border-l' : '')}>
-              <dt className="order-2 text-xs text-muted-foreground">{label}</dt>
-              <dd className="font-display text-4xl leading-none text-primary">{value}</dd>
-            </div>
-          ))}
-        </dl>
+        <MetricStrip
+          className="hidden md:grid md:grid-cols-4"
+          metrics={[
+            { value: policies.length, label: 'policies' },
+            { value: distinctJurisdictions.size, label: 'jurisdictions' },
+            { value: developmentCount, label: 'developments' },
+            { value: automaticSourceCount, label: 'sources monitored' },
+          ]}
+        />
       </section>
 
       <section className="reveal reveal-2 container mx-auto px-4 pb-10 sm:px-6 lg:px-8">
@@ -313,7 +311,7 @@ export function PolicyBrowser({
                   placeholder="Search policies, agencies and topics"
                   value={search}
                   onChange={(event) => setSearch(event.target.value)}
-                  className="h-11 w-full border border-input bg-background pl-11 pr-14 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/15"
+                  className="h-11 w-full rounded-md border border-input bg-background pl-11 pr-14 text-sm outline-none transition-[border-color,box-shadow] duration-[var(--dur-base)] placeholder:text-muted-foreground focus:border-primary focus:ring-2 focus:ring-primary/20"
                 />
                 <kbd className="absolute right-3 top-1/2 hidden -translate-y-1/2 border border-border px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground sm:block">
                   ⌘K
@@ -374,7 +372,7 @@ export function PolicyBrowser({
                         if (types.includes(value)) toggleFilter(value, setTypes);
                         if (statuses.includes(value)) toggleFilter(value, setStatuses);
                       }}
-                      className="inline-flex min-h-9 items-center gap-2 rounded-md border border-primary/30 bg-accent px-3 text-xs font-medium text-primary transition-colors hover:border-primary/60"
+                      className="group inline-flex min-h-9 items-center gap-2 rounded-full border border-primary/30 bg-accent px-3 text-xs font-medium text-primary transition-colors duration-[var(--dur-fast)] hover:border-primary/60 hover:bg-primary hover:text-primary-foreground"
                     >
                       {label}
                       <span aria-hidden="true">×</span>
@@ -414,7 +412,11 @@ export function PolicyBrowser({
             </div>
             <div>
               {developments.slice(0, 5).map((development) => (
-                <article key={development.id} className="content-auto border-b border-border py-4">
+                <article
+                  key={development.id}
+                  style={jurisdictionRailStyle(development.jurisdiction)}
+                  className="ink-rail content-auto border-b border-border py-4 pl-3"
+                >
                   <p className="font-mono text-[10px] uppercase text-muted-foreground">{formatDevelopmentDate(development)}</p>
                   <a href={development.url} target="_blank" rel="noopener noreferrer" className="group mt-2 inline-flex items-start gap-1.5 text-sm font-semibold leading-5 hover:text-primary">
                     {development.title}
@@ -429,7 +431,7 @@ export function PolicyBrowser({
               ))}
               {developments.length === 0 ? (
                 <p className="border-b border-border py-5 text-xs leading-5 text-muted-foreground">
-                  No newly verified developments are published. Automated leads remain available in the radar.
+                  Nothing verified yet. Unconfirmed leads are still listed on the radar.
                 </p>
               ) : null}
             </div>

--- a/src/components/policy-browser.tsx
+++ b/src/components/policy-browser.tsx
@@ -256,38 +256,30 @@ export function PolicyBrowser({
 
   return (
     <div>
-      <section className="container mx-auto px-4 pb-4 pt-6 sm:px-6 sm:pt-8 lg:px-8 lg:pb-6">
-        <div className="grid gap-6 border-b border-border pb-6 lg:grid-cols-[minmax(0,1fr)_23rem] lg:items-end">
-          <div className="reveal">
-            <h1 className="max-w-5xl font-display text-[clamp(2.65rem,4.5vw,4.5rem)] leading-[0.98] tracking-[-0.035em]">
-              The Australian AI policy register
-            </h1>
-            <p className="mt-4 max-w-2xl text-base leading-7 text-muted-foreground">
+      {/*
+        No display heading here. The register is what the page is for, so it
+        opens on the data with the title reduced to a label.
+      */}
+      <section className="container mx-auto px-4 pb-2 pt-7 sm:px-6 lg:px-8">
+        <div className="reveal flex flex-col gap-3 sm:flex-row sm:items-baseline sm:justify-between">
+          <div>
+            <h1 className="page-eyebrow">Australian AI policy register</h1>
+            <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
               Legislation, guidance and court practice notes from federal, state
-              and territory governments. Every record links to the official
-              source it came from.
+              and territory governments, each linked to its official source.
             </p>
           </div>
-          <div className="reveal reveal-1 hidden border-l border-border pl-5 lg:mb-1 lg:block">
+          <div className="flex shrink-0 items-center gap-3">
             <HealthSignal health={collectionHealth} />
-            <p className="mt-2 text-sm">{freshLabel}</p>
-            {freshnessDate ? (
-              <p className="mt-2 font-mono text-[11px] uppercase text-muted-foreground">
-                {formatDate(freshnessDate)}
-              </p>
-            ) : null}
+            <span className="page-eyebrow">
+              {freshLabel}
+              {freshnessDate ? ` · ${formatDate(freshnessDate)}` : ''}
+            </span>
           </div>
         </div>
 
-        <p className="reveal reveal-1 border-b border-border py-4 text-sm text-muted-foreground md:hidden">
-          <span className="font-display text-2xl text-primary">{policies.length}</span> policies
-          <span className="mx-2">·</span>
-          <span className="font-display text-2xl text-primary">{distinctJurisdictions.size}</span> jurisdictions
-          <span className="mx-2">·</span>
-          <span className="font-display text-2xl text-primary">{developmentCount}</span> developments
-        </p>
         <MetricStrip
-          className="hidden md:grid md:grid-cols-4"
+          className="mt-5"
           metrics={[
             { value: policies.length, label: 'policies' },
             { value: distinctJurisdictions.size, label: 'jurisdictions' },
@@ -303,7 +295,7 @@ export function PolicyBrowser({
 
           <div className="min-w-0 flex-1 py-5 lg:px-8">
             <div className="flex flex-col gap-3 sm:flex-row">
-              <div id="policy-search" className="relative flex-1 scroll-mt-36">
+              <div id="policy-search" className="relative flex-1 scroll-mt-28">
                 <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" strokeWidth={1.75} />
                 <input
                   ref={searchRef}
@@ -330,7 +322,7 @@ export function PolicyBrowser({
                 </SheetTrigger>
                 <SheetContent side="bottom" className="max-h-[88svh] overflow-y-auto p-5">
                   <SheetHeader className="px-0 pt-0">
-                    <SheetTitle className="font-display text-2xl">Filter policies</SheetTitle>
+                    <SheetTitle className="section-title">Filter policies</SheetTitle>
                     <SheetDescription className="sr-only">
                       Filter the policy register by jurisdiction, policy type, and status.
                     </SheetDescription>
@@ -406,7 +398,7 @@ export function PolicyBrowser({
             />
           </div>
 
-          <aside className="hidden w-[19.5rem] shrink-0 border-l border-border py-5 pl-7 xl:block">
+          <aside className="hidden w-[19.5rem] shrink-0 border-l border-[var(--rule-hair)] py-5 pl-7 xl:block">
             <div className="flex items-center justify-between border-b border-border pb-3">
               <h2 className="font-mono text-[11px] font-medium uppercase tracking-[0.12em]">Latest developments</h2>
             </div>

--- a/src/components/policy-table.tsx
+++ b/src/components/policy-table.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { ArrowRight, CheckCircle2 } from 'lucide-react';
+import { ArrowRight, ChevronDown, ChevronUp, ChevronsUpDown, CheckCircle2 } from 'lucide-react';
 import {
   getJurisdictionName,
   getPolicyDateTypeName,
@@ -12,6 +12,7 @@ import {
   type Policy,
 } from '@/types';
 import { formatPolicyDate } from '@/lib/format-policy-date';
+import { jurisdictionAccent, jurisdictionRailStyle } from '@/lib/jurisdiction-accent';
 import { cn } from '@/lib/utils';
 
 export type PolicySortField = 'title' | 'jurisdiction' | 'type' | 'status' | 'effectiveDate';
@@ -31,16 +32,36 @@ function comparePolicies(a: Policy, b: Policy, field: PolicySortField): number {
 function StatusPill({ status }: { status: Policy['status'] }) {
   const tone =
     status === 'active'
-      ? 'border-[var(--trust)]/20 bg-[var(--status-active-bg)] text-[var(--status-active)]'
+      ? 'border-[var(--trust)]/25 bg-[var(--status-active-bg)] text-[var(--status-active)]'
       : status === 'proposed'
-        ? 'border-[var(--caution)]/20 bg-[var(--status-proposed-bg)] text-[var(--status-proposed)]'
+        ? 'border-[var(--caution)]/25 bg-[var(--status-proposed-bg)] text-[var(--status-proposed)]'
         : status === 'amended'
-          ? 'border-primary/20 bg-[var(--status-amended-bg)] text-[var(--status-amended)]'
+          ? 'border-primary/25 bg-[var(--status-amended-bg)] text-[var(--status-amended)]'
           : 'border-border bg-[var(--status-repealed-bg)] text-[var(--status-repealed)]';
 
   return (
     <span className={cn('inline-flex rounded-md border px-2 py-1 text-xs font-medium', tone)}>
       {getPolicyStatusName(status)}
+    </span>
+  );
+}
+
+/** Jurisdiction name preceded by its livery colour, so rows group by eye. */
+function JurisdictionMark({
+  jurisdiction,
+  className,
+}: {
+  jurisdiction: string;
+  className?: string;
+}) {
+  return (
+    <span className={cn('inline-flex items-center gap-2', className)}>
+      <span
+        aria-hidden="true"
+        className="h-1.5 w-1.5 shrink-0 rounded-full"
+        style={{ background: jurisdictionAccent(jurisdiction) }}
+      />
+      {getJurisdictionName(jurisdiction)}
     </span>
   );
 }
@@ -67,7 +88,10 @@ function PolicyCard({ policy, compact = false }: { policy: Policy; compact?: boo
   const primaryDate = getPrimaryPolicyDate(policy);
 
   return (
-    <article className="content-auto border border-border bg-card/45 p-4">
+    <article
+      style={jurisdictionRailStyle(policy.jurisdiction)}
+      className="ink-rail hover-lift content-auto border border-border bg-card/45 p-4 pl-5 hover:border-[var(--rule)]"
+    >
       <Link
         href={`/policies/${policy.id}`}
         className="text-[17px] font-semibold leading-snug text-primary hover:underline"
@@ -80,7 +104,7 @@ function PolicyCard({ policy, compact = false }: { policy: Policy; compact?: boo
         </p>
       ) : null}
       <p className="mt-3 text-sm">
-        {getJurisdictionName(policy.jurisdiction)}
+        <JurisdictionMark jurisdiction={policy.jurisdiction} />
         <span className="mx-2 text-border">•</span>
         {getPolicyTypeName(policy.type)}
       </p>
@@ -139,15 +163,12 @@ export function PolicyTable({
     onSort(field);
   };
 
-  const sortLabel = (field: PolicySortField, label: string) =>
-    `${label}${sortField === field ? (sortDirection === 'asc' ? ' ↑' : ' ↓') : ''}`;
-
   if (paged.length === 0) {
     return (
       <div className="border-y border-border py-14 text-center">
-        <p className="font-display text-2xl">No matching policies</p>
+        <p className="font-display text-2xl">Nothing matches those filters</p>
         <p className="mt-2 text-sm text-muted-foreground">
-          Try removing a filter or broadening the search.
+          Remove a filter or search for a broader term.
         </p>
       </div>
     );
@@ -168,25 +189,55 @@ export function PolicyTable({
           <div className="hidden overflow-x-auto md:block">
             <table className="w-full table-fixed">
               <thead>
-                <tr className="border-y border-foreground/55">
+                <tr className="border-y border-[var(--rule-heavy)]">
                   {([
-                    ['title', 'Policy', 'w-[33%]'],
-                    ['jurisdiction', 'Jurisdiction', 'w-[16%]'],
-                    ['type', 'Type', 'w-[11%]'],
+                    ['title', 'Policy', 'w-[32%] pl-3'],
+                    ['jurisdiction', 'Jurisdiction', 'w-[15%]'],
+                    ['type', 'Type', 'w-[10%]'],
                     ['status', 'Status', 'w-[10%]'],
-                    ['effectiveDate', 'Key date', 'w-[11%]'],
-                  ] as const).map(([field, label, width]) => (
-                    <th key={field} className={cn('py-2 pr-3 text-left', width)}>
-                      <button
-                        type="button"
-                        onClick={() => handleSort(field)}
-                        className="font-mono text-[10px] font-medium uppercase tracking-[0.1em] text-muted-foreground hover:text-foreground"
+                    ['effectiveDate', 'Key date', 'w-[13%]'],
+                  ] as const).map(([field, label, width]) => {
+                    const isSorted = sortField === field;
+                    const SortIcon = !isSorted
+                      ? ChevronsUpDown
+                      : sortDirection === 'asc'
+                        ? ChevronUp
+                        : ChevronDown;
+                    return (
+                      <th
+                        key={field}
+                        className={cn('py-2.5 pr-3 text-left', width)}
+                        aria-sort={
+                          isSorted
+                            ? sortDirection === 'asc'
+                              ? 'ascending'
+                              : 'descending'
+                            : 'none'
+                        }
                       >
-                        {sortLabel(field, label)}
-                      </button>
-                    </th>
-                  ))}
-                  <th className="w-[16%] py-2 text-left font-mono text-[10px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+                        <button
+                          type="button"
+                          onClick={() => handleSort(field)}
+                          className={cn(
+                            'group inline-flex items-center gap-1 whitespace-nowrap font-mono text-[10px] font-medium uppercase tracking-[0.1em] transition-colors duration-[var(--dur-fast)]',
+                            isSorted
+                              ? 'text-foreground'
+                              : 'text-muted-foreground hover:text-foreground',
+                          )}
+                        >
+                          {label}
+                          <SortIcon
+                            className={cn(
+                              'h-3 w-3 transition-opacity duration-[var(--dur-fast)]',
+                              isSorted ? 'opacity-100' : 'opacity-0 group-hover:opacity-60',
+                            )}
+                            strokeWidth={2.2}
+                          />
+                        </button>
+                      </th>
+                    );
+                  })}
+                  <th className="w-[15%] whitespace-nowrap py-2.5 text-left font-mono text-[10px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
                     Source
                   </th>
                   <th className="w-6" />
@@ -196,9 +247,16 @@ export function PolicyTable({
                 {paged.map((policy) => {
                   const primaryDate = getPrimaryPolicyDate(policy);
                   return (
-                    <tr key={policy.id} className="group/row content-auto border-b border-border transition-colors hover:bg-[var(--row-hover)]">
-                      <td className="py-3 pr-5 align-top">
-                        <Link href={`/policies/${policy.id}`} className="text-sm font-semibold leading-5 text-primary hover:underline">
+                    <tr
+                      key={policy.id}
+                      style={jurisdictionRailStyle(policy.jurisdiction)}
+                      className="group/row content-auto border-b border-border transition-colors duration-[var(--dur-fast)] hover:bg-[var(--row-hover)]"
+                    >
+                      <td className="ink-rail py-3 pl-3 pr-5 align-top">
+                        <Link
+                          href={`/policies/${policy.id}`}
+                          className="text-sm font-semibold leading-5 text-primary hover:underline"
+                        >
                           {policy.title}
                         </Link>
                         <p className="mt-1 line-clamp-2 max-w-xl text-xs leading-4 text-muted-foreground">
@@ -206,7 +264,7 @@ export function PolicyTable({
                         </p>
                       </td>
                       <td className="py-3 pr-3 align-top text-xs leading-5 text-muted-foreground">
-                        {getJurisdictionName(policy.jurisdiction)}
+                        <JurisdictionMark jurisdiction={policy.jurisdiction} />
                       </td>
                       <td className="py-3 pr-3 align-top text-xs leading-5 text-muted-foreground">
                         {getPolicyTypeName(policy.type)}
@@ -218,8 +276,12 @@ export function PolicyTable({
                       </td>
                       <td className="py-3 align-top"><SourceState policy={policy} /></td>
                       <td className="py-3 align-top">
-                        <Link href={`/policies/${policy.id}`} aria-label={`View ${policy.title}`} className="text-primary">
-                          <ArrowRight className="h-4 w-4 transition-transform duration-200 group-hover/row:translate-x-0.5" />
+                        <Link
+                          href={`/policies/${policy.id}`}
+                          aria-label={`View ${policy.title}`}
+                          className="text-primary"
+                        >
+                          <ArrowRight className="h-4 w-4 transition-transform duration-[var(--dur-base)] ease-[var(--ease-out-quint)] group-hover/row:translate-x-1" />
                         </Link>
                       </td>
                     </tr>
@@ -236,10 +298,20 @@ export function PolicyTable({
             Page {safePage + 1} of {totalPages}
           </span>
           <div className="flex gap-2">
-            <button type="button" onClick={() => setPage(Math.max(0, safePage - 1))} disabled={safePage === 0} className="min-h-10 border border-border px-4 text-xs font-medium hover:bg-muted disabled:opacity-35">
+            <button
+              type="button"
+              onClick={() => setPage(Math.max(0, safePage - 1))}
+              disabled={safePage === 0}
+              className="min-h-10 rounded-md border border-border px-4 text-xs font-medium transition-colors duration-[var(--dur-fast)] hover:bg-muted disabled:opacity-35 disabled:hover:bg-transparent"
+            >
               Previous
             </button>
-            <button type="button" onClick={() => setPage(Math.min(totalPages - 1, safePage + 1))} disabled={safePage >= totalPages - 1} className="min-h-10 border border-border px-4 text-xs font-medium hover:bg-muted disabled:opacity-35">
+            <button
+              type="button"
+              onClick={() => setPage(Math.min(totalPages - 1, safePage + 1))}
+              disabled={safePage >= totalPages - 1}
+              className="min-h-10 rounded-md border border-border px-4 text-xs font-medium transition-colors duration-[var(--dur-fast)] hover:bg-muted disabled:opacity-35 disabled:hover:bg-transparent"
+            >
               Next
             </button>
           </div>

--- a/src/components/policy-table.tsx
+++ b/src/components/policy-table.tsx
@@ -166,7 +166,7 @@ export function PolicyTable({
   if (paged.length === 0) {
     return (
       <div className="border-y border-border py-14 text-center">
-        <p className="font-display text-2xl">Nothing matches those filters</p>
+        <p className="section-title">Nothing matches those filters</p>
         <p className="mt-2 text-sm text-muted-foreground">
           Remove a filter or search for a broader term.
         </p>

--- a/src/components/timeline-browser.tsx
+++ b/src/components/timeline-browser.tsx
@@ -78,7 +78,7 @@ export function TimelineBrowser({
     <div className="container mx-auto px-4 py-7 sm:px-6 lg:px-8">
       <PageIntro
         title="Policy timeline"
-        description="Source-linked milestones across Australian jurisdictions."
+        description="Dated events from the register, each linked to the source that recorded it."
       />
 
       <MetricStrip metrics={[

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-[var(--dur-fast)] ease-[var(--ease-out-quint)] active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50 disabled:active:scale-100 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/src/components/ui/count-up.tsx
+++ b/src/components/ui/count-up.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const DURATION_MS = 900;
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+/**
+ * Counts from zero to `value` the first time it scrolls into view.
+ *
+ * The final value is what renders on the server and on the first client render,
+ * so the correct figure is present without JavaScript and for screen readers.
+ */
+export function CountUp({ value }: { value: number }) {
+  const [display, setDisplay] = useState(value);
+  const ref = useRef<HTMLSpanElement>(null);
+  const hasRun = useRef(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || hasRun.current || prefersReducedMotion() || value <= 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0]?.isIntersecting || hasRun.current) return;
+        hasRun.current = true;
+        observer.disconnect();
+
+        const start = performance.now();
+        const step = (now: number) => {
+          const progress = Math.min(1, (now - start) / DURATION_MS);
+          // Ease-out quint, matching --ease-out-quint elsewhere in the UI.
+          const eased = 1 - Math.pow(1 - progress, 5);
+          setDisplay(Math.round(eased * value));
+          if (progress < 1) requestAnimationFrame(step);
+        };
+        setDisplay(0);
+        requestAnimationFrame(step);
+      },
+      { threshold: 0.4 },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [value]);
+
+  return (
+    <span ref={ref} className="tabular">
+      {display}
+    </span>
+  );
+}

--- a/src/components/ui/health-signal.tsx
+++ b/src/components/ui/health-signal.tsx
@@ -1,0 +1,44 @@
+import type { CollectionHealthStatus } from '@/types';
+import { cn } from '@/lib/utils';
+
+const SIGNALS: Record<
+  CollectionHealthStatus,
+  { label: string; color: string; live: boolean }
+> = {
+  healthy: { label: 'Live', color: 'var(--trust)', live: true },
+  degraded: { label: 'Degraded', color: 'var(--caution)', live: false },
+  failed: { label: 'Failed', color: 'var(--alarm)', live: false },
+};
+
+/**
+ * Collection-health indicator. The dot takes the colour of the state it is
+ * reporting, and only a healthy run gets the live pulse.
+ */
+export function HealthSignal({
+  health,
+  className,
+}: {
+  health: CollectionHealthStatus;
+  className?: string;
+}) {
+  const signal = SIGNALS[health] ?? SIGNALS.failed;
+
+  return (
+    <p
+      className={cn(
+        'flex items-center gap-2 font-mono text-[11px] font-medium uppercase tracking-[0.14em]',
+        className,
+      )}
+      style={{ color: signal.color }}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          'relative inline-flex h-2.5 w-2.5 shrink-0 rounded-full bg-current',
+          signal.live && 'pulse-live',
+        )}
+      />
+      {signal.label}
+    </p>
+  );
+}

--- a/src/components/visualizations/PolicyFrameworkMap.tsx
+++ b/src/components/visualizations/PolicyFrameworkMap.tsx
@@ -171,7 +171,7 @@ function PillarCard({ pillar, isSelected, onSelect }: { pillar: Pillar; isSelect
         <CardDescription className="text-sm">{pillar.description}</CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="flex items-center gap-2 text-sm">
+        <div className="flex flex-wrap items-center gap-2 text-sm">
           <Badge variant="secondary">{pillar.principles.length} Principles</Badge>
           <Badge variant="destructive">{mandatoryCount} Mandatory</Badge>
         </div>
@@ -218,13 +218,13 @@ export function PolicyFrameworkMap({ data, onPillarSelect }: PolicyFrameworkMapP
             <Building2 className="h-6 w-6 text-primary" />
             <h2 className="text-2xl font-bold">{data.title}</h2>
           </div>
-          <div className="flex items-center gap-2 mt-2">
+          <div className="mt-2 flex flex-wrap items-center gap-2">
             <Badge variant="outline">Version {data.version}</Badge>
             <Badge variant="secondary">Effective: {new Date(data.effectiveDate).toLocaleDateString('en-AU')}</Badge>
-            <Badge>{data.authority}</Badge>
+            <Badge className="max-w-full whitespace-normal text-left">{data.authority}</Badge>
           </div>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <Button
             variant={view === 'overview' ? 'default' : 'outline'}
             size="sm"

--- a/src/lib/jurisdiction-accent.ts
+++ b/src/lib/jurisdiction-accent.ts
@@ -1,0 +1,21 @@
+import type { CSSProperties } from 'react';
+import { JURISDICTION_NAMES, type Jurisdiction } from '@/types';
+
+/**
+ * Each jurisdiction carries an accent taken from its own government livery
+ * (Queensland maroon, Northern Territory ochre, and so on). The values live in
+ * `globals.css` as `--jd-*` so they follow the active theme.
+ */
+export function jurisdictionAccent(jurisdiction: string): string {
+  return jurisdiction in JURISDICTION_NAMES
+    ? `var(--jd-${jurisdiction as Jurisdiction})`
+    : 'var(--muted-foreground)';
+}
+
+/**
+ * Sets the custom property the `.ink-rail` utility reads, so a row or card
+ * highlights in the colour of the jurisdiction that issued it.
+ */
+export function jurisdictionRailStyle(jurisdiction: string): CSSProperties {
+  return { '--rail-color': jurisdictionAccent(jurisdiction) } as CSSProperties;
+}


### PR DESCRIPTION
Two passes over the register's interface and its public copy, plus six pre-existing defects.

The editorial identity is unchanged — paper/ink palette, Newsreader, Public Sans, IBM Plex Mono. What changed is scale, depth, colour coding and copy.

## Pass 1 — sharpen (702b6a7)

**Design system**
- Every theme colour declared once with `light-dark()`, so each token has one source of truth and the theme can be pinned via `color-scheme` alone.
- Added rule weights, motion tokens, elevation and a global `:focus-visible`.
- Nine jurisdiction accents drawn from each government's own livery.

**Interface**
- Light / dark / system theme toggle. The site was system-only with no override; an init script applies the stored choice before first paint.
- The "ink rail": a jurisdiction-tinted spine that wipes down a hovered row or card.
- Figures count up when a metric band scrolls into view; sort headers gained chevrons and `aria-sort`.

## Pass 2 — strip back (51813af)

- Removed the display headline from the register. It now opens on a mono label and the table: six rows above the fold where two were.
- Added a shared heading scale so sizes stop drifting page-by-page — `.page-eyebrow` (10px), `.page-title` (26–32px), `.section-title` (18px), `.article-title` (30–42px, for a policy record or post where the title is the content). Headings had reached 80px.
- Metric band reduced to figures on one hairline; the bordered four-column version read as a second table.
- Masthead 84px → 68px, sticky offsets moved with it.

## Defects fixed

All pre-existing, none introduced here.

| Was | Now |
| --- | --- |
| Collection health rendered *degraded* and *failed* in healthy-green, on two pages | `HealthSignal` colours the dot by the state it reports, pulses only when healthy |
| Filter group labels struck through by their own rule (a `<legend>` paints inside its fieldset's top border) | Rule moved to a wrapper |
| Methodology, blog and courts centred their body under a full-width heading | Aligned to the same left edge |
| Map's detail panel kept its border and card background while parked off-canvas, leaving a visible sliver | Hidden until a jurisdiction is selected |
| Framework badges overflowed horizontally below ~400px | Wrap |
| Map page had no heading | Has one |

## Copy

Humanizer and copywriting passes. Removed the "made legible" tagline, the footer's three-part slogan, and "Where Australian AI policy converges"; rewrote passive empty states and promotional status lines; sentence case in headings.

## Verification

`npm run check` — lint, typecheck, 413 tests, data validation (0 errors, the 4 known editorial-review warnings), production build (33 routes). Checked at 1440px and 390px in both themes: no horizontal overflow. Theme toggle, ink rail and jurisdiction tinting driven in a real browser.

## Not addressed

The Key requirements tab on the OVIC policy detail page renders scraped page furniture (a 2020 Internet Explorer notice) instead of requirements. That is a collector/extraction issue, not UI, so it is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)