### PR TITLE
IBM Plex Mono across the whole site

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,9 +5,11 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-public-sans), -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  /* One face site-wide (matching A2J): sans, mono and display all resolve to
+     IBM Plex Mono, so existing font-sans/font-display usage needs no edits. */
+  --font-sans: var(--font-plex-mono), 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
   --font-mono: var(--font-plex-mono), 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
-  --font-display: var(--font-newsreader), 'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif;
+  --font-display: var(--font-plex-mono), 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -289,24 +291,24 @@
 
   .page-title {
     font-family: var(--font-display);
-    font-size: clamp(1.6rem, 2.2vw, 2rem);
-    line-height: 1.15;
-    letter-spacing: -0.02em;
+    font-size: clamp(1.5rem, 2.1vw, 1.9rem);
+    line-height: 1.2;
+    letter-spacing: -0.01em;
   }
 
   .article-title {
     font-family: var(--font-display);
-    font-size: clamp(1.9rem, 3vw, 2.6rem);
-    line-height: 1.1;
-    letter-spacing: -0.025em;
+    font-size: clamp(1.7rem, 2.7vw, 2.3rem);
+    line-height: 1.2;
+    letter-spacing: -0.01em;
   }
 
   /* A clear step below .page-title, so sections never rival the page name. */
   .section-title {
     font-family: var(--font-display);
-    font-size: 1.15rem;
-    line-height: 1.3;
-    letter-spacing: -0.01em;
+    font-size: 1.1rem;
+    line-height: 1.35;
+    letter-spacing: 0;
   }
 
   /* Hide scrollbars on horizontal tab strips without disabling scroll */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { IBM_Plex_Mono, Newsreader, Public_Sans } from 'next/font/google';
+import { IBM_Plex_Mono } from 'next/font/google';
 import './globals.css';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
@@ -8,22 +8,12 @@ import { BackToTop } from '@/components/ui/back-to-top';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { getCollectionMeta } from '@/lib/data-service';
 
-const displaySerif = Newsreader({
+// One face for the whole site, matching the A2J property: IBM Plex Mono
+// carries body, headings and data alike, and `ch` becomes an exact unit.
+const plexMono = IBM_Plex_Mono({
   subsets: ['latin'],
-  variable: '--font-newsreader',
+  weight: ['400', '500', '600', '700'],
   style: ['normal', 'italic'],
-  display: 'swap',
-});
-
-const interfaceSans = Public_Sans({
-  subsets: ['latin'],
-  variable: '--font-public-sans',
-  display: 'swap',
-});
-
-const metadataMono = IBM_Plex_Mono({
-  subsets: ['latin'],
-  weight: ['400', '500'],
   variable: '--font-plex-mono',
   display: 'swap',
 });
@@ -54,7 +44,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en-AU"
-      className={`${displaySerif.variable} ${interfaceSans.variable} ${metadataMono.variable}`}
+      className={plexMono.variable}
       suppressHydrationWarning
     >
       <head>

--- a/src/app/policies/[id]/policy-detail-tabs.tsx
+++ b/src/app/policies/[id]/policy-detail-tabs.tsx
@@ -214,7 +214,7 @@ export function PolicyDetailTabs({
                         <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--status-active-bg)] text-xs font-semibold text-[var(--trust)]">
                           {index + 1}
                         </span>
-                        <p className="text-sm leading-6">{requirement}</p>
+                        <p className="min-w-0 flex-1 break-words text-sm leading-6">{requirement}</p>
                       </li>
                     ))}
                   </ol>
@@ -248,7 +248,7 @@ export function PolicyDetailTabs({
                 {requirements.map((requirement, index) => (
                   <li key={`${requirement.slice(0, 30)}-${index}`} className="flex gap-4 border-b border-border py-4 last:border-b-0">
                     <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--status-active-bg)] text-sm font-semibold text-[var(--trust)]">{index + 1}</span>
-                    <p className="text-sm leading-6">{requirement}</p>
+                    <p className="min-w-0 flex-1 break-words text-sm leading-6">{requirement}</p>
                   </li>
                 ))}
               </ol>

--- a/src/app/policies/[id]/policy-detail-tabs.tsx
+++ b/src/app/policies/[id]/policy-detail-tabs.tsx
@@ -206,7 +206,8 @@ export function PolicyDetailTabs({
               ) : null}
 
               <div className="mt-7 grid gap-7 lg:grid-cols-[minmax(0,1fr)_17rem]">
-                <div>
+                {/* Grid items default to min-width auto and refuse to shrink. */}
+                <div className="min-w-0">
                   <h2 className="section-title">Key requirements</h2>
                   <ol className="mt-3 border-y border-border">
                     {requirements.slice(0, 3).map((requirement, index) => (
@@ -225,7 +226,7 @@ export function PolicyDetailTabs({
                   ) : null}
                 </div>
 
-                <div className="border-l border-border pl-5">
+                <div className="min-w-0 border-l border-border pl-5">
                   <h2 className="page-eyebrow">Policy changes</h2>
                   <ol className="mt-4 space-y-5">
                     {policy.dates.slice(0, 4).map((date, index) => (

--- a/src/components/policy-browser.tsx
+++ b/src/components/policy-browser.tsx
@@ -269,7 +269,7 @@ export function PolicyBrowser({
             <p className="font-mono text-[11px] font-medium uppercase tracking-[0.08em] text-[var(--hero-accent)]">
               The policy observatory
             </p>
-            <h1 className="mt-5 max-w-[29rem] font-sans text-[clamp(2.7rem,4.25vw,4.25rem)] font-semibold leading-[1.03] tracking-[-0.035em] text-white">
+            <h1 className="mt-5 max-w-[29rem] font-sans text-[clamp(2.3rem,3.6vw,3.5rem)] font-semibold leading-[1.08] tracking-[-0.01em] text-white">
               See Australian AI policy as it changes.
             </h1>
             <p className="mt-5 max-w-[29rem] text-[14px] leading-6 text-white/64">
@@ -414,7 +414,7 @@ export function PolicyBrowser({
         <div className="flex flex-col gap-3 border-b border-[var(--rule-heavy)] pb-5 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="page-eyebrow">Source-linked records</p>
-            <h2 className="mt-2 font-display text-[2rem] leading-none tracking-[-0.025em]">Policy register</h2>
+            <h2 className="mt-2 font-display text-[1.8rem] leading-tight tracking-[-0.01em]">Policy register</h2>
           </div>
           <div className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-[0.11em] text-muted-foreground">
             <span


### PR DESCRIPTION
Matches the A2J property (probono.policai.org): one face for everything.

- The three font variables (`--font-sans`, `--font-mono`, `--font-display`) all resolve to IBM Plex Mono (weights 400–700 + italics), so no component needed a font edit — Newsreader and Public Sans are gone from the bundle.
- Display sizes step down slightly and serif-era negative tracking eases to ~0: mono glyphs carry their own air and collide under tight tracking. `ch` is now an exact unit site-wide.
- Two real layout fixes surfaced by the wider glyphs, both on the policy-detail page at 390px: a flex paragraph and two grid items needed `min-w-0` to shrink. Found via screenshot sweep, not inspection.

Verified on the CI host: typecheck, lint, 442/442 tests, build; 12-shot sweep (4 pages × light/dark 1440 + mobile 390), zero overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)