### PR TITLE
fix(meta): hyphen, not em-dash, as the page-title separator

### DIFF
--- a/src/app/agencies/page.tsx
+++ b/src/app/agencies/page.tsx
@@ -5,7 +5,7 @@ import { getCommonwealthAgencies } from '@/lib/data-service';
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: 'Agency AI Transparency Statements — Policai',
+  title: 'Agency AI Transparency Statements - Policai',
   description:
     'Browse Australian Government agency AI transparency statements and public disclosures.',
 };

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({
   }
 
   return {
-    title: `${post.title} — Policai Blog`,
+    title: `${post.title} - Policai Blog`,
     description: post.description,
   };
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -5,7 +5,7 @@ import { ArrowRight } from 'lucide-react';
 import { PageIntro } from '@/components/layout';
 
 export const metadata = {
-  title: 'Blog — Policai',
+  title: 'Blog - Policai',
   description: 'Project updates and AI policy commentary from Policai.',
 };
 

--- a/src/app/courts/page.tsx
+++ b/src/app/courts/page.tsx
@@ -5,7 +5,7 @@ import { getPolicies } from '@/lib/data-service';
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: 'Courts & Tribunals — Policai',
+  title: 'Courts & Tribunals - Policai',
   description:
     'Verified Australian court practice notes, directions, and guidance governing the use of artificial intelligence in proceedings.',
 };

--- a/src/app/developments/page.tsx
+++ b/src/app/developments/page.tsx
@@ -11,7 +11,7 @@ import { summarizeManualSourceCoverage } from '@/lib/source-monitoring';
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: 'Developments — Policai',
+  title: 'Developments - Policai',
   description: 'Verified and emerging Australian AI policy developments from official government sources.',
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ const plexMono = IBM_Plex_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'Policai — Australian AI Policy and Governance Tracker',
+  title: 'Policai - Australian AI Policy and Governance Tracker',
   description:
     'A register of AI policy, regulation and court guidance from Australian federal, state and territory governments, each record linked to its official source.',
   keywords: [

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -5,7 +5,7 @@ import { getPolicies } from '@/lib/data-service';
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: 'Australian AI Policy Map — Policai',
+  title: 'Australian AI Policy Map - Policai',
   description:
     'Explore verified and review-pending Australian AI policy records by jurisdiction.',
 };

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -12,7 +12,7 @@ import { MetricStrip, PageIntro } from '@/components/layout';
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: 'Methodology & Verification — Policai',
+  title: 'Methodology & Verification - Policai',
   description:
     'How Policai discovers, verifies, reviews, and publishes Australian AI policy information.',
 };

--- a/src/app/network/page.tsx
+++ b/src/app/network/page.tsx
@@ -7,7 +7,7 @@ import { parseNetworkViewState } from '@/lib/network-view-state';
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: 'Australian AI Policy Network — Policai',
+  title: 'Australian AI Policy Network - Policai',
   description:
     'Explore source-backed relationships among Australian AI policy instruments.',
 };

--- a/src/app/policies/[id]/page.tsx
+++ b/src/app/policies/[id]/page.tsx
@@ -31,9 +31,9 @@ async function getRelatedPolicies(currentPolicy: Policy): Promise<Policy[]> {
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const policy = await getPolicyById(id);
-  if (!policy) return { title: 'Policy Not Found — Policai' };
+  if (!policy) return { title: 'Policy Not Found - Policai' };
   return {
-    title: `${policy.title} — Policai`,
+    title: `${policy.title} - Policai`,
     description: policy.description,
     keywords: policy.tags,
   };

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -5,7 +5,7 @@ import { getPolicies, getTimelineEvents } from '@/lib/data-service';
 export const revalidate = 3600;
 
 export const metadata: Metadata = {
-  title: 'Australian AI Policy Timeline — Policai',
+  title: 'Australian AI Policy Timeline - Policai',
   description:
     'A source-backed timeline of Australian artificial intelligence policy, governance, and court developments.',
 };


### PR DESCRIPTION
Replaces the em-dash with a plain hyphen in every `<title>` — root layout plus the ten page/template titles (developments, methodology, network, policy detail + not-found, blog index + post, map, courts, agencies, timeline). Tab titles now read "Policai - Australian AI Policy and Governance Tracker", "Developments - Policai", etc. No other copy touched; on-page prose keeps its em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)