### PR TITLE
Self-host on Argus at policai.org

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Policai is an Australian AI policy tracker. It maintains a curated register of AI policy, regulation, governance and court guidance across federal and state/territory jurisdictions, plus an automated "developments" feed of newly detected policy activity.
 
-**Git is the database.** All canonical data is JSON committed to this repository (`public/data/`, `data/`). The deployed site (Vercel) only reads that data — pages are statically rendered from it at build time. Automation runs in GitHub Actions, which commits new detections; the push triggers a redeploy. There is no runtime database, no auth, and no admin dashboard.
+**Git is the database.** All canonical data is JSON committed to this repository (`public/data/`, `data/`). The deployed site only reads that data. It is self-hosted on the Argus server at [policai.org](https://policai.org), behind a Cloudflare tunnel — see [docs/hosting-argus.md](./docs/hosting-argus.md). Automation runs in GitHub Actions, which commits new detections; the host pulls those commits and serves them through ISR without a rebuild. There is no runtime database, no auth, and no admin dashboard.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ High-confidence detections are staged in `data/source-reviews.json`; a reviewer 
 - Next.js 16 App Router, React 19, TypeScript 5 (strict)
 - Tailwind CSS 4, shadcn/ui on Radix UI, D3.js
 - Cheerio for scraping and deterministic relevance classification
-- Vitest; GitHub Actions for automation; Vercel for hosting
+- Vitest; GitHub Actions for automation; self-hosted on Argus behind a Cloudflare tunnel
 
 ## Quick Start
 
@@ -107,7 +107,7 @@ filters as the site.
 
 ## Deployment
 
-Vercel serves the site; pushes to `main` deploy automatically. The collector does not require an external analysis service or model credential. See [docs/collector.md](./docs/collector.md).
+The site is self-hosted at [policai.org](https://policai.org) on the Argus server, served by `next start` behind a Cloudflare tunnel. The host pulls `main` on a timer: data-only commits are picked up by ISR within the hour, and code changes trigger a rebuild and restart. See [docs/hosting-argus.md](./docs/hosting-argus.md). The collector does not require an external analysis service or model credential. See [docs/collector.md](./docs/collector.md).
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This directory holds the project-facing documentation that should stay in sync w
 - [Collector operations guide](./collector.md) — how the daily collector works, running it locally, the GitHub Actions workflow, reviewing detections into the register, and adding sources.
 - [Architecture](./architecture.md) — system boundaries, data ownership, and non-negotiable invariants.
 - [Information trust model](./trust-model.md) — verification tiers, source rules, date policy, and publication gates.
+- [Hosting on Argus](./hosting-argus.md) — serving policai.org from the Argus server behind a Cloudflare tunnel: architecture, cutover, rollback, and failure modes.
 - [Authoritative refactor tracker](./refactor-authoritative-policai.md) — baseline findings, workstreams, and completion gates.
 - [Network relationship explorer concept](./design/policai-network-concept-02.md) — the approved desktop/mobile semantic design contract for `/network`.
 

--- a/docs/collector.md
+++ b/docs/collector.md
@@ -203,7 +203,7 @@ force the selected source regardless of its normal daily/weekly due time.
 6. On any failure: open (or comment on) an issue labelled `collector-failure`
    so scheduled breakage is never silent
 
-The push triggers a Vercel deployment, so the site republishes with the new data. Manual runs: Actions → "Collect AI policy developments" → Run workflow (optionally with a single source id).
+The host pulls the push on its timer. Because pages read the JSON from disk at request time and revalidate hourly, the new data appears without a rebuild or a restart. Manual runs: Actions → "Collect AI policy developments" → Run workflow (optionally with a single source id).
 
 The CLI persists source reviews and developments before advancing
 `watch-state.json`. Stable review/development ids make a retry idempotent if an

--- a/docs/hosting-argus.md
+++ b/docs/hosting-argus.md
@@ -1,0 +1,226 @@
+# Policai on Argus, behind a Cloudflare tunnel
+
+Design for Phase 1: move hosting from Vercel to the Argus server and serve it at
+policai.org. Phase 2, replacing the GitHub Actions collector with a scheduled
+Claude run, is deliberately out of scope and is specified separately.
+
+Date: 2026-08-07
+
+## Goal
+
+policai.org serves the register from Argus. The Vercel deployment is retired
+once the new host is proven, with no window where the site is unreachable and no
+window where collection stops.
+
+## Current state
+
+Observed on 2026-08-06, not assumed:
+
+- The live site is `policai.vercel.app`. `policai.com.au` appears in four places
+  in the code but is not a live domain.
+- `policai.org` is active in the "Tideflow" Cloudflare account, the same account
+  as `tideflow.au`. It has two placeholder A records pointing at
+  `103.42.108.46`, both proxied.
+- Argus runs Ubuntu 26.04 with Node v22.23.2, 43 GB memory available and 1.7 TB
+  free. User service linger is on for `l0cka`.
+- Argus already runs one named cloudflared tunnel, `desk-webapp`, serving six
+  `tideflow.au` hostnames from `~/.cloudflared/desk-webapp.yml` under the user
+  unit `cloudflared-desk.service`.
+- `cloudflared tunnel list` returns `unauthorized`, so the stored `cert.pem` can
+  no longer manage tunnels.
+- Ports 8789 and 8791 to 8793 are taken. 8794 is free.
+- Argus authenticates to GitHub both by `gh` and by the SSH key
+  `id_ed25519_github`.
+
+Two properties of the application shape this design:
+
+- `data-service` reads its JSON from `process.cwd()` at request time, and every
+  page sets `revalidate = 3600`. New data on disk is therefore served within the
+  hour with no rebuild and no restart.
+- `/policies/[id]`, `/network` and `/api/*` are dynamic, and there is no
+  `generateStaticParams`. A static export is not possible; the app needs a Node
+  process.
+
+## Non-goals
+
+- Replacing the collector. GitHub Actions keeps running on its 19:30 UTC
+  schedule throughout this phase.
+- Moving `policai.com.au`. It is not live and is being dropped from the code
+  rather than migrated.
+- Changing the trust model or the methodology page. Those change in Phase 2,
+  when what they describe actually changes.
+
+## Architecture
+
+```
+GitHub (canonical data, unchanged)
+        |  git pull, every 15 min
+        v
+~/live/policai            checkout on Argus
+        |  next start
+        v
+127.0.0.1:8794            policai.service        (user systemd unit)
+        |
+        v
+cloudflared               cloudflared-policai.service
+        |
+        v
+policai.org, www.policai.org
+```
+
+Git stays the database. Argus is a reader: it pulls, it never pushes in this
+phase. That keeps the cutover one-directional and makes rollback trivial.
+
+## Components
+
+### `policai.service`
+
+Runs `next start -p 8794` from `~/live/policai`. A user unit, matching the
+existing `desk-webapp.service` convention, with `Restart=on-failure` and
+`RestartSec=10`. Depends on the checkout being built. Binds to loopback only, so
+nothing is exposed except through the tunnel.
+
+### `policai-pull.service` and `.timer`
+
+Every 15 minutes: `git pull --ff-only`. If the pull changes anything under
+`src/`, `package.json` or `package-lock.json`, it runs `npm ci` and
+`npm run build` and restarts `policai.service`. If it only changes files under
+`data/` or `public/data/`, it does nothing further, because ISR picks those up
+on its own.
+
+`--ff-only` is deliberate. Argus must never produce a merge commit or diverge
+from origin; if it cannot fast-forward, that is a fault to report rather than
+resolve automatically.
+
+### `cloudflared-policai.service`
+
+A dedicated named tunnel, `policai`, with its own config at
+`~/.cloudflared/policai.yml` and its own unit. It is kept separate from
+`desk-webapp` so that a mistake in Policai's ingress cannot affect the six
+production `tideflow.au` hostnames.
+
+Ingress:
+
+```yaml
+ingress:
+  - hostname: policai.org
+    service: http://127.0.0.1:8794
+  - hostname: www.policai.org
+    service: http://127.0.0.1:8794
+  - service: http_status:404
+```
+
+### Domain references in the application
+
+Four values change from `policai.com.au` to `policai.org`:
+
+| File | Value |
+| --- | --- |
+| `src/app/layout.tsx` | `metadataBase` |
+| `src/app/sitemap.ts` | `BASE_URL` |
+| `src/app/robots.ts` | `sitemap` URL |
+| `src/lib/pipeline/fetch.ts` | collector User-Agent |
+
+The User-Agent one matters beyond tidiness: it is how the collector identifies
+itself to the government sites it fetches, and the URL in it should resolve.
+
+`www.policai.org` redirects to the apex so the two hostnames do not compete as
+separate canonical URLs. The redirect is done in the application, as a `redirects()`
+entry in `next.config.ts` matching on the `www` host, rather than as a Cloudflare
+rule. That keeps the behaviour in the repository where it is reviewable and
+testable, instead of as dashboard state nobody can see from the code.
+
+## Deployment and update flow
+
+Data changes need nothing. The pull timer writes new JSON and ISR serves it
+within the hour.
+
+Code changes need `git pull`, `npm ci`, `npm run build`, then a restart. The
+pull timer does this automatically; it is also a single documented command to
+run by hand.
+
+The build runs on Argus. It has ample memory, and building elsewhere would mean
+shipping artefacts around for no benefit.
+
+## Cutover
+
+1. Build and start the service on Argus. Verify locally over SSH with `curl`
+   against `127.0.0.1:8794` while the site is still served by Vercel.
+2. Create the tunnel. Do not route DNS yet.
+3. Delete the two placeholder A records, then run `cloudflared tunnel route dns`
+   for both hostnames. The order matters: the route command will not overwrite
+   an existing record, so the A records must go first. This is the moment the
+   site changes hands, and it is deliberately a single short step.
+4. Verify policai.org and www.policai.org externally, in both themes, including
+   a dynamic route and an API route.
+5. Leave Vercel running for at least one collection cycle, so a full
+   pull-to-serve round trip is proven on Argus.
+6. Retire the Vercel project.
+
+## Rollback
+
+Each step reverses independently:
+
+- Application faulty: `systemctl --user stop policai`, point DNS back. Vercel is
+  still serving until step 6.
+- Tunnel faulty: `systemctl --user stop cloudflared-policai`. The `desk-webapp`
+  tunnel is untouched throughout, so tideflow.au is unaffected by anything here.
+- Bad deploy: the checkout is a git clone, so `git reset --hard <sha>`, rebuild,
+  restart.
+
+The DNS change in step 3 is the only step with a propagation delay, and it is
+the last one before verification.
+
+## Failure modes
+
+| Failure | Handling |
+| --- | --- |
+| Build fails during an automatic pull | Keep serving the old build. Do not restart on a failed build. Report. |
+| `git pull` cannot fast-forward | Stop, do not merge, report. Someone has committed to the checkout. |
+| `next start` exits | `Restart=on-failure` with a 10 second delay. |
+| Tunnel drops | `Restart=on-failure`. Cloudflare serves its own error page meanwhile. |
+| Disk fills | Out of scope here, but `.next` growth is worth watching; noted for observability. |
+
+Failures are visible through `systemctl --user status` and the journal. Active
+alerting is deferred to Phase 2, which introduces the alerting pattern for the
+collector; the site failing is less urgent than collection failing silently,
+because the site failing is externally obvious.
+
+## Success criteria
+
+- `https://policai.org` and `https://www.policai.org` serve the register over
+  HTTPS, with `www` redirecting to the apex.
+- A dynamic route (`/policies/<id>`) and an API route (`/api/policies`) both
+  respond correctly.
+- A data commit pushed to GitHub is visible on policai.org within the hour
+  without any manual step.
+- `systemctl --user restart policai` recovers the site.
+- Rebooting Argus brings both units back automatically.
+- The six `tideflow.au` hostnames are unaffected, verified before and after.
+
+## Requires the operator
+
+One step cannot be automated: `cloudflared tunnel login` opens a browser for
+Cloudflare authorisation, because the stored certificate no longer has
+permission to manage tunnels. Everything else follows from that.
+
+## Carried into Phase 2
+
+Recorded here so the next phase starts from evidence rather than a fresh survey:
+
+- Argus can push to GitHub as `l0cka`, by `gh` token and by the
+  `id_ed25519_github` SSH key. The Actions workflow currently pushes with a
+  separate collector deploy key that is a bypass actor on the "Protect main"
+  ruleset. Whether `l0cka` can push to `main` directly is unverified and is a
+  precondition for Phase 2.
+- Claude Code 2.1.221 is installed on Argus with credentials present.
+  `ANTHROPIC_API_KEY` is not set in a non-interactive environment, so the auth
+  model for an unattended run is an open question.
+- The collector needs headless Chromium; the workflow installs it with
+  `playwright-core install --with-deps chromium`.
+- `collect.yml` contains two guards worth preserving: `npm run validate:data`,
+  and a check that the collector never modifies `data/policies.json`. Both
+  matter more, not less, once a model is involved.
+- Phase 2 must rewrite the methodology page, `AGENTS.md` and the trust model,
+  which currently state that analysis is deterministic with no external AI
+  provider.

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,10 +3,24 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
 	// data-service resolves these files through runtime path parameters, which
 	// Next's static dependency tracer cannot infer. Include them for every
-	// server route so Vercel functions and ISR never deploy without the
-	// canonical register or collection metadata.
+	// server route so self-hosted ISR never serves without the canonical
+	// register or collection metadata.
 	outputFileTracingIncludes: {
 		"/*": ["./data/**/*.json", "./public/data/**/*.json"],
+	},
+
+	async redirects() {
+		return [
+			// The tunnel answers for both hostnames, so the canonical choice is
+			// made here rather than as a Cloudflare rule: it stays visible in the
+			// repository and survives a move between hosts.
+			{
+				source: "/:path*",
+				has: [{ type: "host", value: "www.policai.org" }],
+				destination: "https://policai.org/:path*",
+				permanent: true,
+			},
+		];
 	},
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,7 +39,7 @@ export const metadata: Metadata = {
     'government policy',
     'AI governance Australia',
   ],
-  metadataBase: new URL('https://policai.com.au'),
+  metadataBase: new URL('https://policai.org'),
 };
 
 export default async function RootLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,6 +9,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/admin/', '/api/'],
       },
     ],
-    sitemap: 'https://policai.com.au/sitemap.xml',
+    sitemap: 'https://policai.org/sitemap.xml',
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next';
 import { getPolicies } from '@/lib/data-service';
 
-const BASE_URL = 'https://policai.com.au';
+const BASE_URL = 'https://policai.org';
 export const revalidate = 3600;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {

--- a/src/lib/pipeline/fetch.ts
+++ b/src/lib/pipeline/fetch.ts
@@ -25,7 +25,7 @@ const MAX_LINKED_DOCUMENTS = 8;
 export type DocumentKind = 'pdf' | 'docx' | 'doc' | 'rtf';
 
 export const COLLECTOR_USER_AGENT =
-  'Mozilla/5.0 (compatible; Policai/1.0; +https://policai.com.au)';
+  'Mozilla/5.0 (compatible; Policai/1.0; +https://policai.org)';
 
 export class SourceFetchError extends Error {
   readonly status?: number;


### PR DESCRIPTION
Moves hosting from Vercel to the Argus server, served at policai.org behind a dedicated Cloudflare tunnel.

Design: [`docs/hosting-argus.md`](./docs/hosting-argus.md), added in the first commit.

## Why the domain changes

`policai.com.au` appeared in four places and is not a live domain. One of them is the collector's `User-Agent`, which is how it identifies itself to the government sites it fetches — that URL should resolve.

`www.policai.org` redirects to the apex in `next.config.ts` rather than as a Cloudflare rule. The tunnel answers for both hostnames, and keeping the canonical choice in the repository means it is reviewable, testable, and survives a move between hosts.

## Already running on Argus

Both units are up and enabled, bound to loopback, with **no public change yet** — policai.org still resolves to its placeholder origin.

```
policai.service              active, enabled   127.0.0.1:8794
cloudflared-policai.service  active, enabled   4 healthy connections (syd06/syd08)
```

Verified over SSH: homepage 200 in 19 ms, `/policies/<id>` 200, `/api/policies` returning JSON.

The `policai` tunnel was created through the Cloudflare API rather than `cloudflared tunnel login`, because that command would have overwritten the `cert.pem` the live `desk-webapp` tunnel depends on. `cert.pem` is untouched and both tideflow tunnels still report 4 healthy connections.

## Docs

`AGENTS.md`, `README.md` and `docs/collector.md` described Vercel and a redeploy-on-push model. Data commits are now picked up by ISR within the hour without a rebuild, because `data-service` reads its JSON from disk at request time.

## Still to come, after this merges

1. Argus pulls and rebuilds on this commit
2. DNS cutover — delete the two placeholder A records, route both hostnames to the tunnel
3. Verify externally, then retire Vercel after one collection cycle

Replacing the GitHub Actions collector with a scheduled run on Argus is deliberately a separate phase.

## Verification

`npm run check` — lint, typecheck, 413 tests, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)