### PR TITLE
fix(collector): harden browser and Firecrawl retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 /tmp/
 /plans/
 docs/superpowers/
+/artifacts/fix_report.md
 
 # debug
 npm-debug.log*

--- a/src/lib/pipeline/browser-egress-proxy.test.ts
+++ b/src/lib/pipeline/browser-egress-proxy.test.ts
@@ -1,0 +1,154 @@
+/* @vitest-environment node */
+
+import net from 'node:net';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import { createBrowserEgressProxy } from './browser-egress-proxy';
+
+async function connectResponse(
+  proxyUrl: string,
+  authority: string,
+): Promise<string> {
+  const proxy = new URL(proxyUrl);
+  return await new Promise((resolve, reject) => {
+    const socket = net.connect({
+      host: proxy.hostname,
+      port: Number(proxy.port),
+    });
+    let response = '';
+    socket.setTimeout(2_000);
+    socket.once('connect', () => {
+      socket.write(
+        `CONNECT ${authority} HTTP/1.1\r\nHost: ${authority}\r\n\r\n`,
+      );
+    });
+    socket.on('data', (chunk) => {
+      response += chunk.toString('utf8');
+      if (response.includes('\r\n\r\n')) {
+        socket.destroy();
+        resolve(response);
+      }
+    });
+    socket.once('timeout', () => {
+      socket.destroy(new Error('proxy test timed out'));
+    });
+    socket.once('error', reject);
+  });
+}
+
+async function connectUntilClosed(
+  proxyUrl: string,
+  authority: string,
+): Promise<string> {
+  const proxy = new URL(proxyUrl);
+  return await new Promise((resolve, reject) => {
+    const socket = net.connect({
+      host: proxy.hostname,
+      port: Number(proxy.port),
+    });
+    let response = '';
+    socket.setTimeout(2_000);
+    socket.once('connect', () => {
+      socket.write(
+        `CONNECT ${authority} HTTP/1.1\r\nHost: ${authority}\r\n\r\n`,
+      );
+    });
+    socket.on('data', (chunk) => {
+      response += chunk.toString('utf8');
+    });
+    socket.once('close', () => resolve(response));
+    socket.once('timeout', () => {
+      socket.destroy(new Error('proxy test timed out'));
+    });
+    socket.once('error', reject);
+  });
+}
+
+describe('createBrowserEgressProxy', () => {
+  it.each([
+    '127.0.0.1',
+    '10.0.0.1',
+    '169.254.169.254',
+    '::ffff:127.0.0.1',
+    'fc00::1',
+  ])('rejects CONNECT when DNS resolves to blocked address %s', async (address) => {
+    const connect = vi.fn(async () => new PassThrough());
+    const proxy = await createBrowserEgressProxy({
+      resolveHost: async () => [address],
+      connect,
+    });
+    try {
+      const response = await connectResponse(
+        proxy.serverUrl,
+        'source.example.gov.au:443',
+      );
+
+      expect(response).toMatch(/^HTTP\/1\.1 403 /);
+      expect(connect).not.toHaveBeenCalled();
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('pins the tunnel to a validated public address', async () => {
+    const connect = vi.fn(async () => new PassThrough());
+    const proxy = await createBrowserEgressProxy({
+      resolveHost: async () => ['93.184.216.34'],
+      connect,
+    });
+    try {
+      const response = await connectResponse(
+        proxy.serverUrl,
+        'source.example.gov.au:443',
+      );
+
+      expect(response).toMatch(/^HTTP\/1\.1 200 /);
+      expect(connect).toHaveBeenCalledWith('93.184.216.34', 443);
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('rejects plaintext and non-standard-port proxy requests', async () => {
+    const connect = vi.fn(async () => new PassThrough());
+    const proxy = await createBrowserEgressProxy({
+      resolveHost: async () => ['93.184.216.34'],
+      connect,
+    });
+    try {
+      const response = await connectResponse(
+        proxy.serverUrl,
+        'source.example.gov.au:8443',
+      );
+
+      expect(response).toMatch(/^HTTP\/1\.1 403 /);
+      expect(connect).not.toHaveBeenCalled();
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it('closes the tunnel before forwarding bytes over the aggregate budget', async () => {
+    const upstream = new PassThrough();
+    const connect = vi.fn(async () => upstream);
+    const proxy = await createBrowserEgressProxy({
+      resolveHost: async () => ['93.184.216.34'],
+      connect,
+      maxTunnelBytes: 4,
+    });
+    try {
+      const pending = connectUntilClosed(
+        proxy.serverUrl,
+        'source.example.gov.au:443',
+      );
+      await vi.waitFor(() => expect(connect).toHaveBeenCalledOnce());
+      upstream.write(Buffer.from('12345'));
+      const response = await pending;
+
+      expect(response).toMatch(/^HTTP\/1\.1 200 /);
+      expect(response.split('\r\n\r\n')[1]).toBe('');
+    } finally {
+      await proxy.close();
+    }
+  });
+});

--- a/src/lib/pipeline/browser-egress-proxy.ts
+++ b/src/lib/pipeline/browser-egress-proxy.ts
@@ -1,0 +1,183 @@
+import http from 'node:http';
+import { isIP } from 'node:net';
+import net from 'node:net';
+import { Transform, type Duplex } from 'node:stream';
+import {
+  assertSafeSourceUrl,
+  DEFAULT_MAX_RESPONSE_BYTES,
+  resolveHostAddresses,
+} from './fetch';
+
+const UPSTREAM_CONNECT_TIMEOUT_MS = 10_000;
+
+export interface BrowserEgressProxy {
+  serverUrl: string;
+  close(): Promise<void>;
+}
+
+export interface BrowserEgressProxyOptions {
+  resolveHost?: (hostname: string) => Promise<string[]>;
+  connect?: (address: string, port: number) => Promise<Duplex>;
+  maxTunnelBytes?: number;
+}
+
+function parseConnectAuthority(authority: string | undefined): URL {
+  if (!authority) throw new Error('Missing CONNECT authority');
+  const target = new URL(`https://${authority}`);
+  if (
+    target.protocol !== 'https:' ||
+    (target.port && target.port !== '443') ||
+    target.pathname !== '/' ||
+    target.search ||
+    target.hash ||
+    target.username ||
+    target.password
+  ) {
+    throw new Error('Invalid CONNECT authority');
+  }
+  return target;
+}
+
+async function connectPinnedAddress(
+  address: string,
+  port: number,
+): Promise<Duplex> {
+  return await new Promise((resolve, reject) => {
+    const socket = net.connect({
+      host: address,
+      port,
+      family: isIP(address),
+    });
+    socket.setTimeout(UPSTREAM_CONNECT_TIMEOUT_MS);
+    socket.once('connect', () => {
+      socket.setTimeout(0);
+      resolve(socket);
+    });
+    socket.once('timeout', () => {
+      socket.destroy(new Error('Timed out connecting to source'));
+    });
+    socket.once('error', reject);
+  });
+}
+
+async function connectFirstAvailable(
+  addresses: string[],
+  port: number,
+  connect: (address: string, port: number) => Promise<Duplex>,
+): Promise<Duplex> {
+  let lastError: unknown;
+  for (const address of addresses) {
+    try {
+      return await connect(address, port);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error('No validated source address was available');
+}
+
+function rejectConnect(socket: Duplex): void {
+  socket.end(
+    'HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n',
+  );
+}
+
+export async function createBrowserEgressProxy(
+  options: BrowserEgressProxyOptions = {},
+): Promise<BrowserEgressProxy> {
+  const resolveHost = options.resolveHost ?? resolveHostAddresses;
+  const connect = options.connect ?? connectPinnedAddress;
+  const maxTunnelBytes =
+    options.maxTunnelBytes ?? DEFAULT_MAX_RESPONSE_BYTES + 4 * 1024 * 1024;
+  let tunnelBytes = 0;
+  const sockets = new Set<Duplex>();
+  const server = http.createServer((_request, response) => {
+    response.writeHead(403, { Connection: 'close' });
+    response.end();
+  });
+
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+  server.on('connect', (request, clientSocket, head) => {
+    void (async () => {
+      try {
+        const target = parseConnectAuthority(request.url);
+        const safeUrl = `https://${target.hostname}/`;
+        const addresses = await assertSafeSourceUrl(
+          safeUrl,
+          resolveHost,
+          'public-https',
+        );
+        const upstream = await connectFirstAvailable(
+          addresses,
+          443,
+          connect,
+        );
+        sockets.add(upstream);
+        upstream.once('close', () => sockets.delete(upstream));
+        clientSocket.write(
+          'HTTP/1.1 200 Connection Established\r\nProxy-Agent: Policai\r\n\r\n',
+        );
+        if (head.length > 0) upstream.write(head);
+        const trafficLimiter = () => new Transform({
+          transform(chunk: Buffer, _encoding, callback) {
+            tunnelBytes += chunk.byteLength;
+            if (tunnelBytes > maxTunnelBytes) {
+              callback(
+                new Error(
+                  `Browser traffic exceeds ${maxTunnelBytes} byte limit`,
+                ),
+              );
+              return;
+            }
+            callback(null, chunk);
+          },
+        });
+        const uploadLimiter = trafficLimiter();
+        const downloadLimiter = trafficLimiter();
+        clientSocket.pipe(uploadLimiter).pipe(upstream);
+        upstream.pipe(downloadLimiter).pipe(clientSocket);
+        for (const limiter of [uploadLimiter, downloadLimiter]) {
+          limiter.once('error', () => {
+            upstream.destroy();
+            clientSocket.destroy();
+          });
+        }
+        upstream.once('error', () => clientSocket.destroy());
+        clientSocket.once('error', () => upstream.destroy());
+        upstream.once('close', () => clientSocket.destroy());
+        clientSocket.once('close', () => upstream.destroy());
+      } catch {
+        rejectConnect(clientSocket);
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Browser egress proxy did not bind a TCP port');
+  }
+
+  return {
+    serverUrl: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}

--- a/src/lib/pipeline/browser-fetch.test.ts
+++ b/src/lib/pipeline/browser-fetch.test.ts
@@ -2,10 +2,13 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import {
-  createBrowserFetch,
+  createBrowserFetch as createBrowserFetchRaw,
   type BrowserLike,
   type BrowserPageLike,
   type BrowserResponseLike,
+  type BrowserRouteLike,
+  type BrowserWebSocketRouteLike,
+  type CreateBrowserFetchOptions,
 } from './browser-fetch';
 import { retrieveSource } from './fetch';
 
@@ -21,11 +24,27 @@ interface FakePageScript {
   bodyBytes?: Buffer;
   /** Overrides the navigation response body (e.g. empty for PDF downloads). */
   navigationBodyBytes?: Buffer;
+  contentLength?: number;
+  /** Redirect and subresource requests issued before goto resolves. */
+  extraRequestUrls?: string[];
+  webSocketUrls?: string[];
+  gotoDelayMs?: number;
   gotoResult?: 'null' | 'abort';
   /** Makes the context request API fail, as Akamai does to non-browser TLS. */
   requestGetResult?: 'timeout';
   /** Status the context request API returns (WAFs 403 non-browser TLS). */
   requestGetStatus?: number;
+}
+
+function createBrowserFetch(options: CreateBrowserFetchOptions = {}) {
+  return createBrowserFetchRaw({
+    resolveHost: async () => ['93.184.216.34'],
+    egressProxyFactory: async () => ({
+      serverUrl: 'http://127.0.0.1:1',
+      close: async () => {},
+    }),
+    ...options,
+  });
 }
 
 function fakeBrowser(
@@ -37,9 +56,19 @@ function fakeBrowser(
     closedBrowser: false,
     closedContexts: 0,
     waits: [] as number[],
-    contextOptions: [] as Array<{ userAgent?: string } | undefined>,
+    contextOptions: [] as Array<
+      {
+        userAgent?: string;
+        serviceWorkers?: 'block';
+        proxy?: { server: string };
+      } | undefined
+    >,
     requestGets: [] as string[],
     inPageFetches: [] as string[],
+    routedRequests: [] as string[],
+    blockedRequests: [] as string[],
+    connectedWebSockets: [] as string[],
+    blockedWebSockets: [] as string[],
     loadStateWaits: [] as string[],
     rejectLoadStateWaits: false,
   };
@@ -48,9 +77,57 @@ function fakeBrowser(
     state.launches++;
     return {
       ...(browserVersion ? { version: () => browserVersion } : {}),
-      newContext: async (contextOptions?: { userAgent?: string }) => {
+      newContext: async (contextOptions?: {
+        userAgent?: string;
+        serviceWorkers?: 'block';
+        proxy?: { server: string };
+      }) => {
         state.contextOptions.push(contextOptions);
+        let routeHandler:
+          | ((route: BrowserRouteLike) => Promise<void>)
+          | undefined;
+        let webSocketHandler:
+          | ((route: BrowserWebSocketRouteLike) => Promise<void>)
+          | undefined;
+        const dispatchRequest = async (requestUrl: string) => {
+          state.routedRequests.push(requestUrl);
+          if (!routeHandler) return;
+          let blocked = false;
+          await routeHandler({
+            request: () => ({ url: () => requestUrl }),
+            continue: async () => {},
+            abort: async () => {
+              blocked = true;
+              state.blockedRequests.push(requestUrl);
+            },
+          });
+          if (blocked) {
+            throw new Error(`net::ERR_BLOCKED_BY_CLIENT at ${requestUrl}`);
+          }
+        };
+        const dispatchWebSocket = async (socketUrl: string) => {
+          if (!webSocketHandler) return;
+          await webSocketHandler({
+            url: () => socketUrl,
+            connectToServer: () => {
+              state.connectedWebSockets.push(socketUrl);
+              return {};
+            },
+            close: async () => {
+              state.blockedWebSockets.push(socketUrl);
+            },
+          });
+        };
         return {
+        route: async (_pattern: string, handler: (route: BrowserRouteLike) => Promise<void>) => {
+          routeHandler = handler;
+        },
+        routeWebSocket: async (
+          _pattern: string,
+          handler: (route: BrowserWebSocketRouteLike) => Promise<void>,
+        ) => {
+          webSocketHandler = handler;
+        },
         newPage: async (): Promise<BrowserPageLike> => {
           let script: FakePageScript = {};
           let gotoIndex = 0;
@@ -61,6 +138,19 @@ function fakeBrowser(
               script = routes[url] ?? {};
               currentUrl = script.finalUrl ?? url;
               readsInNavigation = 0;
+              await dispatchRequest(url);
+              if (currentUrl !== url) await dispatchRequest(currentUrl);
+              for (const requestUrl of script.extraRequestUrls ?? []) {
+                await dispatchRequest(requestUrl);
+              }
+              for (const socketUrl of script.webSocketUrls ?? []) {
+                await dispatchWebSocket(socketUrl);
+              }
+              if (script.gotoDelayMs) {
+                await new Promise((resolve) =>
+                  setTimeout(resolve, script.gotoDelayMs),
+                );
+              }
               if (script.gotoResult === 'null') return null;
               if (script.gotoResult === 'abort') {
                 throw new Error(
@@ -76,34 +166,50 @@ function fakeBrowser(
                 url: () => currentUrl,
                 headers: () => ({
                   'content-type': script.contentType ?? 'text/html',
+                  ...(script.contentLength === undefined
+                    ? {}
+                    : { 'content-length': String(script.contentLength) }),
                 }),
-                body: async () =>
-                  script.navigationBodyBytes ??
-                  script.bodyBytes ??
-                  Buffer.from(script.contents?.[0] ?? ''),
               };
-            },
-            // Content reflects the last navigation, advancing again when the
-            // page re-renders between reads (challenge settling).
-            content: async () => {
-              const contents = script.contents ?? [''];
-              const index = Math.max(0, gotoIndex - 1) + readsInNavigation;
-              readsInNavigation++;
-              return contents[Math.min(index, contents.length - 1)];
             },
             url: () => currentUrl,
             // Stands in for an in-page same-origin fetch of the arg URL.
             evaluate: async (_fn: unknown, arg: unknown) => {
-              const target = String(arg);
-              state.inPageFetches.push(target);
-              const targetScript = routes[target] ?? {};
-              return {
-                status: targetScript.status ?? 200,
-                contentType: targetScript.contentType ?? 'text/html',
-                base64: (targetScript.bodyBytes ?? Buffer.alloc(0)).toString(
-                  'base64',
-                ),
-              } as never;
+              const options = arg as {
+                target?: string;
+                byteLimit: number;
+              };
+              if (options.target) {
+                const target = options.target;
+                state.inPageFetches.push(target);
+                await dispatchRequest(target);
+                const targetScript = routes[target] ?? {};
+                const payload = targetScript.bodyBytes ?? Buffer.alloc(0);
+                if (
+                  (targetScript.contentLength ?? payload.byteLength) >
+                  options.byteLimit
+                ) {
+                  throw new Error(
+                    `Source response exceeds ${options.byteLimit} byte limit`,
+                  );
+                }
+                return {
+                  status: targetScript.status ?? 200,
+                  contentType: targetScript.contentType ?? 'text/html',
+                  finalUrl: targetScript.finalUrl ?? target,
+                  base64Chunks: [payload.toString('base64')],
+                } as never;
+              }
+              const contents = script.contents ?? [''];
+              const index = Math.max(0, gotoIndex - 1) + readsInNavigation;
+              readsInNavigation++;
+              const content = contents[Math.min(index, contents.length - 1)];
+              if (Buffer.byteLength(content, 'utf8') > options.byteLimit) {
+                throw new Error(
+                  `Source response exceeds ${options.byteLimit} byte limit`,
+                );
+              }
+              return content as never;
             },
             waitForTimeout: async (ms: number) => {
               state.waits.push(ms);
@@ -275,9 +381,79 @@ describe('createBrowserFetch', () => {
     const userAgent = state.contextOptions[0]?.userAgent ?? '';
     expect(userAgent).toContain('Chrome/149.0.0.0');
     expect(userAgent).not.toContain('Headless');
+    expect(state.contextOptions[0]?.serviceWorkers).toBe('block');
+    expect(state.contextOptions[0]?.proxy?.server).toBe(
+      'http://127.0.0.1:1',
+    );
   });
 
-  it('retrieves document payloads through the context request API when navigation aborts', async () => {
+  it.each([
+    '127.0.0.1',
+    '10.0.0.1',
+    '169.254.169.254',
+    '::ffff:127.0.0.1',
+    'fc00::1',
+  ])('rejects an official hostname resolving to blocked address %s before launch', async (address) => {
+    const { launch, state } = fakeBrowser({});
+    const browserFetch = createBrowserFetch({
+      launch,
+      resolveHost: async () => [address],
+    });
+
+    await expect(
+      browserFetch.fetchImpl('https://www.example.gov.au/news'),
+    ).rejects.toThrow(/blocked network address/i);
+    expect(state.launches).toBe(0);
+  });
+
+  it('blocks private redirects and subresources before Chromium continues them', async () => {
+    const sourceUrl = 'https://www.example.gov.au/news';
+    const privateUrl = 'https://metadata.example.gov.au/latest/meta-data';
+    const { launch, state } = fakeBrowser({
+      [sourceUrl]: {
+        extraRequestUrls: [privateUrl],
+        contents: ['<html><body>never returned</body></html>'],
+      },
+    });
+    const browserFetch = createBrowserFetch({
+      launch,
+      resolveHost: async (hostname) =>
+        hostname === 'metadata.example.gov.au'
+          ? ['169.254.169.254']
+          : ['93.184.216.34'],
+    });
+
+    await expect(browserFetch.fetchImpl(sourceUrl)).rejects.toThrow(
+      /blocked_by_client/i,
+    );
+    expect(state.blockedRequests).toEqual([privateUrl]);
+  });
+
+  it('blocks private WebSocket destinations and permits public secure sockets', async () => {
+    const sourceUrl = 'https://www.example.gov.au/news';
+    const privateSocket = 'wss://internal.example.gov.au/events';
+    const publicSocket = 'wss://updates.example.gov.au/events';
+    const { launch, state } = fakeBrowser({
+      [sourceUrl]: {
+        webSocketUrls: [privateSocket, publicSocket],
+        contents: ['<html><body>ok</body></html>'],
+      },
+    });
+    const browserFetch = createBrowserFetch({
+      launch,
+      resolveHost: async (hostname) =>
+        hostname === 'internal.example.gov.au'
+          ? ['10.0.0.5']
+          : ['93.184.216.34'],
+    });
+
+    await browserFetch.fetchImpl(sourceUrl);
+
+    expect(state.blockedWebSockets).toEqual([privateSocket]);
+    expect(state.connectedWebSockets).toEqual([publicSocket]);
+  });
+
+  it('retrieves document payloads through a bounded in-page stream when navigation aborts', async () => {
     const pdfBytes = Buffer.from('%PDF-1.7 fake body');
     const { launch, state } = fakeBrowser({
       'https://www.example.gov.au/files/policy.pdf': {
@@ -295,12 +471,12 @@ describe('createBrowserFetch', () => {
     expect(response.status).toBe(200);
     expect(Buffer.from(await response.arrayBuffer())).toEqual(pdfBytes);
     expect(response.headers.get('content-type')).toContain('application/pdf');
-    expect(state.requestGets).toEqual([
+    expect(state.inPageFetches).toEqual([
       'https://www.example.gov.au/files/policy.pdf',
     ]);
   });
 
-  it('retries an empty non-HTML navigation body through the request API', async () => {
+  it('retrieves raw non-HTML bytes through the bounded in-page stream', async () => {
     const pdfBytes = Buffer.from('%PDF-1.7 nav-empty');
     const { launch, state } = fakeBrowser({
       'https://www.example.gov.au/files/empty.pdf': {
@@ -316,9 +492,72 @@ describe('createBrowserFetch', () => {
     );
 
     expect(Buffer.from(await response.arrayBuffer())).toEqual(pdfBytes);
-    expect(state.requestGets).toEqual([
+    expect(state.inPageFetches).toEqual([
       'https://www.example.gov.au/files/empty.pdf',
     ]);
+  });
+
+  it('rejects an oversized declared browser response before reading its body', async () => {
+    const url = 'https://www.example.gov.au/files/large.pdf';
+    const { launch, state } = fakeBrowser({
+      [url]: {
+        contentType: 'application/pdf',
+        contentLength: 11,
+        bodyBytes: Buffer.from('small'),
+      },
+    });
+    const browserFetch = createBrowserFetch({ launch, maxResponseBytes: 10 });
+
+    await expect(browserFetch.fetchImpl(url)).rejects.toThrow(
+      /exceeds 10 byte limit/i,
+    );
+    expect(state.inPageFetches).toEqual([]);
+  });
+
+  it('aborts a chunked browser payload once streamed bytes exceed the limit', async () => {
+    const url = 'https://www.example.gov.au/files/chunked.pdf';
+    const { launch } = fakeBrowser({
+      [url]: {
+        contentType: 'application/pdf',
+        bodyBytes: Buffer.from('eleven-byte'),
+      },
+    });
+    const browserFetch = createBrowserFetch({ launch, maxResponseBytes: 10 });
+
+    await expect(browserFetch.fetchImpl(url)).rejects.toThrow(
+      /exceeds 10 byte limit/i,
+    );
+  });
+
+  it('rejects rendered HTML that exceeds the response budget', async () => {
+    const url = 'https://www.example.gov.au/news';
+    const { launch } = fakeBrowser({
+      [url]: { contents: ['<html><body>too large</body></html>'] },
+    });
+    const browserFetch = createBrowserFetch({ launch, maxResponseBytes: 12 });
+
+    await expect(browserFetch.fetchImpl(url)).rejects.toThrow(
+      /exceeds 12 byte limit/i,
+    );
+  });
+
+  it('propagates an AbortSignal and closes the active browser context', async () => {
+    const url = 'https://www.example.gov.au/news';
+    const { launch, state } = fakeBrowser({
+      [url]: {
+        gotoDelayMs: 100,
+        contents: ['<html><body>late response</body></html>'],
+      },
+    });
+    const browserFetch = createBrowserFetch({ launch });
+    const controller = new AbortController();
+    const pending = browserFetch.fetchImpl(url, { signal: controller.signal });
+
+    await vi.waitFor(() => expect(state.launches).toBe(1));
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(state.closedContexts).toBeGreaterThan(0);
   });
 
   it('re-fetches when the PDF viewer shell masquerades as the document', async () => {
@@ -339,7 +578,7 @@ describe('createBrowserFetch', () => {
     );
 
     expect(Buffer.from(await response.arrayBuffer())).toEqual(pdfBytes);
-    expect(state.requestGets).toEqual([
+    expect(state.inPageFetches).toEqual([
       'https://www.example.gov.au/files/viewer.pdf',
     ]);
   });

--- a/src/lib/pipeline/browser-fetch.ts
+++ b/src/lib/pipeline/browser-fetch.ts
@@ -1,4 +1,15 @@
-import { looksLikeBotChallenge } from './fetch';
+import {
+  assertContentLengthWithinLimit,
+  assertSafeSourceUrl,
+  DEFAULT_MAX_RESPONSE_BYTES,
+  looksLikeBotChallenge,
+  resolveHostAddresses,
+  SourceFetchError,
+} from './fetch';
+import {
+  createBrowserEgressProxy,
+  type BrowserEgressProxy,
+} from './browser-egress-proxy';
 
 /**
  * Headless-browser retriever with the fetch signature, so `retrieveSource`
@@ -14,7 +25,6 @@ export interface BrowserResponseLike {
   status(): number;
   url(): string;
   headers(): Record<string, string>;
-  body(): Promise<Buffer>;
 }
 
 export interface BrowserPageLike {
@@ -22,7 +32,6 @@ export interface BrowserPageLike {
     url: string,
     options?: { waitUntil?: 'load' | 'domcontentloaded'; timeout?: number },
   ): Promise<BrowserResponseLike | null>;
-  content(): Promise<string>;
   url(): string;
   evaluate<Arg, Result>(
     fn: (arg: Arg) => Result | Promise<Result>,
@@ -36,15 +45,28 @@ export interface BrowserPageLike {
   close(): Promise<void>;
 }
 
+export interface BrowserRouteLike {
+  request(): { url(): string };
+  continue(): Promise<void>;
+  abort(errorCode?: string): Promise<void>;
+}
+
+export interface BrowserWebSocketRouteLike {
+  url(): string;
+  connectToServer(): unknown;
+  close(options?: { code?: number; reason?: string }): Promise<void>;
+}
+
 export interface BrowserContextLike {
   newPage(): Promise<BrowserPageLike>;
-  /** Non-rendering HTTP client sharing the context's cookies and identity. */
-  request: {
-    get(
-      url: string,
-      options?: { timeout?: number },
-    ): Promise<BrowserResponseLike>;
-  };
+  route(
+    pattern: string,
+    handler: (route: BrowserRouteLike) => Promise<void>,
+  ): Promise<unknown>;
+  routeWebSocket?(
+    pattern: string,
+    handler: (route: BrowserWebSocketRouteLike) => Promise<void>,
+  ): Promise<unknown>;
   close(): Promise<void>;
 }
 
@@ -52,6 +74,8 @@ export interface BrowserLike {
   newContext(options?: {
     userAgent?: string;
     locale?: string;
+    serviceWorkers?: 'block';
+    proxy?: { server: string };
   }): Promise<BrowserContextLike>;
   version?(): string;
   close(): Promise<void>;
@@ -67,6 +91,11 @@ export interface CreateBrowserFetchOptions {
   /** How long to let a bot-challenge interstitial settle before re-reading. */
   challengeSettleMs?: number;
   navigationTimeoutMs?: number;
+  maxResponseBytes?: number;
+  resolveHost?: (hostname: string) => Promise<string[]>;
+  egressProxyFactory?: (
+    maxTunnelBytes: number,
+  ) => Promise<BrowserEgressProxy>;
 }
 
 const DEFAULT_CHALLENGE_SETTLE_MS = 5_000;
@@ -76,6 +105,7 @@ const DEFAULT_NAVIGATION_TIMEOUT_MS = 45_000;
  * hardware widens that window; bounded so long-polling pages cannot stall.
  */
 const NETWORK_IDLE_SETTLE_MS = 5_000;
+const BROWSER_TRAFFIC_OVERHEAD_BYTES = 4 * 1024 * 1024;
 
 const BROWSER_LOCALE = 'en-AU';
 /** Statuses WAF interstitials return before a challenge cookie is granted. */
@@ -85,11 +115,19 @@ async function launchPlaywrightChromium(): Promise<BrowserLike> {
   const playwright = await import('playwright-core');
   // Full Chromium in new-headless mode: the lighter headless shell trips
   // HTTP2 protocol errors and WAF blocks on Akamai-fronted GovCMS hosts.
-  return playwright.chromium.launch({
+  const browser = await playwright.chromium.launch({
     headless: true,
     channel: 'chromium',
-    args: ['--disable-blink-features=AutomationControlled'],
+    args: [
+      '--disable-background-networking',
+      '--disable-blink-features=AutomationControlled',
+    ],
   });
+  return {
+    newContext: (options) => browser.newContext(options),
+    version: () => browser.version(),
+    close: () => browser.close(),
+  };
 }
 
 function userAgentPlatform(): string {
@@ -132,29 +170,11 @@ function responseHeaderSubset(
   const headers: Record<string, string> = {
     'content-type': responseHeaders['content-type'] ?? 'text/html',
   };
-  for (const key of ['etag', 'last-modified'] as const) {
+  for (const key of ['content-length', 'etag', 'last-modified'] as const) {
     const value = responseHeaders[key];
     if (value) headers[key] = value;
   }
   return headers;
-}
-
-/** Fail fast so blocked hosts fall through to the in-page fetch. */
-const CONTEXT_REQUEST_TIMEOUT_MS = 15_000;
-
-async function fetchViaContextRequest(
-  context: BrowserContextLike,
-  url: string,
-): Promise<Response> {
-  const apiResponse = await context.request.get(url, {
-    timeout: CONTEXT_REQUEST_TIMEOUT_MS,
-  });
-  return toFetchResponse(
-    apiResponse.status(),
-    apiResponse.url(),
-    new Uint8Array(await apiResponse.body()),
-    responseHeaderSubset(apiResponse.headers()),
-  );
 }
 
 /**
@@ -167,6 +187,7 @@ async function fetchViaPage(
   page: BrowserPageLike,
   url: string,
   navigationTimeoutMs: number,
+  maxResponseBytes: number,
 ): Promise<Response> {
   const origin = new URL(url).origin;
   if (!page.url().startsWith(origin)) {
@@ -175,47 +196,151 @@ async function fetchViaPage(
       timeout: navigationTimeoutMs,
     });
   }
-  const result = await page.evaluate(async (target: string) => {
-    const response = await fetch(target, { credentials: 'include' });
-    const buffer = new Uint8Array(await response.arrayBuffer());
-    let binary = '';
-    const chunkSize = 0x8000;
-    for (let index = 0; index < buffer.length; index += chunkSize) {
-      binary += String.fromCharCode(
-        ...buffer.subarray(index, index + chunkSize),
+  let result: {
+    status: number;
+    contentType: string;
+    finalUrl: string;
+    base64Chunks: string[];
+  };
+  try {
+    result = await page.evaluate(async ({ target, byteLimit }) => {
+      const response = await fetch(target, {
+        credentials: 'include',
+        redirect: 'follow',
+      });
+      const declaredLength = Number(response.headers.get('content-length'));
+      if (Number.isFinite(declaredLength) && declaredLength > byteLimit) {
+        await response.body?.cancel();
+        throw new Error(`Source response exceeds ${byteLimit} byte limit`);
+      }
+      if (!response.body) {
+        return {
+          status: response.status,
+          contentType: response.headers.get('content-type') ?? '',
+          finalUrl: response.url || target,
+          base64Chunks: [],
+        };
+      }
+
+      const reader = response.body.getReader();
+      const base64Chunks: string[] = [];
+      let received = 0;
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          received += value.byteLength;
+          if (received > byteLimit) {
+            await reader.cancel();
+            throw new Error(`Source response exceeds ${byteLimit} byte limit`);
+          }
+          let binary = '';
+          const chunkSize = 0x8000;
+          for (let index = 0; index < value.length; index += chunkSize) {
+            binary += String.fromCharCode(
+              ...value.subarray(index, index + chunkSize),
+            );
+          }
+          base64Chunks.push(btoa(binary));
+        }
+      } finally {
+        reader.releaseLock();
+      }
+      return {
+        status: response.status,
+        contentType: response.headers.get('content-type') ?? '',
+        finalUrl: response.url || target,
+        base64Chunks,
+      };
+    }, { target: url, byteLimit: maxResponseBytes });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes(`exceeds ${maxResponseBytes} byte limit`)
+    ) {
+      throw new SourceFetchError(
+        `Source response exceeds ${maxResponseBytes} byte limit`,
+        { retryable: false, cause: error },
       );
     }
-    return {
-      status: response.status,
-      contentType: response.headers.get('content-type') ?? '',
-      base64: btoa(binary),
-    };
-  }, url);
+    throw error;
+  }
+  const chunks = result.base64Chunks.map((chunk) => Buffer.from(chunk, 'base64'));
+  const payload = Buffer.concat(chunks);
   return toFetchResponse(
     result.status,
-    url,
-    new Uint8Array(Buffer.from(result.base64, 'base64')),
+    result.finalUrl,
+    new Uint8Array(payload),
     {
       'content-type': result.contentType || 'application/octet-stream',
+      'content-length': String(payload.byteLength),
     },
   );
 }
 
 async function fetchDocumentPayload(
-  context: BrowserContextLike,
   page: BrowserPageLike,
   url: string,
   navigationTimeoutMs: number,
+  maxResponseBytes: number,
 ): Promise<Response> {
+  return await fetchViaPage(
+    page,
+    url,
+    navigationTimeoutMs,
+    maxResponseBytes,
+  );
+}
+
+async function readBoundedPageContent(
+  page: BrowserPageLike,
+  maxResponseBytes: number,
+): Promise<string> {
   try {
-    const response = await fetchViaContextRequest(context, url);
-    // WAFs that block the request client's non-browser TLS answer with a
-    // challenge status; only the in-page fetch presents as the real browser.
-    if (!CHALLENGE_STATUSES.has(response.status)) return response;
-  } catch {
-    // Timeouts and protocol failures fall through to the in-page fetch.
+    return await page.evaluate(({ byteLimit }) => {
+      const html = document.documentElement?.outerHTML ?? '';
+      if (new TextEncoder().encode(html).byteLength > byteLimit) {
+        throw new Error(`Source response exceeds ${byteLimit} byte limit`);
+      }
+      return html;
+    }, { byteLimit: maxResponseBytes });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes(`exceeds ${maxResponseBytes} byte limit`)
+    ) {
+      throw new SourceFetchError(
+        `Source response exceeds ${maxResponseBytes} byte limit`,
+        { retryable: false, cause: error },
+      );
+    }
+    throw error;
   }
-  return await fetchViaPage(page, url, navigationTimeoutMs);
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException('The operation was aborted', 'AbortError');
+}
+
+async function raceWithAbort<T>(
+  operation: Promise<T>,
+  signal: AbortSignal | null | undefined,
+  abort: () => Promise<void>,
+): Promise<T> {
+  if (!signal) return operation;
+  if (signal.aborted) {
+    await abort();
+    throw abortReason(signal);
+  }
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      void abort().finally(() => reject(abortReason(signal)));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+    operation.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
 }
 
 function toFetchResponse(
@@ -242,6 +367,13 @@ export function createBrowserFetch(
     options.challengeSettleMs ?? DEFAULT_CHALLENGE_SETTLE_MS;
   const navigationTimeoutMs =
     options.navigationTimeoutMs ?? DEFAULT_NAVIGATION_TIMEOUT_MS;
+  const maxResponseBytes =
+    options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+  const resolveHost = options.resolveHost ?? resolveHostAddresses;
+  const egressProxyFactory =
+    options.egressProxyFactory ??
+    ((maxTunnelBytes: number) =>
+      createBrowserEgressProxy({ maxTunnelBytes }));
 
   let browserPromise: Promise<BrowserLike> | null = null;
   const getBrowser = (): Promise<BrowserLike> => {
@@ -249,92 +381,136 @@ export function createBrowserFetch(
     return browserPromise;
   };
 
-  const fetchImpl = (async (input: RequestInfo | URL) => {
+  const fetchImpl = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
     const url = String(input);
+    await assertSafeSourceUrl(url, resolveHost, 'official');
+    if (init?.signal?.aborted) throw abortReason(init.signal);
     const browser = await getBrowser();
-    const context = await browser.newContext({
-      userAgent: browserUserAgent(browser),
-      locale: BROWSER_LOCALE,
-    });
+    const egressProxy = await egressProxyFactory(
+      maxResponseBytes + BROWSER_TRAFFIC_OVERHEAD_BYTES,
+    );
+    let context: BrowserContextLike | undefined;
     try {
-      const page = await context.newPage();
-      let navigation: BrowserResponseLike | null;
-      try {
-        navigation = await page.goto(url, {
-          waitUntil: 'load',
-          timeout: navigationTimeoutMs,
-        });
-      } catch (error) {
-        if (!isDownloadNavigationError(error)) throw error;
-        // Chromium aborts navigations it treats as downloads (PDFs, Word
-        // documents); retrieve those without rendering.
-        return await fetchDocumentPayload(context, page, url, navigationTimeoutMs);
-      }
-      if (!navigation) {
-        throw new Error(`Browser navigation to ${url} produced no response`);
-      }
-      if (
-        CHALLENGE_STATUSES.has(navigation.status()) &&
-        isHtmlContentType(navigation.headers()['content-type'] ?? '') &&
-        challengeSettleMs > 0
-      ) {
-        // WAF interstitials run JS, set a clearance cookie, and only then
-        // serve content; give that a beat and re-navigate once.
-        await page.waitForTimeout(challengeSettleMs);
-        navigation =
-          (await page.goto(url, {
+      context = await browser.newContext({
+        userAgent: browserUserAgent(browser),
+        locale: BROWSER_LOCALE,
+        serviceWorkers: 'block',
+        proxy: { server: egressProxy.serverUrl },
+      });
+      await context.route('**/*', async (route) => {
+        try {
+          await assertSafeSourceUrl(
+            route.request().url(),
+            resolveHost,
+            'public-https',
+          );
+          await route.continue();
+        } catch {
+          await route.abort('blockedbyclient');
+        }
+      });
+      await context.routeWebSocket?.('**/*', async (route) => {
+        const socketUrl = route.url();
+        const validationUrl = socketUrl.replace(/^wss:/i, 'https:');
+        try {
+          await assertSafeSourceUrl(
+            validationUrl,
+            resolveHost,
+            'public-https',
+          );
+          route.connectToServer();
+        } catch {
+          await route.close({ code: 1008, reason: 'Blocked destination' });
+        }
+      });
+
+      const operation = (async () => {
+        const page = await context.newPage();
+        let navigation: BrowserResponseLike | null;
+        try {
+          navigation = await page.goto(url, {
             waitUntil: 'load',
             timeout: navigationTimeoutMs,
-          })) ?? navigation;
-      }
-
-      const status = navigation.status();
-      const headers = responseHeaderSubset(navigation.headers());
-      const contentType = headers['content-type'];
-
-      if (!isHtmlContentType(contentType)) {
-        const payload = await navigation.body();
-        const declaresBinaryDocument =
-          /pdf|msword|wordprocessingml|rtf|octet-stream/.test(
-            contentType.toLowerCase(),
-          );
-        const looksLikeMarkup = payload
-          .toString('utf8', 0, Math.min(payload.length, 64))
-          .trimStart()
-          .startsWith('<');
-        if (payload.length === 0 || (declaresBinaryDocument && looksLikeMarkup)) {
-          // Chromium substitutes its own viewer shell (or an empty body via
-          // the download manager) for document navigations; re-fetch the raw
-          // bytes without rendering.
+          });
+        } catch (error) {
+          if (!isDownloadNavigationError(error)) throw error;
+          // Chromium aborts navigations it treats as downloads; retrieve the
+          // bytes through a same-origin streamed fetch with the same cookies.
           return await fetchDocumentPayload(
-            context,
             page,
             url,
             navigationTimeoutMs,
+            maxResponseBytes,
           );
         }
-        return toFetchResponse(
-          status,
-          navigation.url(),
-          new Uint8Array(payload),
-          headers,
-        );
-      }
+        if (!navigation) {
+          throw new Error(`Browser navigation to ${url} produced no response`);
+        }
+        if (
+          CHALLENGE_STATUSES.has(navigation.status()) &&
+          isHtmlContentType(navigation.headers()['content-type'] ?? '') &&
+          challengeSettleMs > 0
+        ) {
+          // WAF interstitials run JS, set a clearance cookie, and only then
+          // serve content; give that a beat and re-navigate once.
+          await page.waitForTimeout(challengeSettleMs);
+          navigation =
+            (await page.goto(url, {
+              waitUntil: 'load',
+              timeout: navigationTimeoutMs,
+            })) ?? navigation;
+        }
 
-      await page
-        .waitForLoadState?.('networkidle', { timeout: NETWORK_IDLE_SETTLE_MS })
-        .catch(() => {
-          // Pages that never go idle (long polling, analytics beacons) are
-          // read as-is after the bounded settle window.
-        });
-      let body = await page.content();
-      if (looksLikeBotChallenge(body) && challengeSettleMs > 0) {
-        await page.waitForTimeout(challengeSettleMs);
-        body = await page.content();
-      }
-      return toFetchResponse(status, page.url(), body, headers);
+        await assertSafeSourceUrl(
+          navigation.url(),
+          resolveHost,
+          'public-https',
+        );
+        const status = navigation.status();
+        const headers = responseHeaderSubset(navigation.headers());
+        assertContentLengthWithinLimit(
+          headers['content-length'],
+          maxResponseBytes,
+        );
+        const contentType = headers['content-type'];
+
+        if (!isHtmlContentType(contentType)) {
+          return await fetchDocumentPayload(
+            page,
+            navigation.url(),
+            navigationTimeoutMs,
+            maxResponseBytes,
+          );
+        }
+
+        await page
+          .waitForLoadState?.('networkidle', { timeout: NETWORK_IDLE_SETTLE_MS })
+          .catch(() => {
+            // Pages that never go idle (long polling, analytics beacons) are
+            // read as-is after the bounded settle window.
+          });
+        let body = await readBoundedPageContent(page, maxResponseBytes);
+        if (looksLikeBotChallenge(body) && challengeSettleMs > 0) {
+          await page.waitForTimeout(challengeSettleMs);
+          body = await readBoundedPageContent(page, maxResponseBytes);
+        }
+        return toFetchResponse(status, page.url(), body, headers);
+      })();
+      return await raceWithAbort(
+        operation,
+        init?.signal,
+        () => context?.close() ?? Promise.resolve(),
+      );
     } finally {
-      await context.close();
+      if (context) {
+        await context.close().catch(() => {
+          // Abort-driven closure can race normal cleanup.
+        });
+      }
+      await egressProxy.close();
     }
   }) as typeof fetch;
 

--- a/src/lib/pipeline/collect.test.ts
+++ b/src/lib/pipeline/collect.test.ts
@@ -2026,7 +2026,7 @@ describe('collect browser fallback', () => {
       ok: true,
       markdown: `# New AI policy framework released\n\nFirecrawl-sourced content for ${url}.`,
       title: 'New AI policy framework released',
-      sourceUrl: url,
+      finalUrl: `${url}/canonical`,
     }));
 
     const result = await collect({
@@ -2054,6 +2054,13 @@ describe('collect browser fallback', () => {
     expect(
       result.developments.map((development) => development.url),
     ).toContain('https://www.example.gov.au/news/ai-policy-framework');
+    expect(
+      result.developments.find((development) =>
+        development.url.endsWith('/ai-policy-framework'),
+      )?.verification.source.finalUrl,
+    ).toBe(
+      'https://www.example.gov.au/news/ai-policy-framework/canonical',
+    );
   });
 
   it('falls through to the headless browser when Firecrawl cannot serve a candidate page', async () => {

--- a/src/lib/pipeline/collect.ts
+++ b/src/lib/pipeline/collect.ts
@@ -162,20 +162,24 @@ function isBrowserFallbackFutile(error: unknown): boolean {
  */
 async function retrievedSourceFromFirecrawl(
   markdown: string,
-  url: string,
+  requestedUrl: string,
+  finalUrl: string,
   now: () => Date,
 ): Promise<RetrievedSource> {
-  const replayFetch: typeof fetch = async () =>
+  const replayFetch: typeof fetch = async () => {
     // text/plain, not text/markdown: extractRetrievedDocument only knows how
     // to read HTML, XML, or plain text bodies. Markdown reads fine as plain
     // text — cheerio treats it as one untagged text node — but a
     // text/markdown content type would hit the "unsupported content type"
     // guard and fail every Firecrawl-sourced candidate.
-    new Response(markdown, {
+    const response = new Response(markdown, {
       status: 200,
       headers: { 'content-type': 'text/plain; charset=utf-8' },
     });
-  return retrieveSource(url, { fetchImpl: replayFetch, now });
+    Object.defineProperty(response, 'url', { value: finalUrl });
+    return response;
+  };
+  return retrieveSource(requestedUrl, { fetchImpl: replayFetch, now });
 }
 
 export function emptyWatchState(): WatchState {
@@ -1131,6 +1135,7 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
           return retrievedSourceFromFirecrawl(
             firecrawled.markdown,
             url,
+            firecrawled.finalUrl,
             () => now,
           );
         }

--- a/src/lib/pipeline/fetch.ts
+++ b/src/lib/pipeline/fetch.ts
@@ -18,7 +18,7 @@ import type {
 const DEFAULT_TIMEOUT_MS = 20_000;
 const DEFAULT_ATTEMPTS = 2;
 const DEFAULT_RETRY_DELAY_MS = 250;
-const DEFAULT_MAX_RESPONSE_BYTES = 20 * 1024 * 1024;
+export const DEFAULT_MAX_RESPONSE_BYTES = 20 * 1024 * 1024;
 const DEFAULT_MAX_LINKED_DOCUMENT_BYTES = 32 * 1024 * 1024;
 const MAX_REDIRECTS = 5;
 const MAX_LINKED_DOCUMENTS = 8;
@@ -160,7 +160,7 @@ for (const [network, prefix] of [
 const GLOBAL_IPV6_UNICAST = new BlockList();
 GLOBAL_IPV6_UNICAST.addSubnet('2000::', 3, 'ipv6');
 
-async function resolveHostAddresses(hostname: string): Promise<string[]> {
+export async function resolveHostAddresses(hostname: string): Promise<string[]> {
   const addresses = await lookup(hostname, {
     all: true,
     verbatim: true,
@@ -721,7 +721,7 @@ function normalizedAddress(address: string): string {
     : address;
 }
 
-function assertContentLengthWithinLimit(
+export function assertContentLengthWithinLimit(
   value: string | string[] | undefined,
   maxResponseBytes: number,
 ): void {
@@ -739,7 +739,7 @@ function assertContentLengthWithinLimit(
   }
 }
 
-async function readResponseBytes(
+export async function readResponseBytes(
   response: Response,
   maxResponseBytes: number,
 ): Promise<Buffer> {

--- a/src/lib/pipeline/firecrawl.test.ts
+++ b/src/lib/pipeline/firecrawl.test.ts
@@ -1,7 +1,18 @@
 /* @vitest-environment node */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { firecrawlBaseUrl, scrapeWithFirecrawl } from './firecrawl';
+import {
+  firecrawlBaseUrl,
+  scrapeWithFirecrawl as scrapeWithFirecrawlRaw,
+  type FirecrawlOptions,
+} from './firecrawl';
+
+function scrapeWithFirecrawl(url: string, options: FirecrawlOptions = {}) {
+  return scrapeWithFirecrawlRaw(url, {
+    resolveHost: async () => ['93.184.216.34'],
+    ...options,
+  });
+}
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -23,12 +34,24 @@ describe('firecrawlBaseUrl', () => {
 describe('scrapeWithFirecrawl', () => {
   it('returns markdown and title on success', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(
-      JSON.stringify({ success: true, data: { markdown: '# OAIC', metadata: { title: 'OAIC' } } }),
+      JSON.stringify({
+        success: true,
+        data: {
+          markdown: '# OAIC',
+          metadata: {
+            title: 'OAIC',
+            sourceURL: 'https://www.oaic.gov.au/',
+          },
+        },
+      }),
       { status: 200 },
     )));
     const result = await scrapeWithFirecrawl('https://www.oaic.gov.au/');
     expect(result).toEqual({
-      ok: true, markdown: '# OAIC', title: 'OAIC', sourceUrl: 'https://www.oaic.gov.au/',
+      ok: true,
+      markdown: '# OAIC',
+      title: 'OAIC',
+      finalUrl: 'https://www.oaic.gov.au/',
     });
   });
 
@@ -62,5 +85,129 @@ describe('scrapeWithFirecrawl', () => {
     }));
     const result = await scrapeWithFirecrawl('https://example.test/');
     expect(result).toMatchObject({ ok: false, reason: 'timeout' });
+  });
+
+  it('rejects an oversized declared response before parsing JSON', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('small', {
+      status: 200,
+      headers: { 'content-length': '101' },
+    })));
+
+    const result = await scrapeWithFirecrawl('https://www.oaic.gov.au/', {
+      maxResponseBytes: 100,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'response_too_large',
+    });
+  });
+
+  it('aborts a chunked response when streamed bytes exceed the limit', async () => {
+    const encoder = new TextEncoder();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('{"success":'));
+          controller.enqueue(encoder.encode('true,"padding":"too large"}'));
+          controller.close();
+        },
+      }),
+      { status: 200 },
+    )));
+
+    const result = await scrapeWithFirecrawl('https://www.oaic.gov.au/', {
+      maxResponseBytes: 16,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'response_too_large',
+    });
+  });
+
+  it('rejects malformed JSON as an invalid response', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{not-json', {
+      status: 200,
+    })));
+
+    const result = await scrapeWithFirecrawl('https://www.oaic.gov.au/');
+
+    expect(result).toMatchObject({ ok: false, reason: 'invalid_response' });
+  });
+
+  it('rejects success payloads without final URL provenance', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      data: { markdown: '# OAIC', metadata: { title: 'OAIC' } },
+    }), { status: 200 })));
+
+    const result = await scrapeWithFirecrawl('https://www.oaic.gov.au/');
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'invalid_provenance',
+    });
+  });
+
+  it('rejects conflicting Firecrawl final URL metadata', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      data: {
+        markdown: '# OAIC',
+        metadata: {
+          sourceURL: 'https://www.oaic.gov.au/',
+          url: 'https://evil.example/',
+        },
+      },
+    }), { status: 200 })));
+
+    const result = await scrapeWithFirecrawl('https://www.oaic.gov.au/');
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'invalid_provenance',
+    });
+  });
+
+  it('rejects a final source URL resolving to a private address', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      data: {
+        markdown: '# OAIC',
+        metadata: { sourceURL: 'https://internal.example.gov.au/' },
+      },
+    }), { status: 200 })));
+
+    const result = await scrapeWithFirecrawl(
+      'https://www.oaic.gov.au/',
+      { resolveHost: async () => ['10.0.0.5'] },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'invalid_provenance',
+    });
+  });
+
+  it('returns the verified Firecrawl final URL', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      data: {
+        markdown: '# OAIC',
+        metadata: {
+          sourceURL: 'https://www.oaic.gov.au/privacy/final',
+        },
+      },
+    }), { status: 200 })));
+
+    const result = await scrapeWithFirecrawl(
+      'https://www.oaic.gov.au/privacy/start',
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      finalUrl: 'https://www.oaic.gov.au/privacy/final',
+    });
   });
 });

--- a/src/lib/pipeline/firecrawl.ts
+++ b/src/lib/pipeline/firecrawl.ts
@@ -1,3 +1,12 @@
+import { sourceUrlsEqual } from '@/lib/source-url';
+import {
+  assertSafeSourceUrl,
+  DEFAULT_MAX_RESPONSE_BYTES,
+  readResponseBytes,
+  resolveHostAddresses,
+  SourceFetchError,
+} from './fetch';
+
 /**
  * Client for the self-hosted Firecrawl stack on the collection host.
  *
@@ -18,13 +27,22 @@ let hasCompletedACall = false;
 
 export interface FirecrawlOptions {
   timeoutMs?: number;
+  maxResponseBytes?: number;
+  resolveHost?: (hostname: string) => Promise<string[]>;
 }
 
 export type FirecrawlResult =
-  | { ok: true; markdown: string; title: string | null; sourceUrl: string }
+  | { ok: true; markdown: string; title: string | null; finalUrl: string }
   | {
       ok: false;
-      reason: 'timeout' | 'unavailable' | 'http_error' | 'empty';
+      reason:
+        | 'timeout'
+        | 'unavailable'
+        | 'http_error'
+        | 'empty'
+        | 'invalid_response'
+        | 'response_too_large'
+        | 'invalid_provenance';
       detail: string;
     };
 
@@ -44,6 +62,8 @@ export async function scrapeWithFirecrawl(
   const timeoutMs =
     options.timeoutMs ??
     (hasCompletedACall ? WARM_TIMEOUT_MS : COLD_START_TIMEOUT_MS);
+  const maxResponseBytes =
+    options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -64,22 +84,81 @@ export async function scrapeWithFirecrawl(
       };
     }
 
-    const payload = (await response.json()) as {
+    let payload: {
       success?: boolean;
-      data?: { markdown?: string; metadata?: { title?: string } };
+      data?: {
+        markdown?: string;
+        metadata?: { title?: string; sourceURL?: string; url?: string };
+      };
     };
+    try {
+      const responseBytes = await readResponseBytes(response, maxResponseBytes);
+      payload = JSON.parse(responseBytes.toString('utf8')) as typeof payload;
+    } catch (error) {
+      if (
+        error instanceof SourceFetchError &&
+        error.message.includes('byte limit')
+      ) {
+        return {
+          ok: false,
+          reason: 'response_too_large',
+          detail: error.message,
+        };
+      }
+      return {
+        ok: false,
+        reason: 'invalid_response',
+        detail: error instanceof Error ? error.message : String(error),
+      };
+    }
     const markdown = payload.data?.markdown?.trim() ?? '';
 
     if (!payload.success || markdown.length === 0) {
       return { ok: false, reason: 'empty', detail: 'no markdown returned' };
+    }
+    if (Buffer.byteLength(markdown, 'utf8') > maxResponseBytes) {
+      return {
+        ok: false,
+        reason: 'response_too_large',
+        detail: `firecrawl markdown exceeds ${maxResponseBytes} byte limit`,
+      };
+    }
+
+    const metadata = payload.data?.metadata;
+    const finalUrl = metadata?.sourceURL?.trim() ?? '';
+    const alternateUrl = metadata?.url?.trim();
+    if (
+      !finalUrl ||
+      (alternateUrl && !sourceUrlsEqual(finalUrl, alternateUrl))
+    ) {
+      return {
+        ok: false,
+        reason: 'invalid_provenance',
+        detail: !finalUrl
+          ? 'firecrawl omitted final source URL metadata'
+          : 'firecrawl returned conflicting final URL metadata',
+      };
+    }
+    try {
+      await assertSafeSourceUrl(
+        finalUrl,
+        options.resolveHost ?? resolveHostAddresses,
+        'official',
+      );
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'invalid_provenance',
+        detail: error instanceof Error ? error.message : String(error),
+      };
     }
 
     hasCompletedACall = true;
     return {
       ok: true,
       markdown,
-      title: payload.data?.metadata?.title ?? null,
-      sourceUrl: url,
+      title: metadata?.title ?? null,
+      finalUrl,
     };
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

- bound browser and Firecrawl response streaming to the collector's 20 MiB source budget
- route Chromium HTTP(S) and WebSocket traffic through a DNS-validated, IP-pinned egress proxy
- block private, loopback, link-local, metadata, non-standard-port, service-worker, and aggregate-tunnel escape paths
- preserve and validate Firecrawl's actual final URL in source evidence
- ignore the generated local security fix report

## Root cause

The browser and Firecrawl adapters validated content after potentially unbounded buffering. Chromium could also initiate redirects, subresources, in-page fetches, or WebSockets before post-navigation destination validation. Separately, the Firecrawl adapter substituted the requested URL for the actual retrieval destination, weakening provenance.

## Impact

Collector retrieval now fails closed before oversized or private-network content reaches downstream parsing. Valid public HTTPS pages, redirects, secure WebSockets, browser cookies, document retrieval, and the Firecrawl fallback contract remain supported.

## Validation

- `npm run check` — passed
  - ESLint and TypeScript passed
  - Vitest: 39 files, 468 tests passed
  - data validation: 0 errors, 3 existing editorial-review warnings
  - Next.js production build: 33 routes generated
- focused security regression suite: 4 files, 98 tests passed
- `git diff --check` — passed
- live Playwright retrieval through the pinned proxy returned HTTP 200 from `https://www.oaic.gov.au/` with 86,482 bytes

## Remaining uncertainty

The collection host's live self-hosted Firecrawl service was unavailable during local validation. The patched client fails closed and falls back to Playwright when final-URL metadata is missing, conflicting, or unsafe.