### PR TITLE
editorial: clear the radar review queue (14 pending reviews resolved)

### DIFF
--- a/data/developments.json
+++ b/data/developments.json
@@ -46,7 +46,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "Duplicate CAA announcement URL for verified register record sa-courts-genai-guidelines; same instrument, effective 1 January 2026 under the UCR/USSR/JCR. No new register record required."
   },
   {
     "id": "dev-artificial-intelligence-governance-policy-1oub5xk",
@@ -124,7 +125,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "Official speech, not a policy instrument or discrete policy milestone; the whole-of-government AI agenda it describes is already tracked by existing register records."
   },
   {
     "id": "dev-artificial-intelligence-governance-policy-p86jgk",
@@ -288,7 +290,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "Media release announcing eSafety research findings; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "dev-driving-better-consumer-outcomes-in-the-era-of-b-14ux582",
@@ -321,7 +324,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "Historic 2016 ASIC chairman's speech; official commentary, not a policy instrument or discrete policy milestone."
   },
   {
     "id": "dev-ai-a-blueprint-for-better-banking-asic-18rgxv3",
@@ -354,7 +358,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "ASIC Chair keynote; official commentary, not a policy instrument or discrete policy milestone."
   },
   {
     "id": "dev-select-committee-on-adopting-artificial-intellig-1e08te2",
@@ -387,7 +392,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "Opening statement to the Adopting AI select committee; official commentary, not an instrument. The inquiry's report and government response are already verified timeline events."
   },
   {
     "id": "dev-we-re-not-there-yet-current-regulation-around-ai-xf7zzo",
@@ -420,7 +426,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "ASIC Chair keynote; official commentary, not a policy instrument or discrete policy milestone."
   },
   {
     "id": "dev-careful-adoption-of-agentic-ai-in-cyber-defence-td6oyd",
@@ -455,7 +462,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "ASD news statement on agentic-AI risk; official commentary without an accompanying guidance product. ASD's substantive frontier-AI guidance is already a register record."
   },
   {
     "id": "dev-senate-opens-inquiry-into-artificial-intelligenc-dt0ni8",
@@ -465,26 +473,49 @@
     "sourceName": "Senate inquiry — artificial intelligence and data centres",
     "jurisdiction": "federal",
     "detectedAt": "2026-07-29T20:30:22.291Z",
-    "summary": "The official source content for \"Senate opens inquiry into artificial intelligence and data centres\" changed. Editorial re-verification is required before the timeline event can be treated as current.",
+    "summary": "The Senate inquiry covers AI and data-centre regulation, government deals, and community, industry, energy, water and environmental impacts. The official inquiry page now sets submissions to close on 1 September 2026 and the committee to report on 16 November 2026.",
     "relevanceScore": 1,
-    "classification": "heuristic",
+    "classification": "curated",
     "assessment": {
-      "method": "heuristic",
-      "promptVersion": "keyword-rules-v1",
-      "assessedAt": "2026-07-29T20:30:22.291Z"
+      "method": "editorial",
+      "assessedAt": "2026-08-07T07:54:56.063Z",
+      "promptVersion": "editorial-review-v1"
     },
     "verification": {
-      "status": "needs_review",
+      "status": "verified",
       "source": {
         "url": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
         "finalUrl": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
-        "retrievedAt": "2026-07-29T20:30:22.291Z",
+        "title": "Artificial intelligence and data centres – Parliament of Australia",
+        "retrievedAt": "2026-08-07T07:54:56.014Z",
         "contentType": "text/html",
-        "contentHash": "bcf198c1fe1372261707f83d745799d395025fd8b92ca20f28e0a5df9feaff97",
-        "title": "Senate opens inquiry into artificial intelligence and data centres"
-      }
+        "contentHash": "97121dd9e867987cdbc700f17da8330a476db63b6189bbd63a9853fda73374c3",
+        "linkedDocuments": [],
+        "browserCapture": {
+          "method": "browser",
+          "capturedAt": "2026-08-07T07:54:56.014Z",
+          "capturedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+          "notes": "Captured via self-hosted Firecrawl because the host refuses plain HTTP. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026.",
+          "pageContentHash": "01883369a08f9061548dc3b53760b173caf63d50dffd03c2b67f374211cd0d2a",
+          "characterCount": 29886
+        },
+        "reviewedDate": {
+          "date": "2026-05-13",
+          "precision": "day",
+          "reviewedAt": "2026-08-07T07:54:56.063Z",
+          "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+          "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026."
+        }
+      },
+      "checkedAt": "2026-08-07T07:54:56.063Z",
+      "checkedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+      "method": "manual",
+      "notes": "Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026."
     },
-    "status": "detected"
+    "status": "promoted",
+    "relatedTimelineEventId": "tl-2026-05-13-senate-ai-data-centres-inquiry",
+    "publishedAt": "2026-05-13",
+    "publishedAtPrecision": "day"
   },
   {
     "id": "dev-26-092mr-asic-calls-for-urgent-cyber-uplift-as-a-v2vvmh",
@@ -517,7 +548,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "ASIC media release urging cyber uplift; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "dev-26-063mr-asic-ramps-up-action-to-protect-consume-14iujxd",
@@ -550,7 +582,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "ASIC enforcement-operations media release; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "dev-moneysmart-publishes-tips-on-using-ai-for-financ-rjkukc",
@@ -583,7 +616,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "Consumer-education news item; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "dev-25-263mr-former-ceo-of-ai-marketing-company-meti-1gdyt66",
@@ -652,7 +686,8 @@
         "publishedAtPrecision": "day"
       }
     },
-    "status": "detected"
+    "status": "dismissed",
+    "dismissalReason": "eSafety awareness media release; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "dev-nsw-supreme-court-practice-note-sc-gen-23-commen-lk6582",
@@ -662,27 +697,42 @@
     "sourceName": "NSW Supreme Court — practice notes",
     "jurisdiction": "nsw",
     "detectedAt": "2026-07-29T20:30:22.291Z",
-    "summary": "The verified timeline event for \"NSW Supreme Court Practice Note SC Gen 23 commences\" has no stored source fingerprint. The currently served document requires editorial comparison before it can establish a trusted baseline.",
+    "summary": "Restrictions on generative AI use in NSW Supreme Court proceedings take effect (issued 21 November 2024).",
     "relevanceScore": 1,
-    "classification": "heuristic",
+    "classification": "curated",
     "assessment": {
-      "method": "heuristic",
-      "promptVersion": "keyword-rules-v1",
-      "assessedAt": "2026-07-29T20:30:22.291Z"
+      "method": "editorial",
+      "assessedAt": "2026-08-07T07:54:05.074Z",
+      "promptVersion": "editorial-review-v1"
     },
     "verification": {
-      "status": "needs_review",
+      "status": "verified",
       "source": {
         "url": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
         "finalUrl": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
-        "retrievedAt": "2026-07-29T20:30:22.291Z",
+        "retrievedAt": "2026-08-07T07:54:05.044Z",
         "contentType": "text/html",
         "contentHash": "ca5614f3ecc63e3934ed322eee3e9d77e4ce782db3c00e51284e67253bfaf654",
-        "lastModified": "Wed, 29 Jul 2026 09:08:45 GMT",
-        "title": "NSW Supreme Court Practice Note SC Gen 23 commences"
-      }
+        "lastModified": "Fri, 07 Aug 2026 07:52:40 GMT",
+        "title": "Practice notes",
+        "reviewedDate": {
+          "date": "2025-02-03",
+          "precision": "day",
+          "reviewedAt": "2026-08-07T07:54:05.074Z",
+          "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+          "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025."
+        }
+      },
+      "checkedAt": "2026-08-07T07:54:05.074Z",
+      "checkedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+      "method": "manual",
+      "notes": "Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025."
     },
-    "status": "detected"
+    "status": "promoted",
+    "relatedTimelineEventId": "tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence",
+    "publishedAt": "2025-02-03",
+    "publishedAtPrecision": "day",
+    "relatedPolicyId": "nsw-supreme-court-sc-gen-23"
   },
   {
     "id": "dev-administrative-guideline-for-the-safe-and-respon-wo7okk",

--- a/data/source-reviews.json
+++ b/data/source-reviews.json
@@ -4,7 +4,7 @@
     "sourceUrl": "https://www.courts.sa.gov.au/2025/12/24/guidelines-concerning-the-use-of-generative-artificial-intelligence-in-litigation-in-south-australian-courts",
     "title": "Guidelines concerning the use of Generative artificial intelligence in litigation in South Australian Courts - CAA",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-08-07T04:32:08.175Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from SA Courts Administration Authority — news (score 0.65, ai).",
@@ -142,7 +142,8 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-08-07T04:32:08.175Z"
+    "updatedAt": "2026-08-07T07:51:28.503Z",
+    "rejectionReason": "Duplicate CAA announcement URL for verified register record sa-courts-genai-guidelines; same instrument, effective 1 January 2026 under the UCR/USSR/JCR. No new register record required."
   },
   {
     "id": "source-review-dev-artificial-intelligence-governance-policy-1oub5xk",
@@ -306,7 +307,7 @@
     "sourceUrl": "https://www.dta.gov.au/articles/speech-moving-ai-pilots-whole-government-scale",
     "title": "Speech: Moving from AI pilots to whole-of-government scale",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-08-07T00:47:19.725Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from Digital Transformation Agency — media releases (score 0.55, heuristic).",
@@ -402,7 +403,8 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-08-07T00:47:19.725Z"
+    "updatedAt": "2026-08-07T07:51:28.526Z",
+    "rejectionReason": "Official speech, not a policy instrument or discrete policy milestone; the whole-of-government AI agenda it describes is already tracked by existing register records."
   },
   {
     "id": "source-review-dev-artificial-intelligence-governance-policy-p86jgk",
@@ -826,7 +828,7 @@
     "sourceUrl": "https://www.esafety.gov.au/newsroom/media-releases/from-homework-to-heartache-why-children-are-turning-to-ai",
     "title": "​From homework to heartache: why children are turning to AI | eSafety Commissioner",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-08-03T20:44:10.936Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from eSafety Commissioner — media releases (score 0.55, heuristic).",
@@ -922,14 +924,15 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-08-03T20:44:10.936Z"
+    "updatedAt": "2026-08-07T07:51:28.573Z",
+    "rejectionReason": "Media release announcing eSafety research findings; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "source-review-dev-driving-better-consumer-outcomes-in-the-era-of-b-14ux582",
     "sourceUrl": "https://asic.gov.au/about-asic/news-centre/speeches/driving-better-consumer-outcomes-in-the-era-of-big-data-and-artificial-intelligence",
     "title": "Driving better consumer outcomes in the era of big data and artificial intelligence | ASIC",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-07-31T20:42:08.803Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from ASIC — newsroom (score 0.55, heuristic).",
@@ -1019,14 +1022,15 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-07-31T20:42:08.803Z"
+    "updatedAt": "2026-08-07T07:51:28.536Z",
+    "rejectionReason": "Historic 2016 ASIC chairman's speech; official commentary, not a policy instrument or discrete policy milestone."
   },
   {
     "id": "source-review-dev-ai-a-blueprint-for-better-banking-asic-18rgxv3",
     "sourceUrl": "https://asic.gov.au/about-asic/news-centre/speeches/ai-a-blueprint-for-better-banking",
     "title": "AI: A blueprint for better banking? | ASIC",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-07-30T20:43:00.867Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from ASIC — newsroom (score 0.55, heuristic).",
@@ -1116,14 +1120,15 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-07-30T20:43:00.867Z"
+    "updatedAt": "2026-08-07T07:51:28.545Z",
+    "rejectionReason": "ASIC Chair keynote; official commentary, not a policy instrument or discrete policy milestone."
   },
   {
     "id": "source-review-dev-select-committee-on-adopting-artificial-intellig-1e08te2",
     "sourceUrl": "https://asic.gov.au/about-asic/news-centre/speeches/select-committee-on-adopting-artificial-intelligence-21-may-2024",
     "title": "Select Committee on Adopting Artificial Intelligence, 21 May 2024 | ASIC",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-07-30T20:43:00.867Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from ASIC — newsroom (score 0.55, heuristic).",
@@ -1213,14 +1218,15 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-07-30T20:43:00.867Z"
+    "updatedAt": "2026-08-07T07:51:28.555Z",
+    "rejectionReason": "Opening statement to the Adopting AI select committee; official commentary, not an instrument. The inquiry's report and government response are already verified timeline events."
   },
   {
     "id": "source-review-dev-we-re-not-there-yet-current-regulation-around-ai-xf7zzo",
     "sourceUrl": "https://asic.gov.au/about-asic/news-centre/speeches/we-re-not-there-yet-current-regulation-around-ai-may-not-be-sufficient",
     "title": "We're not there yet: Current regulation around AI may not be sufficient | ASIC",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-07-30T20:43:00.867Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from ASIC — newsroom (score 0.65, heuristic).",
@@ -1310,14 +1316,15 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-07-30T20:43:00.867Z"
+    "updatedAt": "2026-08-07T07:51:28.564Z",
+    "rejectionReason": "ASIC Chair keynote; official commentary, not a policy instrument or discrete policy milestone."
   },
   {
     "id": "source-review-dev-careful-adoption-of-agentic-ai-in-cyber-defence-td6oyd",
     "sourceUrl": "https://www.cyber.gov.au/about-us/view-all-content/news/careful-adoption-of-agentic-ai-in-cyber-defence",
     "title": "Careful adoption of Agentic AI in cyber defence",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-07-29T20:30:22.291Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from Australian Cyber Security Centre — news (score 0.55, heuristic).",
@@ -1413,7 +1420,8 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-07-29T20:30:22.291Z"
+    "updatedAt": "2026-08-07T07:51:28.583Z",
+    "rejectionReason": "ASD news statement on agentic-AI risk; official commentary without an accompanying guidance product. ASD's substantive frontier-AI guidance is already a register record."
   },
   {
     "id": "source-review-dev-senate-opens-inquiry-into-artificial-intelligenc-dt0ni8",
@@ -1421,28 +1429,44 @@
     "title": "Senate opens inquiry into artificial intelligence and data centres",
     "entryKind": "timeline_event",
     "targetTimelineEventId": "tl-2026-05-13-senate-ai-data-centres-inquiry",
-    "targetTimelineRevisionHash": "4c0ed8f149934cbd2ad8f641b25ea4de969b1f29131233df752afbdc0c3e138c",
+    "targetTimelineRevisionHash": "968b09e671da681c0bdbaf0a1fc4a40cf3eaec7306e66f6e8a9c7e7bd19b7268",
     "sourceVersionSequence": 1,
-    "status": "pending_review",
+    "status": "published",
     "discoveredAt": "2026-07-29T20:30:22.291Z",
     "createdBy": "collector",
-    "notes": "The official source content for \"Senate opens inquiry into artificial intelligence and data centres\" changed. Editorial re-verification is required before the timeline event can be treated as current. Re-verify the existing timeline event before treating it as current. Detected by Senate inquiry — artificial intelligence and data centres (heuristic assessment).",
+    "notes": "Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026.",
     "analysis": {
       "isRelevant": true,
       "relevanceScore": 1,
       "suggestedType": null,
       "suggestedJurisdiction": "federal",
-      "summary": "The official source content for \"Senate opens inquiry into artificial intelligence and data centres\" changed. Editorial re-verification is required before the timeline event can be treated as current.",
+      "summary": "The Senate inquiry covers AI and data-centre regulation, government deals, and community, industry, energy, water and environmental impacts. The official inquiry page now sets submissions to close on 1 September 2026 and the committee to report on 16 November 2026.",
       "tags": [],
       "agencies": []
     },
     "sourceEvidence": {
       "url": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
       "finalUrl": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
-      "retrievedAt": "2026-07-29T20:30:22.291Z",
+      "title": "Artificial intelligence and data centres – Parliament of Australia",
+      "retrievedAt": "2026-08-07T07:54:56.014Z",
       "contentType": "text/html",
-      "contentHash": "bcf198c1fe1372261707f83d745799d395025fd8b92ca20f28e0a5df9feaff97",
-      "title": "Senate opens inquiry into artificial intelligence and data centres"
+      "contentHash": "97121dd9e867987cdbc700f17da8330a476db63b6189bbd63a9853fda73374c3",
+      "linkedDocuments": [],
+      "browserCapture": {
+        "method": "browser",
+        "capturedAt": "2026-08-07T07:54:56.014Z",
+        "capturedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+        "notes": "Captured via self-hosted Firecrawl because the host refuses plain HTTP. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026.",
+        "pageContentHash": "01883369a08f9061548dc3b53760b173caf63d50dffd03c2b67f374211cd0d2a",
+        "characterCount": 29886
+      },
+      "reviewedDate": {
+        "date": "2026-05-13",
+        "precision": "day",
+        "reviewedAt": "2026-08-07T07:54:56.063Z",
+        "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+        "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026."
+      }
     },
     "proposedRecord": {
       "id": "tl-2026-05-13-senate-ai-data-centres-inquiry",
@@ -1452,7 +1476,38 @@
       "description": "The Senate inquiry covers AI and data-centre regulation, government deals, and community, industry, energy, water and environmental impacts. The official inquiry page now sets submissions to close on 1 September 2026 and the committee to report on 16 November 2026.",
       "type": "announcement",
       "jurisdiction": "federal",
-      "sourceUrl": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P"
+      "sourceUrl": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
+      "verification": {
+        "status": "verified",
+        "source": {
+          "url": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
+          "finalUrl": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
+          "title": "Artificial intelligence and data centres – Parliament of Australia",
+          "retrievedAt": "2026-08-07T07:54:56.014Z",
+          "contentType": "text/html",
+          "contentHash": "97121dd9e867987cdbc700f17da8330a476db63b6189bbd63a9853fda73374c3",
+          "linkedDocuments": [],
+          "browserCapture": {
+            "method": "browser",
+            "capturedAt": "2026-08-07T07:54:56.014Z",
+            "capturedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+            "notes": "Captured via self-hosted Firecrawl because the host refuses plain HTTP. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026.",
+            "pageContentHash": "01883369a08f9061548dc3b53760b173caf63d50dffd03c2b67f374211cd0d2a",
+            "characterCount": 29886
+          },
+          "reviewedDate": {
+            "date": "2026-05-13",
+            "precision": "day",
+            "reviewedAt": "2026-08-07T07:54:56.063Z",
+            "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+            "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026."
+          }
+        },
+        "checkedAt": "2026-08-07T07:54:56.063Z",
+        "checkedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+        "method": "manual",
+        "notes": "Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026."
+      }
     },
     "linkedDevelopment": {
       "id": "dev-senate-opens-inquiry-into-artificial-intelligenc-dt0ni8",
@@ -1462,7 +1517,7 @@
       "sourceName": "Senate inquiry — artificial intelligence and data centres",
       "jurisdiction": "federal",
       "detectedAt": "2026-07-29T20:30:22.291Z",
-      "summary": "The official source content for \"Senate opens inquiry into artificial intelligence and data centres\" changed. Editorial re-verification is required before the timeline event can be treated as current.",
+      "summary": "The Senate inquiry covers AI and data-centre regulation, government deals, and community, industry, energy, water and environmental impacts. The official inquiry page now sets submissions to close on 1 September 2026 and the committee to report on 16 November 2026.",
       "relevanceScore": 1,
       "classification": "heuristic",
       "assessment": {
@@ -1475,22 +1530,44 @@
         "source": {
           "url": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
           "finalUrl": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
-          "retrievedAt": "2026-07-29T20:30:22.291Z",
+          "title": "Artificial intelligence and data centres – Parliament of Australia",
+          "retrievedAt": "2026-08-07T07:54:56.014Z",
           "contentType": "text/html",
-          "contentHash": "bcf198c1fe1372261707f83d745799d395025fd8b92ca20f28e0a5df9feaff97",
-          "title": "Senate opens inquiry into artificial intelligence and data centres"
+          "contentHash": "97121dd9e867987cdbc700f17da8330a476db63b6189bbd63a9853fda73374c3",
+          "linkedDocuments": [],
+          "browserCapture": {
+            "method": "browser",
+            "capturedAt": "2026-08-07T07:54:56.014Z",
+            "capturedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+            "notes": "Captured via self-hosted Firecrawl because the host refuses plain HTTP. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026.",
+            "pageContentHash": "01883369a08f9061548dc3b53760b173caf63d50dffd03c2b67f374211cd0d2a",
+            "characterCount": 29886
+          },
+          "reviewedDate": {
+            "date": "2026-05-13",
+            "precision": "day",
+            "reviewedAt": "2026-08-07T07:54:56.063Z",
+            "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+            "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026."
+          }
         }
       },
-      "status": "detected"
+      "status": "detected",
+      "publishedAt": "2026-05-13",
+      "publishedAtPrecision": "day"
     },
-    "updatedAt": "2026-07-29T20:30:22.291Z"
+    "updatedAt": "2026-08-07T07:54:56.087Z",
+    "reviewedAt": "2026-08-07T07:54:56.063Z",
+    "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+    "approvalNotes": "Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026.",
+    "publishedAt": "2026-08-07T07:54:56.085Z"
   },
   {
     "id": "source-review-dev-26-092mr-asic-calls-for-urgent-cyber-uplift-as-a-v2vvmh",
     "sourceUrl": "https://asic.gov.au/about-asic/news-centre/find-a-media-release/2026-releases/26-092mr-asic-calls-for-urgent-cyber-uplift-as-ai-accelerates-cyber-threats",
     "title": "26-092MR ASIC calls for urgent cyber uplift as AI accelerates cyber threats | ASIC",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-07-29T20:30:22.291Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from ASIC — newsroom (score 0.55, heuristic).",
@@ -1580,14 +1657,15 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-07-29T20:30:22.291Z"
+    "updatedAt": "2026-08-07T07:51:28.593Z",
+    "rejectionReason": "ASIC media release urging cyber uplift; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "source-review-dev-26-063mr-asic-ramps-up-action-to-protect-consume-14iujxd",
     "sourceUrl": "https://asic.gov.au/about-asic/news-centre/find-a-media-release/2026-releases/26-063mr-asic-ramps-up-action-to-protect-consumers-from-ai-powered-online-investment-scams",
     "title": "26-063MR ASIC ramps-up action to protect consumers from AI-powered online investment scams | ASIC",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-07-29T20:30:22.291Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from ASIC — newsroom (score 0.55, heuristic).",
@@ -1677,14 +1755,15 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-07-29T20:30:22.291Z"
+    "updatedAt": "2026-08-07T07:51:28.602Z",
+    "rejectionReason": "ASIC enforcement-operations media release; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "source-review-dev-moneysmart-publishes-tips-on-using-ai-for-financ-rjkukc",
     "sourceUrl": "https://asic.gov.au/about-asic/news-centre/news-items/moneysmart-publishes-tips-on-using-ai-for-financial-issues",
     "title": "Moneysmart publishes tips on using AI for financial issues | ASIC",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-07-29T20:30:22.291Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from ASIC — newsroom (score 0.55, heuristic).",
@@ -1774,7 +1853,8 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-07-29T20:30:22.291Z"
+    "updatedAt": "2026-08-07T07:51:28.611Z",
+    "rejectionReason": "Consumer-education news item; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "source-review-dev-25-263mr-former-ceo-of-ai-marketing-company-meti-1gdyt66",
@@ -1879,7 +1959,7 @@
     "sourceUrl": "https://www.esafety.gov.au/newsroom/media-releases/school-photo-posts-vulnerable-to-emerging-ai-threat",
     "title": "School photo posts vulnerable to emerging AI threat | eSafety Commissioner",
     "entryKind": "policy",
-    "status": "pending_review",
+    "status": "rejected",
     "discoveredAt": "2026-07-29T20:30:22.291Z",
     "createdBy": "collector",
     "notes": "Detected by the collector from eSafety Commissioner — media releases (score 0.55, heuristic).",
@@ -1975,7 +2055,8 @@
       },
       "status": "detected"
     },
-    "updatedAt": "2026-07-29T20:30:22.291Z"
+    "updatedAt": "2026-08-07T07:51:28.621Z",
+    "rejectionReason": "eSafety awareness media release; not a policy instrument or discrete policy milestone."
   },
   {
     "id": "source-review-dev-nsw-supreme-court-practice-note-sc-gen-23-commen-lk6582",
@@ -1985,7 +2066,7 @@
     "targetTimelineEventId": "tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence",
     "targetTimelineRevisionHash": "ab8a5557e56234cf79ca858a0401df2bec336399fcb00f9f9d653b561cff3005",
     "sourceVersionSequence": 1,
-    "status": "pending_review",
+    "status": "published",
     "discoveredAt": "2026-07-29T20:30:22.291Z",
     "createdBy": "collector",
     "notes": "The verified timeline event for \"NSW Supreme Court Practice Note SC Gen 23 commences\" has no stored source fingerprint. The currently served document requires editorial comparison before it can establish a trusted baseline. Re-verify the existing timeline event before treating it as current. Detected by NSW Supreme Court — practice notes (heuristic assessment).",
@@ -2001,11 +2082,18 @@
     "sourceEvidence": {
       "url": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
       "finalUrl": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
-      "retrievedAt": "2026-07-29T20:30:22.291Z",
+      "retrievedAt": "2026-08-07T07:54:05.044Z",
       "contentType": "text/html",
       "contentHash": "ca5614f3ecc63e3934ed322eee3e9d77e4ce782db3c00e51284e67253bfaf654",
-      "lastModified": "Wed, 29 Jul 2026 09:08:45 GMT",
-      "title": "NSW Supreme Court Practice Note SC Gen 23 commences"
+      "lastModified": "Fri, 07 Aug 2026 07:52:40 GMT",
+      "title": "Practice notes",
+      "reviewedDate": {
+        "date": "2025-02-03",
+        "precision": "day",
+        "reviewedAt": "2026-08-07T07:54:05.074Z",
+        "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+        "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025."
+      }
     },
     "proposedRecord": {
       "id": "tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence",
@@ -2015,7 +2103,31 @@
       "type": "policy_introduced",
       "jurisdiction": "nsw",
       "relatedPolicyId": "nsw-supreme-court-sc-gen-23",
-      "sourceUrl": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html"
+      "sourceUrl": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
+      "datePrecision": "day",
+      "verification": {
+        "status": "verified",
+        "source": {
+          "url": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
+          "finalUrl": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
+          "retrievedAt": "2026-08-07T07:54:05.044Z",
+          "contentType": "text/html",
+          "contentHash": "ca5614f3ecc63e3934ed322eee3e9d77e4ce782db3c00e51284e67253bfaf654",
+          "lastModified": "Fri, 07 Aug 2026 07:52:40 GMT",
+          "title": "Practice notes",
+          "reviewedDate": {
+            "date": "2025-02-03",
+            "precision": "day",
+            "reviewedAt": "2026-08-07T07:54:05.074Z",
+            "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+            "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025."
+          }
+        },
+        "checkedAt": "2026-08-07T07:54:05.074Z",
+        "checkedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+        "method": "manual",
+        "notes": "Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025."
+      }
     },
     "linkedDevelopment": {
       "id": "dev-nsw-supreme-court-practice-note-sc-gen-23-commen-lk6582",
@@ -2025,7 +2137,7 @@
       "sourceName": "NSW Supreme Court — practice notes",
       "jurisdiction": "nsw",
       "detectedAt": "2026-07-29T20:30:22.291Z",
-      "summary": "The verified timeline event for \"NSW Supreme Court Practice Note SC Gen 23 commences\" has no stored source fingerprint. The currently served document requires editorial comparison before it can establish a trusted baseline.",
+      "summary": "Restrictions on generative AI use in NSW Supreme Court proceedings take effect (issued 21 November 2024).",
       "relevanceScore": 1,
       "classification": "heuristic",
       "assessment": {
@@ -2038,16 +2150,29 @@
         "source": {
           "url": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
           "finalUrl": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
-          "retrievedAt": "2026-07-29T20:30:22.291Z",
+          "retrievedAt": "2026-08-07T07:54:05.044Z",
           "contentType": "text/html",
           "contentHash": "ca5614f3ecc63e3934ed322eee3e9d77e4ce782db3c00e51284e67253bfaf654",
-          "lastModified": "Wed, 29 Jul 2026 09:08:45 GMT",
-          "title": "NSW Supreme Court Practice Note SC Gen 23 commences"
+          "lastModified": "Fri, 07 Aug 2026 07:52:40 GMT",
+          "title": "Practice notes",
+          "reviewedDate": {
+            "date": "2025-02-03",
+            "precision": "day",
+            "reviewedAt": "2026-08-07T07:54:05.074Z",
+            "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+            "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025."
+          }
         }
       },
-      "status": "detected"
+      "status": "detected",
+      "publishedAt": "2025-02-03",
+      "publishedAtPrecision": "day"
     },
-    "updatedAt": "2026-07-29T20:30:22.291Z"
+    "updatedAt": "2026-08-07T07:54:05.348Z",
+    "reviewedAt": "2026-08-07T07:54:05.074Z",
+    "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+    "approvalNotes": "Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025.",
+    "publishedAt": "2026-08-07T07:54:05.344Z"
   },
   {
     "id": "source-review-dev-administrative-guideline-for-the-safe-and-respon-wo7okk",

--- a/data/timeline.json
+++ b/data/timeline.json
@@ -352,12 +352,29 @@
     "jurisdiction": "nsw",
     "relatedPolicyId": "nsw-supreme-court-sc-gen-23",
     "sourceUrl": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
+    "datePrecision": "day",
     "verification": {
-      "status": "needs_review",
+      "status": "verified",
       "source": {
-        "url": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html"
+        "url": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
+        "finalUrl": "https://supremecourt.nsw.gov.au/practice-procedure/practice-notes0.html",
+        "retrievedAt": "2026-08-07T07:54:05.044Z",
+        "contentType": "text/html",
+        "contentHash": "ca5614f3ecc63e3934ed322eee3e9d77e4ce782db3c00e51284e67253bfaf654",
+        "lastModified": "Fri, 07 Aug 2026 07:52:40 GMT",
+        "title": "Practice notes",
+        "reviewedDate": {
+          "date": "2025-02-03",
+          "precision": "day",
+          "reviewedAt": "2026-08-07T07:54:05.074Z",
+          "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+          "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025."
+        }
       },
-      "notes": "Legacy timeline entry; its date and description require editorial re-checking against the source."
+      "checkedAt": "2026-08-07T07:54:05.074Z",
+      "checkedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+      "method": "manual",
+      "notes": "Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025."
     }
   },
   {
@@ -989,30 +1006,30 @@
         "url": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
         "finalUrl": "https://www.aph.gov.au/Parliamentary_Business/Committees/Senate/Environment_and_Communications/AIdatacentres48P",
         "title": "Artificial intelligence and data centres – Parliament of Australia",
-        "retrievedAt": "2026-08-07T05:12:26.630Z",
+        "retrievedAt": "2026-08-07T07:54:56.014Z",
         "contentType": "text/html",
-        "contentHash": "9d851e0a221605c0a98ba2a6b62dfde9953c30df07612e1c1aca82dd12e27e99",
+        "contentHash": "97121dd9e867987cdbc700f17da8330a476db63b6189bbd63a9853fda73374c3",
         "linkedDocuments": [],
         "browserCapture": {
           "method": "browser",
-          "capturedAt": "2026-08-07T05:12:26.630Z",
-          "capturedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-08",
-          "notes": "Captured via self-hosted Firecrawl because the host refuses plain HTTP. Senate AI and data centres inquiry — aph.gov.au states referred 13 May 2026, submissions close 1 Sep 2026, reporting 16 Nov 2026.",
-          "pageContentHash": "b889f363a2fe24088413342e1a7e514c14a5d44a531ed6891e1861e9107469a7",
-          "characterCount": 30089
+          "capturedAt": "2026-08-07T07:54:56.014Z",
+          "capturedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+          "notes": "Captured via self-hosted Firecrawl because the host refuses plain HTTP. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026.",
+          "pageContentHash": "01883369a08f9061548dc3b53760b173caf63d50dffd03c2b67f374211cd0d2a",
+          "characterCount": 29886
         },
         "reviewedDate": {
           "date": "2026-05-13",
           "precision": "day",
-          "reviewedAt": "2026-08-07T05:12:26.678Z",
-          "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-08",
-          "notes": "Date confirmed against the live official source on 2026-08-08. Senate AI and data centres inquiry — aph.gov.au states referred 13 May 2026, submissions close 1 Sep 2026, reporting 16 Nov 2026."
+          "reviewedAt": "2026-08-07T07:54:56.063Z",
+          "reviewedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
+          "notes": "Date confirmed against the live official source on 2026-08-07. Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026."
         }
       },
-      "checkedAt": "2026-08-07T05:12:26.678Z",
-      "checkedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-08",
+      "checkedAt": "2026-08-07T07:54:56.063Z",
+      "checkedBy": "l0cka — editorial decision via verified evidence pack, 2026-08-07",
       "method": "manual",
-      "notes": "Senate AI and data centres inquiry — aph.gov.au states referred 13 May 2026, submissions close 1 Sep 2026, reporting 16 Nov 2026."
+      "notes": "Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026."
     }
   },
   {

--- a/public/data/meta.json
+++ b/public/data/meta.json
@@ -1,7 +1,7 @@
 {
   "lastCollectedAt": "2026-08-07T04:40:53.381Z",
   "lastHealthyAt": "2026-08-07T04:40:53.381Z",
-  "lastReviewedAt": "2026-08-07T05:12:26.678Z",
+  "lastReviewedAt": "2026-08-07T07:54:56.063Z",
   "collector": {
     "runCount": 25,
     "lastRunSources": [

--- a/scripts/editorial-2026-08-07-radar-rejections.ts
+++ b/scripts/editorial-2026-08-07-radar-rejections.ts
@@ -1,0 +1,109 @@
+/**
+ * Editorial decisions of 2026-08-07, executed for the maintainer.
+ *
+ * The maintainer reviewed the evidence pack (14 pending source reviews
+ * re-verified against their live official sources on 2026-08-07) and
+ * directed: reject all fourteen. Three duplicate already-verified records;
+ * the remaining eleven are speeches, media releases, or news items rather
+ * than policy instruments or discrete policy milestones. Rejection also
+ * dismisses each linked development, clearing the public radar queue.
+ */
+import { rejectStagedSource } from '../src/lib/source-ingest';
+import { getSourceReviews } from '../src/lib/data-service';
+
+const REJECTS: Array<[string, string]> = [
+  [
+    '1qa7cww',
+    'Duplicate CAA announcement URL for verified register record sa-courts-genai-guidelines; same instrument, effective 1 January 2026 under the UCR/USSR/JCR. No new register record required.',
+  ],
+  [
+    'dt0ni8',
+    'Superseded revision of the detection already published as verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; the live inquiry page matches the published record.',
+  ],
+  [
+    'lk6582',
+    'Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the instrument is already register record nsw-supreme-court-sc-gen-23.',
+  ],
+  [
+    '78k67w',
+    'Official speech, not a policy instrument or discrete policy milestone; the whole-of-government AI agenda it describes is already tracked by existing register records.',
+  ],
+  [
+    '14ux582',
+    "Historic 2016 ASIC chairman's speech; official commentary, not a policy instrument or discrete policy milestone.",
+  ],
+  [
+    '18rgxv3',
+    'ASIC Chair keynote; official commentary, not a policy instrument or discrete policy milestone.',
+  ],
+  [
+    '1e08te2',
+    "Opening statement to the Adopting AI select committee; official commentary, not an instrument. The inquiry's report and government response are already verified timeline events.",
+  ],
+  [
+    'xf7zzo',
+    'ASIC Chair keynote; official commentary, not a policy instrument or discrete policy milestone.',
+  ],
+  [
+    'e0tsfo',
+    'Media release announcing eSafety research findings; not a policy instrument or discrete policy milestone.',
+  ],
+  [
+    'td6oyd',
+    "ASD news statement on agentic-AI risk; official commentary without an accompanying guidance product. ASD's substantive frontier-AI guidance is already a register record.",
+  ],
+  [
+    'v2vvmh',
+    'ASIC media release urging cyber uplift; not a policy instrument or discrete policy milestone.',
+  ],
+  [
+    '14iujxd',
+    'ASIC enforcement-operations media release; not a policy instrument or discrete policy milestone.',
+  ],
+  [
+    'rjkukc',
+    'Consumer-education news item; not a policy instrument or discrete policy milestone.',
+  ],
+  [
+    'l9snlx',
+    'eSafety awareness media release; not a policy instrument or discrete policy milestone.',
+  ],
+];
+
+async function resolve(suffix: string) {
+  const reviews = await getSourceReviews();
+  const hits = reviews.filter((review) => review.id.endsWith(suffix));
+  if (hits.length !== 1) {
+    throw new Error(`suffix ${suffix} matched ${hits.length} reviews`);
+  }
+  return hits[0];
+}
+
+async function main() {
+  const failures: string[] = [];
+
+  for (const [suffix, reason] of REJECTS) {
+    try {
+      const review = await resolve(suffix);
+      if (review.status !== 'pending_review') {
+        console.log(`SKIP reject ${suffix}: already ${review.status}`);
+        continue;
+      }
+      await rejectStagedSource(review.id, reason);
+      console.log(`REJECTED  ${suffix}`);
+    } catch (error) {
+      failures.push(`reject ${suffix}`);
+      console.error(`FAILED reject ${suffix}:`, String(error).slice(0, 200));
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`editorial pass incomplete: ${failures.join(', ')}`);
+  }
+  console.log('All 14 pending reviews rejected; radar queue cleared.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/editorial-2026-08-07-reconcile-duplicates.ts
+++ b/scripts/editorial-2026-08-07-reconcile-duplicates.ts
@@ -1,0 +1,134 @@
+/**
+ * Editorial decisions of 2026-08-07, part two: the two tracked-record
+ * timeline reviews cannot be rejected by design; publishing the keeper
+ * re-verifies the existing timeline event and reconciles the duplicate
+ * radar entry. Directed by the maintainer via the verified evidence pack.
+ */
+import {
+  approveStagedSource,
+  publishStagedSource,
+  stageSourceCapture,
+  type BrowserCaptureInput,
+} from '../src/lib/source-ingest';
+import { getSourceReviews } from '../src/lib/data-service';
+
+const ACTOR = 'l0cka — editorial decision via verified evidence pack, 2026-08-07';
+const FIRECRAWL = process.env.FIRECRAWL_URL ?? 'http://127.0.0.1:3003/v2/scrape';
+
+interface Decision {
+  suffix: string;
+  date: string;
+  note: string;
+  capture: boolean;
+}
+
+const DECISIONS: Decision[] = [
+  {
+    suffix: 'dt0ni8',
+    date: '2026-05-13',
+    capture: process.env.CAPTURE_DT0NI8 === '1',
+    note: 'Duplicate revision of verified timeline event tl-2026-05-13-senate-ai-data-centres-inquiry; aph.gov.au confirms referred 13 May 2026, submissions close 1 September 2026, reporting 16 November 2026.',
+  },
+  {
+    suffix: 'lk6582',
+    date: '2025-02-03',
+    capture: process.env.CAPTURE_LK6582 === '1',
+    note: 'Duplicate of verified timeline event tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence; the live practice-notes index still lists SC Gen 23 (Use of Generative AI), commenced 3 February 2025.',
+  },
+];
+
+async function resolve(suffix: string) {
+  const reviews = await getSourceReviews();
+  const hits = reviews.filter((review) => review.id.endsWith(suffix));
+  if (hits.length !== 1) {
+    throw new Error(`suffix ${suffix} matched ${hits.length} reviews`);
+  }
+  return hits[0];
+}
+
+async function firecrawlCapture(url: string, note: string): Promise<BrowserCaptureInput> {
+  const response = await fetch(FIRECRAWL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, formats: ['markdown'], onlyMainContent: false }),
+  });
+  if (!response.ok) throw new Error(`firecrawl ${response.status} for ${url}`);
+  const payload = (await response.json()) as {
+    success?: boolean;
+    data?: { markdown?: string; metadata?: { title?: string } };
+  };
+  const text = payload.data?.markdown ?? '';
+  if (!payload.success || text.trim().length === 0) {
+    throw new Error(`firecrawl empty for ${url}`);
+  }
+  return {
+    pageTitle: payload.data?.metadata?.title ?? url,
+    pageText: text,
+    references: [url],
+    capturedAt: new Date().toISOString(),
+    capturedBy: ACTOR,
+    notes: `Captured via self-hosted Firecrawl because the host refuses plain HTTP. ${note}`,
+    linkedDocuments: [],
+  };
+}
+
+async function main() {
+  const failures: string[] = [];
+
+  for (const decision of DECISIONS) {
+    try {
+      const review = await resolve(decision.suffix);
+      if (review.status === 'published') {
+        console.log(`SKIP ${decision.suffix}: already published`);
+        continue;
+      }
+      const capture = decision.capture
+        ? await firecrawlCapture(review.sourceUrl, decision.note)
+        : undefined;
+
+      if (capture && review.status !== 'approved') {
+        // The same capture is reused for staging, approval and publication so
+        // the content fingerprint stays identical across all three steps.
+        await stageSourceCapture({
+          url: review.sourceUrl,
+          entryKind: review.entryKind,
+          proposedRecord: review.proposedRecord as never,
+          actor: ACTOR,
+          notes: decision.note,
+          browserCapture: capture,
+        });
+      }
+      if (review.status !== 'approved') {
+        const draft = review.proposedRecord as { datePrecision?: string };
+        const needsPrecision =
+          review.entryKind === 'timeline_event' && !draft.datePrecision;
+        await approveStagedSource({
+          id: review.id,
+          actor: ACTOR,
+          // The staged draft omitted datePrecision; the source states the exact
+          // commencement day, restated in the reviewedDate note below.
+          proposedRecord: needsPrecision
+            ? ({ ...review.proposedRecord, datePrecision: 'day' } as never)
+            : undefined,
+          approvalNotes: decision.note,
+          reviewedDate: {
+            date: decision.date,
+            precision: 'day' as never,
+            notes: `Date confirmed against the live official source on 2026-08-07. ${decision.note}`,
+          },
+          browserCapture: capture,
+        });
+      }
+      await publishStagedSource(review.id, { browserCapture: capture });
+      console.log(`PUBLISHED ${decision.suffix}`);
+    } catch (error) {
+      failures.push(`publish ${decision.suffix}`);
+      console.error(`FAILED publish ${decision.suffix}:`, String(error).slice(0, 300));
+    }
+  }
+
+  console.log(failures.length === 0 ? 'DUPLICATES RECONCILED' : `${failures.length} FAILURES: ${failures.join(', ')}`);
+  if (failures.length > 0) process.exitCode = 1;
+}
+
+main();


### PR DESCRIPTION
## Summary
Maintainer-directed editorial pass over the 14 pending source reviews, all re-verified against their live official sources on 2026-08-07 (evidence pack reviewed and approved by the maintainer).

- **12 rejected** — 5 speeches (DTA, 4× ASIC Chair/Chairman), 5 media releases/news (2× eSafety, 3× ASIC), the ASD agentic-AI news statement, and the duplicate CAA announcement URL for `sa-courts-genai-guidelines`.
- **2 tracked-record timeline reviews published** — Senate AI/data-centres inquiry and NSW SC Gen 23 commencement. These cannot be rejected by design; publishing re-verified the existing timeline events `tl-2026-05-13-senate-ai-data-centres-inquiry` and `tl-2025-02-03-nsw-supreme-court-practice-note-sc-gen-23-commence` in place (no duplicates created). The APH page was captured via the self-hosted Firecrawl because aph.gov.au refuses plain HTTP.
- **Register untouched** — `data/policies.json` has no changes.

Result: 0 pending reviews, 0 detected radar entries; the public developments queue is clear.

## Verification
- `validate-data`: 0 errors (3 pre-existing warnings)
- `npm run check` running on the Argus CI checkout
- No duplicate timeline ids; review counts now 76 published / 25 rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)