### PR TITLE
fix(nav): point the A2J links at the canonical a2j.policai.org hostname

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -196,7 +196,7 @@ export function Header({
           {/* Sibling property, not a register route: no active state, and the
               arrow signals leaving this app. */}
           <a
-            href="https://probono.policai.org"
+            href="https://a2j.policai.org"
             className="group relative flex h-full items-center gap-1 px-1 text-[15px] font-medium text-white/58 transition-colors duration-[var(--dur-fast)] hover:text-white"
           >
             A2J
@@ -273,7 +273,7 @@ export function Header({
                 ))}
                 <div className="my-2 border-t border-border" />
                 <a
-                  href="https://probono.policai.org"
+                  href="https://a2j.policai.org"
                   className="flex items-center gap-1.5 rounded px-3 py-2 text-sm font-medium text-muted-foreground transition-colors duration-[var(--dur-fast)] hover:bg-muted hover:text-foreground"
                 >
                   A2J


### PR DESCRIPTION
Updates both A2J nav links (desktop and mobile, `Header.tsx`) from `probono.policai.org` to `a2j.policai.org` after today's rename. The old host 301s to the new one, so nothing was broken — this just skips the redirect round trip and links the canonical hostname directly. Repo-wide grep found no other occurrences; nav labels already read "A2J".

🤖 Generated with [Claude Code](https://claude.com/claude-code)